### PR TITLE
Add Galaxy roles management workflow

### DIFF
--- a/.github/workflows/manage-galaxy-roles.yml
+++ b/.github/workflows/manage-galaxy-roles.yml
@@ -1,0 +1,69 @@
+name: Manage Ansible Galaxy Roles
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  manage-roles:
+    name: Manage Ansible Galaxy Roles
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@f0fe604f8a612776892427721526b4c7cfb23aba # v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+
+      - name: Remove existing galaxy roles
+        run: |
+          rm -rf ansible/roles/galaxy
+
+      - name: Install galaxy roles
+        run: |
+          cd ansible
+          nix develop --command ansible-galaxy install -r requirements.yaml -p roles/galaxy
+
+      - name: Check for changes
+        if: github.ref == 'refs/heads/main'
+        run: |
+          if ! git diff --quiet; then
+            echo "Galaxy roles need to be updated on main branch!"
+            git diff --stat
+            exit 1
+          fi
+
+      - name: Commit updated roles
+        if: github.event_name == 'pull_request'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          if ! git diff --cached; then
+            git commit -m "Update Ansible Galaxy roles"
+          fi
+
+      - name: Push changes via PAT
+        if: github.event_name == 'pull_request'
+        run: |
+          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF##*/}}"
+          echo "Pushing to branch: $BRANCH_NAME"
+          git push "https://x-access-token:${{ secrets.PAT }}@github.com/${{ github.repository }}" "HEAD:${BRANCH_NAME}"


### PR DESCRIPTION
This PR adds a GitHub Action workflow that automatically manages Ansible Galaxy roles by:

- Running on PR events (opened, synchronize, reopened) and pushes to main
- Deleting the existing galaxy roles directory
- Reinstalling all roles from requirements.yaml
- Committing any changes back to PRs if differences are found
- Failing on main branch if roles are out of sync

The workflow uses the existing Nix development environment and requires a PAT secret for pushing commits back to PR branches.