### PR TITLE
Add server flag to ArgoCD deploy script

### DIFF
--- a/scripts/argocd-deploy
+++ b/scripts/argocd-deploy
@@ -28,7 +28,7 @@ PR_NUMBER=""
 SYNC_TIMEOUT="300"
 
 # ArgoCD command with standard flags
-ARGOCD="argocd --grpc-web"
+ARGOCD="argocd --server argocd.cow-banjo.ts.net --grpc-web"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## Summary
- Add --server argocd.cow-banjo.ts.net to ARGOCD variable
- Ensures ArgoCD CLI knows which server to connect to when using token auth