### PR TITLE
Set GH_TOKEN for gh CLI authentication in workflow comments

### DIFF
--- a/.github/workflows/argocd-diff.yml
+++ b/.github/workflows/argocd-diff.yml
@@ -36,6 +36,8 @@ jobs:
     - name: Comment No Apps Found
       if: steps.diff.outputs.command-name && steps.detect-apps.outputs.app_count ==
         '0'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh pr comment "${{ github.event.issue.number }}" \
           --body "📋 No ArgoCD applications detected in changed files - nothing to diff."

--- a/.github/workflows/deploy-reset-commands.yml
+++ b/.github/workflows/deploy-reset-commands.yml
@@ -71,6 +71,8 @@ jobs:
     - name: Comment No Apps Found
       if: (steps.deploy.outputs.command-name || steps.reset.outputs.command-name)
         && steps.pr-info.outputs.app_count == '0'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh pr comment "${{ github.event.issue.number }}" \
           --body "📋 No ArgoCD applications detected in changed files - nothing to deploy/reset."


### PR DESCRIPTION
## Summary
- Add GH_TOKEN environment variable to comment steps in both workflows
- Fixes authentication issue when using gh CLI to comment on PRs
- Required for the "no apps found" comments to work properly

## Changes
- Set `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` in comment steps for both argocd-diff.yml and deploy-reset-commands.yml