### PR TITLE
Add flux host configuration and exclude cache directories from backups

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -89,6 +89,18 @@ restic_default_config:
       source:
         - /
 
+      exclude:
+        # System caches
+        - /var/cache/*
+
+        # User caches
+        - /home/*/.cache/*
+        - /root/.cache/*
+
+        # Temporary files
+        - /tmp/*
+        - /var/tmp/*
+
       run-before: &run_before |-
         {% raw %}curl -sf https://healthchecks.io/api/v1/checks/  \
             -d '{ "api_key": "{{ $healthcheck_management_key }}", "name": "restic-{{ .Hostname }}-{{ .Profile.Name }}", "timeout": 259200, "channels": "*", "unique": ["name"] }' \

--- a/ansible/host_vars/flux.yaml
+++ b/ansible/host_vars/flux.yaml
@@ -6,6 +6,6 @@ ip_forwarding_enabled: true
 restic_prometheus_config: {}
 restic_host_config:
   default:
-    # Use a dedicatd repo.  This host has limited disk and memory, so pulling
+    # Use a dedicated repo.  This host has limited disk and memory, so pulling
     # the index for all other machines is not practical.
     repository: sftp:restic@luser.fnord.net:/repos/{{ ansible_hostname }}

--- a/ansible/host_vars/flux.yaml
+++ b/ansible/host_vars/flux.yaml
@@ -6,4 +6,6 @@ ip_forwarding_enabled: true
 restic_prometheus_config: {}
 restic_host_config:
   default:
+    # Use a dedicatd repo.  This host has limited disk and memory, so pulling
+    # the index for all other machines is not practical.
     repository: sftp:restic@luser.fnord.net:/repos/{{ ansible_hostname }}


### PR DESCRIPTION
This PR adds the flux host configuration and improves restic backup efficiency by excluding cache directories.

## Changes Made

### Ansible Configuration
- Add flux.yaml host configuration for Tailscale exit node with restic backup
- Exclude cache directories from restic backups to reduce backup size and time:
  - /var/cache/* (all system caches including apt, fontconfig, etc.)
  - /home/*/.cache/* and /root/.cache/* (user caches)
  - /tmp/* and /var/tmp/* (temporary files)

This will significantly reduce backup size by excluding files that can be regenerated.