### PR TITLE
Integrate 1Password for secrets management and add B2 bucket support

### DIFF
--- a/opentofu/.terraform.lock.hcl
+++ b/opentofu/.terraform.lock.hcl
@@ -25,6 +25,20 @@ provider "registry.opentofu.org/1password/onepassword" {
   ]
 }
 
+provider "registry.opentofu.org/backblaze/b2" {
+  version     = "0.10.0"
+  constraints = "~> 0.10"
+  hashes = [
+    "h1:XopbGPMYulGkGsOipKMYwwiWkL4vfMRQ1gHhH61dFfI=",
+    "h1:e4sWNH6KEXlb7SXKSq3DRuY9StJG6ezZYZqrzLzgO/0=",
+    "zh:03d4ec22a8a47dfc4e1beccd261f37b22113646d246853195fe5d8cb6febf90c",
+    "zh:08c9ea953b3dcb01aeebd372b9bd2c1a6c1f0b996125bde03c094bc5e75fb55b",
+    "zh:4f8589276b11f00feb511bd500e2f02abe41371ce2ab74507dd53a7e1110e944",
+    "zh:8bfcdb1b1cfaa20fa0f717758fca38290e6bd5ff6499ad196dd2f68f95aeab18",
+    "zh:dfac030714a098956d6df3bf6277d08c19b5b037cd7ec30821ec2edb0de49328",
+  ]
+}
+
 provider "registry.opentofu.org/hashicorp/aws" {
   version     = "6.1.0"
   constraints = "~> 6.0"

--- a/opentofu/b2.tf
+++ b/opentofu/b2.tf
@@ -1,0 +1,11 @@
+# Manage the existing B2 bucket with master key (has writeBuckets permission)
+resource "b2_bucket" "restic_backups" {
+  bucket_name = "cmo-restic"
+  bucket_type = "allPrivate"
+
+  # Lifecycle rule: delete old versions 1 day after hidden (minimum allowed)
+  lifecycle_rules {
+    file_name_prefix             = "" # Apply to all files in bucket
+    days_from_hiding_to_deleting = 1
+  }
+}

--- a/opentofu/main.tf
+++ b/opentofu/main.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "1Password/onepassword"
       version = "~> 2.1"
     }
+    b2 = {
+      source  = "Backblaze/b2"
+      version = "~> 0.10"
+    }
   }
 
   backend "s3" {
@@ -41,6 +45,11 @@ provider "aws" {
 
 provider "vultr" {
   api_key = local.vultr_api_key
+}
+
+provider "b2" {
+  application_key_id = local.b2_application_key_id
+  application_key    = local.b2_application_key
 }
 
 module "dns" {

--- a/opentofu/secrets.tf
+++ b/opentofu/secrets.tf
@@ -9,7 +9,26 @@ data "onepassword_item" "vultr_api" {
   title = "Vultr API"
 }
 
+# Backblaze B2 credentials from 1Password (master key with writeBuckets permission)
+data "onepassword_item" "terraform_b2" {
+  vault = data.onepassword_vault.kubernetes.uuid
+  title = "terraform-b2"
+}
+
+# Clean field mapping for B2 credentials
+locals {
+  b2_fields = {
+    for f in flatten([
+      for sec in data.onepassword_item.terraform_b2.section : sec.field
+    ]) : f.label => f.value
+  }
+}
+
 # Local values for easier reference
 locals {
   vultr_api_key = data.onepassword_item.vultr_api.password
+
+  # B2 credentials using clean field mapping
+  b2_application_key_id = local.b2_fields["RCLONE_CONFIG_B2_ACCOUNT"]
+  b2_application_key    = local.b2_fields["RCLONE_CONFIG_B2_KEY"]
 }


### PR DESCRIPTION
- Add 1Password provider for secure credential retrieval from Kubernetes vault
- Replace hardcoded Vultr API key with 1Password-sourced credential
- Add B2 provider using key from 1Password with writeBuckets permission
- Import and manage existing cmo-restic bucket with lifecycle rules
- Implement clean field mapping pattern for 1Password custom fields