### PR TITLE
Extend prettier formatting to entire repository

### DIFF
--- a/.github/workflows/render-helm.yaml
+++ b/.github/workflows/render-helm.yaml
@@ -93,7 +93,8 @@ jobs:
         fi
 
     - name: Commit regenerated manifests
-      if: steps.changes.outputs.need-render-helm == 'true' && github.event_name == 'pull_request'
+      if: steps.changes.outputs.need-render-helm == 'true' && github.event_name ==
+        'pull_request'
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -103,7 +104,8 @@ jobs:
         fi
 
     - name: Push changes via PAT
-      if: steps.changes.outputs.need-render-helm == 'true' && github.event_name == 'pull_request'
+      if: steps.changes.outputs.need-render-helm == 'true' && github.event_name ==
+        'pull_request'
       run: |-
         BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF##*/}}"
         echo "Pushing to branch: $BRANCH_NAME"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 ---
 exclude: ^ansible/galaxy/|^kubernetes/.*/helm/
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
@@ -29,7 +30,6 @@ repos:
   hooks:
   - id: prettier
     types_or: [json, markdown]
-    files: ^kubernetes/  # TODO: Extend prettier to entire repo later
 
 - repo: local
   hooks:


### PR DESCRIPTION
Remove kubernetes/ path restriction from prettier hook to enable
consistent JSON and Markdown formatting across the entire repository.
The global exclude pattern already handles ansible/galaxy/ exclusion.

This addresses the TODO comment and improves repository-wide consistency.
