### PR TITLE
Use ArgoCD environment variables for cleaner configuration

### DIFF
--- a/.github/workflows/deploy-reset-commands.yml
+++ b/.github/workflows/deploy-reset-commands.yml
@@ -16,6 +16,9 @@ concurrency:
 jobs:
   deploy-reset-commands:
     runs-on: ubuntu-latest
+    env:
+      ARGOCD_SERVER: argocd.cow-banjo.ts.net
+      ARGOCD_OPTS: --grpc-web
 
     steps:
     - name: Ensure this is a PR comment

--- a/scripts/argocd-deploy
+++ b/scripts/argocd-deploy
@@ -27,8 +27,6 @@ TARGET_REVISION=""
 PR_NUMBER=""
 SYNC_TIMEOUT="300"
 
-# ArgoCD command with standard flags
-ARGOCD="argocd --grpc-web"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -113,13 +111,18 @@ patch_apps() {
   # Patch all apps to update target revision - fail fast if any fail
   for app in "${apps_array[@]}"; do
     echo "Updating $app to target revision: $TARGET_REVISION..."
-    if ! $ARGOCD app patch "$app" --patch "$patch_json" 2>&1; then
+    if ! argocd app patch "$app" --patch "$patch_json" 2>&1; then
       echo "❌ Failed to update target revision for $app"
       FAILED_APPS=("${apps_array[@]}")
       comment_pr "❌ Failed to update target revision for **$app** to \`$TARGET_REVISION\`. Check ArgoCD application configuration."
       return 1
     fi
     echo "✅ Updated $app target revision"
+
+    echo "Refreshing $app to resolve new target revision..."
+    if ! argocd app get "$app" --refresh 2>&1; then
+      echo "⚠️ Warning: Failed to refresh $app, continuing anyway..."
+    fi
   done
 }
 
@@ -129,7 +132,7 @@ sync_apps() {
   read -ra apps_array <<< "$APPS"
 
   echo "Syncing apps: ${apps_array[*]}"
-  if $ARGOCD app sync "${apps_array[@]}" --timeout "$SYNC_TIMEOUT" 2>&1; then
+  if argocd app sync "${apps_array[@]}" --timeout "$SYNC_TIMEOUT" 2>&1; then
     SUCCESS_APPS=("${apps_array[@]}")
     echo "✅ Successfully synced: ${apps_array[*]}"
     comment_pr "🚀 Successfully deployed **${apps_array[*]}** to \`$TARGET_REVISION\`"


### PR DESCRIPTION
## Summary
- Add ARGOCD_SERVER and ARGOCD_OPTS at job level
- Remove ARGOCD variable from script - use argocd directly
- Add refresh after patch to resolve branch names
- Simplifies configuration and follows ArgoCD best practices