### PR TITLE
Separate terraform checks into dedicated workflow for performance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,3 +35,5 @@ jobs:
 
     - name: Run lint
       run: nix develop --command ./scripts/lint
+      env:
+        SKIP: terraform_trivy,terraform_providers_lock

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,0 +1,50 @@
+---
+name: Terraform checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  terraform:
+    name: Terraform checks
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+
+    - name: Check for Terraform-related changes
+      uses: dorny/paths-filter@v3
+      id: changes
+      with:
+        filters: |
+          terraform:
+            - 'opentofu/**'
+            - 'flake.nix'
+            - 'flake.lock'
+            - '.pre-commit-config.yaml'
+            - '.github/workflows/terraform.yaml'
+
+    - name: Install Nix
+      if: steps.changes.outputs.terraform == 'true'
+      uses: cachix/install-nix-action@c134e4c9e34bac6cab09cf239815f9339aaaf84e  # v31
+      with:
+        github_access_token: ${{ github.token }}
+
+    - name: Cache pre-commit
+      if: steps.changes.outputs.terraform == 'true'
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+      with:
+        path: ~/.cache/pre-commit
+        key: precommit-terraform-${{ hashFiles('.pre-commit-config.yaml') }}
+        restore-keys: |
+          precommit-terraform-
+          precommit-
+
+    - name: Run terraform checks
+      if: steps.changes.outputs.terraform == 'true'
+      run: |
+        nix develop --command pre-commit run terraform_trivy --all-files
+        nix develop --command pre-commit run terraform_providers_lock --all-files


### PR DESCRIPTION
Split slow terraform checks (terraform_trivy, terraform_providers_lock)
from main CI into separate workflow that only runs when terraform-related
files change. This improves main CI performance by ~40 seconds.

Changes:
- Skip terraform_trivy and terraform_providers_lock in main CI via SKIP env
- Add new terraform.yaml workflow with path filtering
- Use dorny/paths-filter pattern matching existing workflows
- Run terraform checks only when opentofu/, nix configs, or pre-commit config changes
