### PR TITLE
Update restic to 0.18.0 and resticprofile to 0.31.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,14 +15,16 @@ repos:
   hooks:
   - id: yamlfix
     args: [-c, .yamlfix.toml]
+    exclude: ^ansible/
 
-- repo: https://github.com/ansible/ansible-lint
-  rev: v25.6.1
+- repo: local
   hooks:
   - id: ansible-lint
-    entry: scripts/ansible-lint-wrapper.sh
-    files: ^ansible/.*\.(yaml|yml)$
-    pass_filenames: true
+    name: ansible-lint
+    entry: scripts/ansible-lint-wrapper
+    language: system
+    files: ^ansible/.*$
+    require_serial: true
 
 - repo: https://github.com/shellcheck-py/shellcheck-py
   rev: v0.10.0.1

--- a/ansible/.ansible-lint.yaml
+++ b/ansible/.ansible-lint.yaml
@@ -1,6 +1,6 @@
 ---
 exclude_paths:
-  - ansible/roles/galaxy/
+  - roles/galaxy/
 skip_list:
   - yaml[line-length]
   - no-changed-when

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -4,23 +4,23 @@ falcon_eip: 50.16.92.207
 
 prometheus_node_exporter_version: 1.0.1
 prometheus_node_exporter_config_flags:
-  "collector.textfile.directory": "/var/lib/node_exporter/textfile_collector"
-  "web.listen-address": "0.0.0.0:9100"
-  "log.level": "info"
-
+  collector.textfile.directory: /var/lib/node_exporter/textfile_collector
+  web.listen-address: 0.0.0.0:9100
+  log.level: info
 enable_ufw: false
 
 ssh_keys:
-  - &jezebel_rsa "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5XY/Pltocwc8sAZwewrhgInrrDDuw89wJ0I1bx6wR16x650iifiSnIZlD+elk2zyu+AqMwJ74URZgshz02W6HMnFmx6CXfvXC6DmEpSnyY4/WThmP2WyNE/A9nJaLBbBb/LnfJoA+Knb8XzJHWFtpFcNmP9Ltlm1Q9VoFFeCrIG04xmXR4WO2AtTa/Bj0WAPa2whfSiCluFrFLMqqXsXw51Myj6RUahNbQdjwOwFQAwzMEegrEINOKYSlojTyV7mdJ6e3oepf5+3GhttMUVjqFHSxG/HK9WB4xxUaQXdMadNhivJKfHKVFxheW+FWae4WBPV31VHqRQuWrUEEamhUQ==
-                 coneill@jezebel"
-  - &xtal_ed25519 "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB3URIT9ojo8mqsEjxmFu1C+Bxa3jdcKkUzM++IfDVmu coneill@xtal.oneill.net"
+  - &jezebel_rsa ssh-rsa
+                 AAAAB3NzaC1yc2EAAAABIwAAAQEA5XY/Pltocwc8sAZwewrhgInrrDDuw89wJ0I1bx6wR16x650iifiSnIZlD+elk2zyu+AqMwJ74URZgshz02W6HMnFmx6CXfvXC6DmEpSnyY4/WThmP2WyNE/A9nJaLBbBb/LnfJoA+Knb8XzJHWFtpFcNmP9Ltlm1Q9VoFFeCrIG04xmXR4WO2AtTa/Bj0WAPa2whfSiCluFrFLMqqXsXw51Myj6RUahNbQdjwOwFQAwzMEegrEINOKYSlojTyV7mdJ6e3oepf5+3GhttMUVjqFHSxG/HK9WB4xxUaQXdMadNhivJKfHKVFxheW+FWae4WBPV31VHqRQuWrUEEamhUQ==
+                 coneill@jezebel
+  - &xtal_ed25519 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB3URIT9ojo8mqsEjxmFu1C+Bxa3jdcKkUzM++IfDVmu coneill@xtal.oneill.net
 
 genericusers_users:
   - name: coneill
