### PR TITLE
Fix GitHub Actions workflow issues and OAuth permissions

### DIFF
--- a/.github/workflows/argocd-diff.yml
+++ b/.github/workflows/argocd-diff.yml
@@ -42,5 +42,6 @@ jobs:
       with:
         argocd-server-fqdn: argocd.cow-banjo.ts.net
         argocd-token: ${{ secrets.ARGOCD_AUTH_TOKEN }}
-        argocd-headers: ''
+        # Workaround for assertion error with empty headers - https://github.com/argocd-diff-action/argocd-diff-action/issues/166
+        argocd-headers: 'Content-Type: application/json'
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-reset-commands.yml
+++ b/.github/workflows/deploy-reset-commands.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Check for deploy command
       id: deploy
       uses: xt0rted/slash-command-action@v2.0.0
+      continue-on-error: true
       with:
         command: deploy
         permission-level: admin
@@ -28,6 +29,7 @@ jobs:
     - name: Check for reset command
       id: reset
       uses: xt0rted/slash-command-action@v2.0.0
+      continue-on-error: true
       with:
         command: reset
         permission-level: admin

--- a/opentofu/tailscale.tf
+++ b/opentofu/tailscale.tf
@@ -102,7 +102,7 @@ resource "tailscale_oauth_client" "k8s_operator" {
 # Create OAuth client for GitHub Actions (ephemeral nodes)
 resource "tailscale_oauth_client" "github_actions" {
   description = "github-actions"
-  scopes      = ["devices:read"]
+  scopes      = ["auth_keys"]
   tags        = ["tag:github-actions"]
 }
 


### PR DESCRIPTION
## Summary
- Fix Tailscale OAuth client scope from `devices:read` to `auth_keys` as required for creating ephemeral nodes via GitHub Actions
- Add `continue-on-error` to slash command checks to prevent workflow failure when using wrong command (e.g., `/diff` in deploy-reset workflow) 
- Add dummy `argocd-headers` value to fix assertion error in argocd-diff-action