### PR TITLE
Integrate 1Password provider for secure secrets management

### DIFF
--- a/opentofu/.terraform.lock.hcl
+++ b/opentofu/.terraform.lock.hcl
@@ -1,6 +1,30 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
+provider "registry.opentofu.org/1password/onepassword" {
+  version     = "2.1.2"
+  constraints = "~> 2.1"
+  hashes = [
+    "h1:GdQ0kRDSi6naVt37Ui42uGLpgDsIEGx8Q8qBC7Ja2vo=",
+    "h1:GodYqoGG/PLyQr/Zm3EAw/lU4ixmDkWGPSJnAGT95nA=",
+    "zh:03d20138bf7bc645707b2c0c00203f66c07902d03c72be3f5f7bc365155bdc35",
+    "zh:0bf54b246f141a7d0cb75c7c2c086d372c810efc061bf5a7ae0b62b70d9558f4",
+    "zh:0ee19a8d1c193eaacc9679fb5ccf1d2be5d0c5e4173c3f3d82c09c717d3f354e",
+    "zh:152c35cdd1bb98683c0a24e48b286eab0473735da242aa27b39df81bc6f84b63",
+    "zh:293d264bccae325cdadcc9125b1d9fe9947a06cab05abb27c301d6244ef24cfd",
+    "zh:37ade0a6cc2c8c2a15535f83281caf54f6fcbc9c75f0588407f1dd8da04a9a95",
+    "zh:3c28c2352cd12464543e95b7d0b827abfe42794e9779f4e049789d864f88f3af",
+    "zh:4676825834b3132234250046ad888b881ad54f6369b5f0302c6b3250ad4983b1",
+    "zh:7da0327fe81c50bb71b510b342a5e2b90a3129f0e30dc479947b50e1dba9fa0d",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:bb2899cada1cb964d75a9a4a7b915ac1ea03131769933e04b20ed0793f8eb02b",
+    "zh:d142810d6f04973abf8471a2cc2fb09537f79010a0f20bd62866068a42fa5ab7",
+    "zh:e2a39b685acd7b6846c8da3a94a355964ad2b411dc68c058a31dd2ce56aadd4a",
+    "zh:effe9dea248ae4fb540ca5c84e2e369b467e229dc1518c606d3aa714049daa74",
+    "zh:fbc4b2d7f7055a1b35c573e93bf89c6cad5f47f5dc30c0e2c61d5abfcf083cca",
+  ]
+}
+
 provider "registry.opentofu.org/hashicorp/aws" {
   version     = "6.1.0"
   constraints = "~> 6.0"

--- a/opentofu/main.tf
+++ b/opentofu/main.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "vultr/vultr"
       version = "~> 2.15"
     }
+    onepassword = {
+      source  = "1Password/onepassword"
+      version = "~> 2.1"
+    }
   }
 
   backend "s3" {
@@ -18,6 +22,11 @@ terraform {
     region  = "us-east-1"
     encrypt = true
   }
+}
+
+# 1Password provider configuration
+provider "onepassword" {
+  account = "6GO3NBF2PRCY3NAW6SN2CG6I2U"
 }
 
 provider "aws" {
@@ -31,7 +40,7 @@ provider "aws" {
 }
 
 provider "vultr" {
-  api_key = var.vultr_api_key
+  api_key = local.vultr_api_key
 }
 
 module "dns" {

--- a/opentofu/secrets.tf
+++ b/opentofu/secrets.tf
@@ -1,0 +1,15 @@
+# Reference to the existing Kubernetes vault
+data "onepassword_vault" "kubernetes" {
+  uuid = "duipvbtxrc4wl22tw3jsihfo2m"
+}
+
+# Vultr API credentials from 1Password
+data "onepassword_item" "vultr_api" {
+  vault = data.onepassword_vault.kubernetes.uuid
+  title = "Vultr API"
+}
+
+# Local values for easier reference
+locals {
+  vultr_api_key = data.onepassword_item.vultr_api.password
+}

--- a/opentofu/variables.tf
+++ b/opentofu/variables.tf
@@ -1,8 +1,3 @@
-variable "vultr_api_key" {
-  type      = string
-  sensitive = true
-}
-
 variable "ssh_pubkey_path" {
   type    = string
   default = "~/.ssh/id_rsa.pub"


### PR DESCRIPTION
- Add 1Password Terraform provider configuration
- Replace vultr_api_key variable with 1Password data source
- Create secrets.tf for centralized 1Password secret references
- Remove hardcoded API key variable from variables.tf
- Enable biometric authentication for Terraform operations

Vultr API credentials now stored securely in 1Password Kubernetes vault
instead of local config files.