-    comment: "Clayton O'Neill"
-    shell: "/bin/bash"
+    comment: Clayton O'Neill
+    shell: /bin/bash
     uid: 10001
-    groups: ["sudo", "audio", "video", "dialout"]
+    groups: [sudo, audio, video, dialout]
     pass: !vault |
       $ANSIBLE_VAULT;1.1;AES256
       31623865666436383432373566303765326238656334323163363735393337303064316137313761
@@ -35,12 +35,12 @@ genericusers_users:
       6533666132636666373833653166356133306338343131386431
     ssh_keys:
       - *jezebel_rsa
-      - &jezebel_ed25519 "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJCMCD7OnhZIJvdUhHhYGIoH7fN5fWLXHPijB60vp21t coneill@jezebel"
+      - &jezebel_ed25519 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJCMCD7OnhZIJvdUhHhYGIoH7fN5fWLXHPijB60vp21t coneill@jezebel
       - *xtal_ed25519
   - name: ansible
-    comment: "Ansible role user"
+    comment: Ansible role user
     uid: 9000
-    groups: ["sudo"]
+    groups: [sudo]
     ssh_keys:
       - *jezebel_rsa
       - *jezebel_ed25519
@@ -82,24 +82,30 @@ restic_default_config:
       one-file-system: true
 
       schedule: "*-*-* {{ 23 | random(seed=inventory_hostname) }}:{{ 60 | random(seed=inventory_hostname) }}:00"
-      schedule-permission: "system"
-      schedule-lock-wait: "23h"
+      schedule-permission: system
+      schedule-lock-wait: 23h
       schedule-priority: background
 
       source:
         - /
 
       exclude:
