### PR TITLE
Extend shfmt shell formatting to entire repository

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,6 @@ repos:
   hooks:
   - id: shfmt
     args: [-i, '2', -ci]
-    files: ^kubernetes/.*\.sh$
 
 - repo: https://github.com/igorshubovych/markdownlint-cli
   rev: v0.45.0


### PR DESCRIPTION
Remove kubernetes/ path restriction from shfmt hook to enable
consistent shell script formatting across the entire repository.
This ensures all shell scripts follow the same formatting standards.

Formatting args remain: -i '2' -ci (2-space indentation, compact if).
