### PR TITLE
Fix ansible-lint performance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,8 @@ repos:
     hooks:
       - id: ansible-lint
         entry: bash -c 'ANSIBLE_CONFIG=ansible/ansible.cfg ansible-lint "$@"' --
-#        files: ^ansible/.*\.(yaml|yml)$
+        files: ^ansible/.*\.(yaml|yml)$
+        pass_filenames: true
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1


### PR DESCRIPTION
Enable files filter and pass_filenames to only run on changed Ansible files instead of all 138 files. Reduces runtime from 4s to <1s.