### PR TITLE
resticprofile: unify variable naming, make SSH and scheduling optional

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -59,8 +59,8 @@ relaymail_smtp_password: !vault |
   36656338616634323135666332363837663061343362343862373939613537323634
 relaymail_overwrite_to_target: clayton.oneill@gmail.com
 
-restic_sftp_client: true
-restic_sftp_servers:
+resticprofile_sftp_client: true
+resticprofile_sftp_servers:
   - id: luser
     fqdn: luser.fnord.net
     user: restic

--- a/ansible/host_vars/localhost.yaml
+++ b/ansible/host_vars/localhost.yaml
@@ -2,3 +2,5 @@
 # Integration test exceptions for localhost
 restic_sftp_client: false
 setup_upgrade: true
+resticprofile_ssh_register: false
+resticprofile_enable_scheduling: false

--- a/ansible/roles/resticprofile/defaults/main.yaml
+++ b/ansible/roles/resticprofile/defaults/main.yaml
@@ -1,4 +1,6 @@
 ---
+#restic_passphrase: <set password in config>
+
 resticprofile_version: "0.21.0"
 resticprofile_arch: amd64
 resticprofile_bin_dir: "/usr/local/bin"
@@ -7,34 +9,19 @@ resticprofile_sftp_server: false
 resticprofile_sftp_client: false
 resticprofile_rclone_client: false
 resticprofile_sftp_servers: []
-# description: backup user on the client
-# type: string
 resticprofile_client_user: root
-
-# description: ssh key on the backup client to connect to the backup server
-# type: string
-resticprofile_ssh_key: "~{{ restic_client_user }}/.ssh/id_restic_{{ resticprofile_ssh_key_type }}"
-
-# description: ssh key bits number to use when generating new keys
-# type: integer
+resticprofile_ssh_key: "~{{ resticprofile_client_user }}/.ssh/id_restic_{{ resticprofile_ssh_key_type }}"
 resticprofile_ssh_key_bits: 2048
+resticprofile_ssh_key_type: ed25519
 
-# description: ssh key type to use when generating new keys
-# type: string
-resticprofile_ssh_key_type: "ed25519"
+# Whether or not to register the ssh key with the backup server.  Used for testing.
+resticprofile_ssh_register: true
 
-#restic_passphrase: <set password in config>
+# Whether or not to enable scheduling.  Used for testing.
+resticprofile_enable_scheduling: true
 
 # The following restic_* variables are used to configure restic itself, not the
 # resticprofile role. We intentionally ignore the var-naming[no-role-prefix]
 # linting rule for these variables.
-restic_version: 0.16.4 # noqa: var-naming[no-role-prefix]
-restic_sftp_server: true # noqa: var-naming[no-role-prefix]
-restic_sftp_client: true # noqa: var-naming[no-role-prefix]
-restic_rclone_client: true # noqa: var-naming[no-role-prefix]
+restic_version: 0.15.2 # noqa: var-naming[no-role-prefix]
 restic_arch: amd64 # noqa: var-naming[no-role-prefix]
-restic_sftp_servers: [] # noqa: var-naming[no-role-prefix]
-restic_client_user: restic # noqa: var-naming[no-role-prefix]
-restic_ssh_key: /root/.ssh/id_ed25519 # noqa: var-naming[no-role-prefix]
-restic_ssh_key_bits: 256 # noqa: var-naming[no-role-prefix]
-restic_ssh_key_type: ed25519 # noqa: var-naming[no-role-prefix]

--- a/ansible/roles/resticprofile/tasks/configure-client.yaml
+++ b/ansible/roles/resticprofile/tasks/configure-client.yaml
@@ -1,6 +1,6 @@
 ---
 - ansible.builtin.user:
-    name: "{{ restic_client_user }}"
+    name: "{{ resticprofile_client_user }}"
     state: present
   register: restic_user_info
 
@@ -9,20 +9,20 @@
     path: "{{ restic_user_info.home }}/.config/resticprofile"
     state: directory
     mode: "0700"
-    owner: "{{ restic_client_user }}"
+    owner: "{{ resticprofile_client_user }}"
 
 - name: "Write passphrase to file"
   ansible.builtin.copy:
     content: "{{ restic_passphrase }}"
     dest: "{{ restic_user_info.home }}/.config/resticprofile/passphrase.txt"
