### PR TITLE
Migrate to Debian Bookworm and improve kubeadm configuration

### DIFF
--- a/ansible/group_vars/kubernetes.yaml
+++ b/ansible/group_vars/kubernetes.yaml
@@ -10,6 +10,7 @@ kernel_parameters: "nofb vga=normal"
 node_exporter_enabled: true
 
 kubernetes_short_version: "1.29"
+kubernetes_version: "1.29.15"
 kubeadm_version: "1.29.15-1.1"
 kubelet_version: "1.29.15-1.1"
 kubectl_version: "1.29.15-1.1"

--- a/ansible/roles/kubeadm/tasks/common.yaml
+++ b/ansible/roles/kubeadm/tasks/common.yaml
@@ -21,26 +21,22 @@
     - br_netfilter
 
 - name: "Configure sysctl for containerd"
-  ansible.builtin.copy:
-    dest: /etc/sysctl.d/99-kubernetes-cri.conf
-    content: |
-      net.bridge.bridge-nf-call-iptables  = 1
-      net.ipv4.ip_forward                 = 1
-      net.bridge.bridge-nf-call-ip6tables = 1
-    mode: "0644"
-  register: sysctl_file
+  ansible.posix.sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    state: present
+    reload: true
+  with_items:
+    - { name: "net.bridge.bridge-nf-call-iptables", value: "1" }
+    - { name: "net.ipv4.ip_forward", value: "1" }
+    - { name: "net.bridge.bridge-nf-call-ip6tables", value: "1" }
 
 - name: "Configure sysctl for inotify watches for Kubernetes"
-  ansible.builtin.copy:
-    dest: "/etc/sysctl.d/90-kubernetes-inotify.conf"
-    content: |
-      fs.inotify.max_user_watches = 1048576
-    mode: "0644"
-  register: inotify_sysctl_file
-
-- name: "Reload sysctl for containerd"
-  ansible.builtin.command: sysctl --system
-  when: sysctl_file.changed or inotify_sysctl_file.changed
+  ansible.posix.sysctl:
+    name: "fs.inotify.max_user_watches"
+    value: "1048576"
+    state: present
+    reload: true
 
 - name: "Disabling accepting ICMP redirects"
   ansible.posix.sysctl:
@@ -67,26 +63,6 @@
     path: /etc/fstab
     regexp: "^([^#].*?\\sswap\\s+sw\\s+.*)$"
     replace: "# \\1"
-
-- name: "Disable nftables on older distributions"
-  community.general.alternatives:
-    name: iptables
-    path: /usr/sbin/iptables-legacy
-  when: ansible_facts['distribution_codename'] != "bookworm"
-
-- name: "Disable systemd-resolved"
-  ansible.builtin.systemd:
-    name: systemd-resolved
-    enabled: false
-    state: stopped
-  when: ansible_facts['distribution_codename'] != "bookworm"
-
-- name: "Disable systemd-resolved dhclient integration"
-  ansible.builtin.file:
-    path: /etc/dhcp/dhclient-enter-hooks.d/resolved
-    state: absent
-  register: dhclient_resolved_file
-  when: ansible_facts['distribution_codename'] != "bookworm"
 
 - name: "Install apt-transport-https"
   ansible.builtin.apt:

--- a/ansible/roles/kubeadm/templates/kubeadm.conf.j2
+++ b/ansible/roles/kubeadm/templates/kubeadm.conf.j2
@@ -1,26 +1,31 @@
----
-apiVersion: kubeadm.k8s.io/v1beta2
-kind: ClusterConfiguration
-apiServer:
-  certSANs:
-  - {{ ansible_fqdn }}
-  - k1.oneill.net
-controllerManager:
-  extraArgs:
-    allocate-node-cidrs: "true"
-    cloud-provider: external
-networking:
-  podSubnet: "10.244.0.0/16"
----
-apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
-localAPIEndpoint:
-  advertiseAddress: {{ api_advertise_address }}
+apiVersion: kubeadm.k8s.io/v1beta3
 bootstrapTokens:
 - groups:
   - system:bootstrappers:kubeadm:default-node-token
   token: {{ kubeadm_bootstrap_token }}
-  ttl: 24h0m0s
-  usages:
-  - signing
-  - authentication
+localAPIEndpoint:
+  advertiseAddress: {{ api_advertise_address }}
+  bindPort: 6443
+nodeRegistration:
+  name: {{ inventory_hostname }}
+  taints:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+---
+kind: ClusterConfiguration
+apiVersion: kubeadm.k8s.io/v1beta3
+apiServer:
+  certSANs:
+  - {{ ansible_fqdn }}
+  - k1.oneill.net
+clusterName: kubernetes
+controllerManager:
+  extraArgs:
+    allocate-node-cidrs: "true"
+    cloud-provider: external
+    cluster-cidr: 10.244.0.0/16
+etcd:
+  local:
+    dataDir: /var/lib/etcd
+kubernetesVersion: v{{ kubernetes_version }}


### PR DESCRIPTION
Migrate to Debian Bookworm and improve kubeadm configuration

- Update kubeadm to v1beta3 API format with proper node registration
- Fix sysctl configuration to use ansible.posix.sysctl module
- Remove backward compatibility for non-Bookworm releases
- Remove static CA cert hash in favor of dynamic token generation
- Update join configuration to use inventory hostnames
- Clean up unused handlers and unnecessary service restarts