### PR TITLE
Fix GH_TOKEN authentication for gh pr view command

### DIFF
--- a/.github/workflows/argocd-diff.yml
+++ b/.github/workflows/argocd-diff.yml
@@ -36,6 +36,8 @@ jobs:
     - name: Comment No Apps Found
       if: steps.diff.outputs.command-name && steps.detect-apps.outputs.app_count ==
         '0'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh pr comment "${{ github.event.issue.number }}" \
           --body "📋 No ArgoCD applications detected in changed files - nothing to diff."

--- a/.github/workflows/deploy-reset-commands.yml
+++ b/.github/workflows/deploy-reset-commands.yml
@@ -71,6 +71,8 @@ jobs:
     - name: Comment No Apps Found
       if: (steps.deploy.outputs.command-name || steps.reset.outputs.command-name)
         && steps.pr-info.outputs.app_count == '0'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh pr comment "${{ github.event.issue.number }}" \
           --body "📋 No ArgoCD applications detected in changed files - nothing to deploy/reset."

--- a/.github/workflows/deploy-reset-commands.yml
+++ b/.github/workflows/deploy-reset-commands.yml
@@ -52,6 +52,8 @@ jobs:
     - name: Get PR Info and Detect Changed Apps
       if: steps.deploy.outputs.command-name || steps.reset.outputs.command-name
       id: pr-info
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         PR_BRANCH=$(gh pr view ${{ github.event.issue.number }} --json headRefName -q .headRefName)
         echo "branch=$PR_BRANCH" >> $GITHUB_OUTPUT
@@ -91,6 +93,8 @@ jobs:
     - name: Execute Command
       if: (steps.deploy.outputs.command-name || steps.reset.outputs.command-name)
         && steps.pr-info.outputs.app_count != '0'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |-
         ./scripts/argocd-deploy \
           --apps "${{ steps.pr-info.outputs.apps }}" \


### PR DESCRIPTION
## Summary
- Add missing GH_TOKEN environment variable to workflow step that uses `gh pr view`
- Fixes authentication error when getting PR branch information

## Problem
The "Get PR Info and Detect Changed Apps" step in deploy-reset-commands.yml uses `gh pr view` to get the PR branch name, but was missing the required `GH_TOKEN` environment variable, causing authentication failures.

## Solution
Added `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the environment for the step that calls `gh pr view`.