-    owner: "{{ restic_client_user }}"
+    owner: "{{ resticprofile_client_user }}"
     mode: "0600"
 
 - name: "Write config file"
   ansible.builtin.template:
     src: "templates/config.j2"
     dest: "{{ restic_user_info.home }}/.config/resticprofile/profiles.yaml"
-    owner: "{{ restic_client_user }}"
+    owner: "{{ resticprofile_client_user }}"
     mode: "0600"
   register: config_file
 
@@ -30,7 +30,8 @@
   ansible.builtin.command: "{{ resticprofile_bin_dir }}/resticprofile status"
   register: restic_status
   changed_when: false
+  when: resticprofile_enable_scheduling
 
 - name: "Update resticprofile schedules"
   ansible.builtin.command: "{{ resticprofile_bin_dir }}/resticprofile schedule"
-  when: restic_status.stdout is search("not found$") or config_file.changed
+  when: resticprofile_enable_scheduling and (restic_status is defined and (restic_status.stdout is search("not found$") or config_file.changed))

--- a/ansible/roles/resticprofile/tasks/install.yaml
+++ b/ansible/roles/resticprofile/tasks/install.yaml
@@ -17,9 +17,9 @@
 
 - name: Compare restic versions
   ansible.builtin.set_fact:
-    resticprofile_install_restic: "{{ resticprofile_restic_version != resticprofile_restic_current_version }}"
+    resticprofile_install_restic: "{{ restic_version != restic_current_version }}"
   vars:
-    resticprofile_restic_current_version: "{{ resticprofile_restic_current.stdout | regex_replace('^restic (\\d+\\.\\d+\\.\\d+) .+$', '\\1') }}"
+    restic_current_version: "{{ resticprofile_restic_current.stdout | regex_replace('^restic (\\d+\\.\\d+\\.\\d+) .+$', '\\1') }}"
   when: resticprofile_restic_bin.stat.exists
 
 # Gathering facts on resticprofile
@@ -65,7 +65,7 @@
 
 - name: Download restic
   ansible.builtin.get_url:
-    url: "https://github.com/restic/restic/releases/download/v{{ resticprofile_restic_version }}/restic_{{ resticprofile_restic_version }}_{{resticprofile_os}}_{{ resticprofile_arch }}.bz2"
+    url: "https://github.com/restic/restic/releases/download/v{{ restic_version }}/restic_{{ restic_version }}_{{resticprofile_os}}_{{ restic_arch }}.bz2"
     dest: "{{ resticprofile_tmp_dir }}/restic.bz2"
     mode: "0640"
   vars:

--- a/ansible/roles/resticprofile/tasks/sftp-client.yaml
+++ b/ansible/roles/resticprofile/tasks/sftp-client.yaml
@@ -1,7 +1,7 @@
 ---
 - name: client | generate ssh key for this machine
   ansible.builtin.user:
-    name: "{{ restic_client_user }}"
+    name: "{{ resticprofile_client_user }}"
     generate_ssh_key: true
     ssh_key_file: "{{ resticprofile_ssh_key }}"
     ssh_key_bits: "{{ resticprofile_ssh_key_bits }}"
@@ -14,7 +14,7 @@
 
 - name: client | disable strict key checking for backup servers
   ansible.builtin.blockinfile:
-    dest: "~{{ restic_client_user }}/.ssh/config"
+    dest: "~{{ resticprofile_client_user }}/.ssh/config"
     create: true
     marker: "### {mark} ANSIBLE MANAGED BLOCK for restic: {{ item.fqdn }} ###"
     content: |
@@ -32,3 +32,4 @@
     key: "{{ sshkey.stdout }}"
   delegate_to: "{{ item.fqdn }}"
   with_items: "{{ resticprofile_sftp_servers }}"
+  when: resticprofile_ssh_register


### PR DESCRIPTION
- Use resticprofile_ prefix for all role variables for clarity and consistency
- Add resticprofile_ssh_register and resticprofile_enable_scheduling (default: true)
- Disable SSH registration and scheduling for localhost in integration tests
- Wrap SSH registration and schedule tasks with conditionals
- Remove old/duplicate restic_ variable references