### PR TITLE
Fix ArgoCD CLI cache misses and RBAC permissions

### DIFF
--- a/.github/workflows/deploy-reset-commands.yml
+++ b/.github/workflows/deploy-reset-commands.yml
@@ -113,24 +113,24 @@ jobs:
       id: cache-argocd
       uses: actions/cache@v4
       with:
-        path: ~/argocd-cli
-        key: argocd-cli-${{ runner.os }}
+        path: ${{ github.workspace }}/.cache/argocd/cli
+        key: argocd-cli-${{ runner.os }}-v1
 
     - name: Install ArgoCD CLI
       if: (steps.deploy.outputs.command-name || steps.reset.outputs.command-name)
         && steps.pr-info.outputs.app_count != '0'
       run: |
-        # Download ArgoCD CLI if not cached
+        mkdir -p "${{ github.workspace }}/.cache/argocd"
         if [[ "${{ steps.cache-argocd.outputs.cache-hit }}" != "true" ]]; then
           echo "Cache miss - downloading ArgoCD CLI from server"
-          curl -sSL -o ~/argocd-cli https://argocd.cow-banjo.ts.net/download/argocd-linux-amd64
-          chmod +x ~/argocd-cli
+          curl -sSL -o "${{ github.workspace }}/.cache/argocd/cli" https://argocd.cow-banjo.ts.net/download/argocd-linux-amd64
+          chmod +x "${{ github.workspace }}/.cache/argocd/cli"
         else
           echo "Cache hit - using cached ArgoCD CLI"
         fi
 
         # Copy binary to PATH
-        sudo cp ~/argocd-cli /usr/local/bin/argocd
+        sudo cp "${{ github.workspace }}/.cache/argocd/cli" /usr/local/bin/argocd
 
     - name: Execute Command
       if: (steps.deploy.outputs.command-name || steps.reset.outputs.command-name)

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-rbac-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-rbac-cm.yaml
@@ -15,12 +15,18 @@ metadata:
     app.kubernetes.io/version: "v3.0.6"
 data:
   policy.csv: |
-    # Allow GitHub Actions to read application status
+    # Allow GitHub Actions to read application status and refresh
     p, role:github-actions, applications, get, *, allow
     # Allow GitHub Actions to trigger sync operations
     p, role:github-actions, applications, sync, *, allow
-    # Allow GitHub Actions to update applications (needed for target revision changes)
+    # Allow GitHub Actions to patch applications (needed for target revision changes)
+    p, role:github-actions, applications, patch, *, allow
+    # Allow GitHub Actions to update applications (patch operations may require update permission)
     p, role:github-actions, applications, update, *, allow
+    # Allow GitHub Actions to read projects (needed for refresh operations)
+    p, role:github-actions, projects, get, *, allow
+    # Allow GitHub Actions to read repositories (needed for branch resolution)
+    p, role:github-actions, repositories, get, *, allow
     # Assign github-actions account to the role
     g, github-actions, role:github-actions
   policy.default: ""


### PR DESCRIPTION
## Summary
- Fix ArgoCD CLI cache that was always missing due to tilde expansion
- Add missing RBAC permissions for github-actions service account