### PR TITLE
Add nut role handlers for peanut container restarts

### DIFF
--- a/ansible/roles/nut/handlers/main.yaml
+++ b/ansible/roles/nut/handlers/main.yaml
@@ -1,0 +1,11 @@
+---
+- name: Restart peanut containers
+  community.docker.docker_compose_v2:
+    project_src: /etc/nut/peanut
+    state: restarted
+    wait: true
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ ler53_aws_access_key }}"
+    AWS_SECRET_ACCESS_KEY: "{{ ler53_aws_secret_key }}"
+    AWS_REGION: "{{ route53_region }}"
+  become: true


### PR DESCRIPTION
Add handlers/main.yaml to the nut role to ensure peanut containers are restarted when configuration files are updated. This handler is referenced in peanut.yaml tasks and is essential for proper service restarts when configuration changes are made.