### PR TITLE
Pin tautulli image to v2.15.3

### DIFF
--- a/kubernetes/tautulli/kustomization.yaml
+++ b/kubernetes/tautulli/kustomization.yaml
@@ -8,6 +8,10 @@ resources:
 - pvc.yaml
 - service.yaml
 
+images:
+- name: tautulli/tautulli
+  newTag: v2.15.3
+
 labels:
 
 - pairs:


### PR DESCRIPTION
- Add image pinning in kustomization.yaml to pin tautulli/tautulli to v2.15.3
- Follows the same pattern as other services for consistent image management
- Prevents automatic updates to latest and ensures reproducible deployments