-        # System caches
+      # System caches
         - /var/cache/*
+        - /var/lib/apt/lists/**
 
         # User caches
         - /home/*/.cache/*
         - /root/.cache/*
 
         # Temporary files
-        - /tmp/*
-        - /var/tmp/*
+        - /tmp/**
+        - /var/tmp/**
+
+        # Kubernetes/Container runtime data
+        - /var/lib/containerd/**
+        - /var/log/containers/**
+        - /var/log/pods/**
 
       run-before: &run_before |-
         {% raw %}curl -sf https://healthchecks.io/api/v1/checks/  \
@@ -119,7 +125,7 @@ restic_default_config:
         {% endraw %}
 restic_prometheus_config:
   default:
-    prometheus-push: "https://pushgateway.k.oneill.net/"
+    prometheus-push: https://pushgateway.k.oneill.net/
     prometheus-labels:
       - host: "{% raw %}{{ .Hostname }}{% endraw %}"
 
@@ -139,7 +145,6 @@ restic_secrets:
     3433346335656662660a633137343563613165663334343836316164306239323339373765346562
     35643236396431666630626532646334653331633935313432363165656231343435646636666665
     6162373932353165646535646632623236653335326636653631
-
 restic_passphrase: !vault |
   $ANSIBLE_VAULT;1.1;AES256
   31386466306334343030376139306166306531353631313537643062613331656665656539303461
@@ -173,7 +178,7 @@ ler53_aws_secret_key: !vault |
 route53_region: us-east-1
 
 aws_secret_access_key: aws_access_key_id
-aws_secret_access_token: !vault |
+aws_secret_access_token: !vault |-
   $ANSIBLE_VAULT;1.1;AES256
   37663466303235396662653362663136326538623964313363343666666363326236383534356565
   3564303034623962366535323037326264613931633131380a356335376134666330313463396631

--- a/ansible/inventory/default
+++ b/ansible/inventory/default
@@ -4,12 +4,10 @@ k1 ansible_host=k1.oneill.net domain=oneill.net
 k2 ansible_host=k2.oneill.net domain=oneill.net
 k4 ansible_host=k4.oneill.net domain=oneill.net
 k5 ansible_host=k5.oneill.net domain=oneill.net
-fiber ansible_host=fiber.oneill.net domain=oneill.net
-voron2 ansible_host=voron2.oneill.net domain=oneill.net
-voron2-pizero ansible_host=voron2-pizero.oneill.net domain=oneill.net
-gasherbrum ansible_host=gasherbrum.oneill.net domain=oneill.net
-gasherbrum-display ansible_host=gasherbrum-display.oneill.net domain=oneill.net
-frank ansible_host=frank.oneill.net domain=oneill.net
+#voron2 ansible_host=voron2.oneill.net domain=oneill.net
+#voron2-pizero ansible_host=voron2-pizero.oneill.net domain=oneill.net
+#gasherbrum ansible_host=gasherbrum.oneill.net domain=oneill.net
+#gasherbrum-display ansible_host=gasherbrum-display.oneill.net domain=oneill.net
 zwavejs ansible_host=zwavejs.oneill.net domain=oneill.net
 upspi ansible_host=upspi.oneill.net domain=oneill.net
 
@@ -31,23 +29,23 @@ k5
 upspi
 
 [certbot]
-gasherbrum
-voron2
+#gasherbrum
+#voron2
 
 [pi]
-voron2-pizero
-gasherbrum
-gasherbrum-display
+#voron2-pizero
+#gasherbrum
+#gasherbrum-display
 zwavejs
 upspi
 
 [pizero]
-voron2-pizero
-gasherbrum-display
+#voron2-pizero
+#gasherbrum-display
 
 [tailscale_disabled]
-voron2-pizero
-gasherbrum-display
+#voron2-pizero
+#gasherbrum-display
 
 [nut_server]
 upspi

--- a/ansible/roles/resticprofile/defaults/main.yaml
+++ b/ansible/roles/resticprofile/defaults/main.yaml
@@ -1,19 +1,18 @@
 ---
 # restic_passphrase: <set password in config>
 
-resticprofile_version: "0.21.0"
+resticprofile_version: 0.31.0
 resticprofile_arch: amd64
-resticprofile_bin_dir: "/usr/local/bin"
-resticprofile_tmp_dir: "/tmp/resticprofile-ansible"
+resticprofile_bin_dir: /usr/local/bin
+resticprofile_tmp_dir: /tmp/resticprofile-ansible
 resticprofile_sftp_server: false
 resticprofile_sftp_client: false
 resticprofile_rclone_client: false
 resticprofile_sftp_servers: []
 resticprofile_client_user: root
-resticprofile_ssh_key: "~{{ resticprofile_client_user }}/.ssh/id_restic_{{ resticprofile_ssh_key_type }}"
+resticprofile_ssh_key: ~{{ resticprofile_client_user }}/.ssh/id_restic_{{ resticprofile_ssh_key_type }}
 resticprofile_ssh_key_bits: 2048
 resticprofile_ssh_key_type: ed25519
-
 
 # Whether or not to register the ssh key with the backup server.  Used for testing.
 resticprofile_ssh_register: true
@@ -24,5 +23,5 @@ resticprofile_enable_scheduling: true
 # The following restic_* variables are used to configure restic itself, not the
 # resticprofile role. We intentionally ignore the var-naming[no-role-prefix]
 # linting rule for these variables.
-restic_version: 0.15.2 # noqa: var-naming[no-role-prefix]
+restic_version: 0.18.0 # noqa: var-naming[no-role-prefix]
 restic_arch: amd64 # noqa: var-naming[no-role-prefix]

--- a/ansible/roles/resticprofile/tasks/configure-client.yaml
+++ b/ansible/roles/resticprofile/tasks/configure-client.yaml
@@ -1,27 +1,27 @@
 ---
-- name: "Ensure resticprofile client user exists"
+- name: Ensure resticprofile client user exists
   ansible.builtin.user:
     name: "{{ resticprofile_client_user }}"
     state: present
   register: restic_user_info
 
-- name: "Create resticprofile configuration directory"
+- name: Create resticprofile configuration directory
   ansible.builtin.file:
     path: "{{ restic_user_info.home }}/.config/resticprofile"
     state: directory
     mode: "0700"
     owner: "{{ resticprofile_client_user }}"
 
-- name: "Write passphrase to file"
+- name: Write passphrase to file
   ansible.builtin.copy:
     content: "{{ restic_passphrase }}"
     dest: "{{ restic_user_info.home }}/.config/resticprofile/passphrase.txt"
     owner: "{{ resticprofile_client_user }}"
     mode: "0600"
 
-- name: "Write config file"
+- name: Write config file
   ansible.builtin.template:
-    src: "templates/config.j2"
+    src: templates/config.j2
     dest: "{{ restic_user_info.home }}/.config/resticprofile/profiles.yaml"
     owner: "{{ resticprofile_client_user }}"
     mode: "0600"
@@ -29,10 +29,22 @@
 
 - name: Check if resticprofile schedules are up to date
   ansible.builtin.command: "{{ resticprofile_bin_dir }}/resticprofile status"
-  register: restic_status
+  register: resticprofile_status
   changed_when: false
   when: resticprofile_enable_scheduling
 
-- name: "Update resticprofile schedules"
+- name: Unschedule existing jobs if upgrading resticprofile
+  ansible.builtin.command: "{{ resticprofile_bin_dir }}/resticprofile unschedule"
+  when:
+    - resticprofile_enable_scheduling
+    - resticprofile_install_resticprofile
+    - resticprofile_status.stdout is not search('not found$')
+  register: unschedule_result
+  failed_when: false
+
+- name: Update resticprofile schedules
   ansible.builtin.command: "{{ resticprofile_bin_dir }}/resticprofile schedule"
-  when: resticprofile_enable_scheduling and (restic_status is defined and (restic_status.stdout is search("not found$") or config_file.changed))
+  when:
+    - resticprofile_enable_scheduling
+    - resticprofile_status is defined
+    - (resticprofile_status.stdout is search("not found$") or config_file.changed or resticprofile_install_resticprofile)

--- a/flake.nix
+++ b/flake.nix
@@ -21,16 +21,15 @@
         default = pkgs.mkShell {
           # Pinned packages available in the environment
           packages = with pkgs; [
+            act
             ansible
+            ansible-lint
             opentofu
             awscli2
             pre-commit
             tflint
             trivy
-            # GitHub Actions local runner
-            act
-            # Nix linters/formatters
-            deadnix
+            yamlfix
           ];
         };
       });

--- a/scripts/ansible-lint-wrapper
+++ b/scripts/ansible-lint-wrapper
@@ -1,12 +1,6 @@
 #!/bin/bash
 
-# ansible-lint wrapper script
-# Sets ANSIBLE_CONFIG and filters files to only process YAML files under ansible/
-
-set -e
-
-# Set ANSIBLE_CONFIG to point to the ansible directory
-export ANSIBLE_CONFIG=ansible.cfg
+set -eu -o pipefail
 
 # Change to the ansible directory
 cd ansible
@@ -24,7 +18,7 @@ done
 
 # Only run ansible-lint if we have files to process
 if [ ${#filtered_files[@]} -gt 0 ]; then
-    exec ansible-lint "${filtered_files[@]}"
+    exec ansible-lint --fix "${filtered_files[@]}"
 else
     echo "No YAML files under ansible/ directory to lint"
     exit 0


### PR DESCRIPTION
• Upgrade restic from 0.15.2 to 0.18.0 and resticprofile from 0.21.0 to 0.31.0
• Add automatic unscheduling and rescheduling during resticprofile upgrades to handle known issues in some releases
• Exclude /var/lib/containerd from backups for all hosts to improve performance
• Comment out offline hosts in inventory to prevent connection attempts
• Fix pre-commit linting configuration to exclude galaxy roles
