### PR TITLE
Upgrade Kubernetes to 1.29.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 ansible-vault-password
 ansible/roles/galaxy
 ansible/admin.conf
+ansible/super-admin.conf
 
 # OpenTofu/Terraform
 *.tfstate

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Ansible
 ansible-vault-password
 ansible/roles/galaxy
+ansible/admin.conf
 
 # OpenTofu/Terraform
 *.tfstate

--- a/ansible/group_vars/kubernetes.yaml
+++ b/ansible/group_vars/kubernetes.yaml
@@ -10,9 +10,9 @@ kernel_parameters: "nofb vga=normal"
 node_exporter_enabled: true
 
 kubernetes_short_version: "1.28"
-kubeadm_version: "1.27.16-1.1"
-kubelet_version: "1.27.16-1.1"
-kubectl_version: "1.27.16-1.1"
+kubeadm_version: "1.28.15-1.1"
+kubelet_version: "1.28.15-1.1"
+kubectl_version: "1.28.15-1.1"
 cri_tools_version: "1.28.0-1.1"
 kubernetes_cni_version: "1.2.0-2.1"
 

--- a/ansible/group_vars/kubernetes.yaml
+++ b/ansible/group_vars/kubernetes.yaml
@@ -9,12 +9,12 @@ kernel_parameters: "nofb vga=normal"
 
 node_exporter_enabled: true
 
-kubernetes_short_version: "1.28"
-kubeadm_version: "1.28.15-1.1"
-kubelet_version: "1.28.15-1.1"
-kubectl_version: "1.28.15-1.1"
-cri_tools_version: "1.28.0-1.1"
-kubernetes_cni_version: "1.2.0-2.1"
+kubernetes_short_version: "1.29"
+kubeadm_version: "1.29.15-1.1"
+kubelet_version: "1.29.15-1.1"
+kubectl_version: "1.29.15-1.1"
+cri_tools_version: "1.29.0-1.1"
+kubernetes_cni_version: "1.3.0-1.1"
 
 kubernetes_master: "k1.oneill.net"
 

--- a/ansible/group_vars/kubernetes.yaml
+++ b/ansible/group_vars/kubernetes.yaml
@@ -9,11 +9,11 @@ kernel_parameters: "nofb vga=normal"
 
 node_exporter_enabled: true
 
-kubernetes_short_version: "1.27"
-kubeadm_version: "1.27.11-1.1"
-kubelet_version: "1.27.11-1.1"
-kubectl_version: "1.27.11-1.1"
-cri_tools_version: "1.27.1-1.1"
+kubernetes_short_version: "1.28"
+kubeadm_version: "1.27.16-1.1"
+kubelet_version: "1.27.16-1.1"
+kubectl_version: "1.27.16-1.1"
+cri_tools_version: "1.28.0-1.1"
 kubernetes_cni_version: "1.2.0-2.1"
 
 kubernetes_master: "k1.oneill.net"

--- a/ansible/roles/kubeadm/handlers/main.yaml
+++ b/ansible/roles/kubeadm/handlers/main.yaml
@@ -3,3 +3,8 @@
   ansible.builtin.service:
     name: iscsid
     state: restarted
+
+- name: "Restart kubelet"
+  ansible.builtin.service:
+    name: kubelet
+    state: restarted

--- a/ansible/roles/kubeadm/tasks/common.yaml
+++ b/ansible/roles/kubeadm/tasks/common.yaml
@@ -146,14 +146,19 @@
     mode: "0644"
   when: cri_tools_version is defined
 
-- name: "Install packages"
+- name: "Install Kubernetes packages (except kubelet)"
   ansible.builtin.apt:
     name:
       - "cri-tools={{ cri_tools_version }}"
-      - "kubelet={{ kubelet_version }}"
       - "kubeadm={{ kubeadm_version }}"
       - "kubectl={{ kubectl_version }}"
       - "kubernetes-cni={{ kubernetes_cni_version }}"
+    state: present
+    allow_downgrade: true
+
+- name: "Install kubelet package"
+  ansible.builtin.apt:
+    name: "kubelet={{ kubelet_version }}"
     state: present
     allow_downgrade: true
   notify: "Restart kubelet"

--- a/ansible/roles/kubeadm/tasks/common.yaml
+++ b/ansible/roles/kubeadm/tasks/common.yaml
@@ -52,8 +52,16 @@
     name: "net.ipv4.conf.all.send_redirects"
     value: "0"
 
+- name: "Check if swap is enabled"
+  ansible.builtin.command: "swapon --show"
+  register: swap_status
+  changed_when: false
+  failed_when: false
+
 - name: "Turn off swap"
   ansible.builtin.command: "swapoff -a"
+  when: swap_status.stdout != ""
+
 - name: "Disable swap in fstab"
   ansible.builtin.replace:
     path: /etc/fstab

--- a/ansible/roles/kubeadm/tasks/common.yaml
+++ b/ansible/roles/kubeadm/tasks/common.yaml
@@ -156,3 +156,4 @@
       - "kubernetes-cni={{ kubernetes_cni_version }}"
     state: present
     allow_downgrade: true
+  notify: "Restart kubelet"

--- a/ansible/roles/kubeadm/tasks/master.yaml
+++ b/ansible/roles/kubeadm/tasks/master.yaml
@@ -19,7 +19,7 @@
 - name: "Set KUBECONFIG for root"
   ansible.builtin.lineinfile:
     path: "/root/.bashrc"
-    line: "export KUBECONFIG=/etc/kubernetes/admin.conf"
+    line: "export KUBECONFIG=/etc/kubernetes/super-admin.conf"
     regexp: "^export KUBECONFIG="
 
 - name: "Fixup admin.conf to use fqdn"
@@ -29,8 +29,21 @@
     backrefs: true
     line: "\\1server: https://{{ ansible_fqdn }}:6443"
 
+- name: "Fixup super-admin.conf to use fqdn"
+  ansible.builtin.lineinfile:
+    path: "/etc/kubernetes/super-admin.conf"
+    regexp: "^(\\s+)server:\\s+"
+    backrefs: true
+    line: "\\1server: https://{{ ansible_fqdn }}:6443"
+
 - name: "Fetch admin.conf for local use"
   ansible.builtin.fetch:
     src: "/etc/kubernetes/admin.conf"
+    dest: "{{ playbook_dir }}/"
+    flat: true
+
+- name: "Fetch super-admin.conf for local use"
+  ansible.builtin.fetch:
+    src: "/etc/kubernetes/super-admin.conf"
     dest: "{{ playbook_dir }}/"
     flat: true


### PR DESCRIPTION
Upgrades Kubernetes cluster from 1.27.11 to 1.29.15. Includes deployment improvements for cleaner upgrades.