### PR TITLE
Create composite actions to reduce duplication in ArgoCD workflows

### DIFF
--- a/.github/actions/detect-apps/action.yml
+++ b/.github/actions/detect-apps/action.yml
@@ -1,0 +1,101 @@
+---
+name: Detect ArgoCD apps from changes
+description: Outputs app names that changed between two refs
+
+inputs:
+  base_ref:
+    required: false
+    description: Git ref or SHA to diff from (if empty, finds all apps)
+  head_ref:
+    required: false
+    description: Git ref or SHA to diff to (if empty, finds all apps)
+  apps_dir:
+    required: false
+    default: kubernetes/argocd-apps
+    description: Directory containing ArgoCD application YAML files
+  pr_number:
+    required: false
+    description: PR number for commenting (if empty, uses echo instead of gh pr comment)
+  action_type:
+    required: false
+    default: deploy
+    description: Action type for no-apps message (deploy, diff, reset)
+
+outputs:
+  apps:
+    description: Space-separated list of app names
+    value: ${{ steps.collect.outputs.apps }}
+  app_count:
+    description: Integer count of detected apps
+    value: ${{ steps.collect.outputs.app_count }}
+
+runs:
+  using: composite
+  steps:
+  - name: Fetch refs (if provided)
+    shell: bash
+    run: |
+      set -euo pipefail
+      if [[ -n "${{ inputs.base_ref }}" ]]; then
+        git fetch --no-tags --prune --depth=0 origin "+${{ inputs.base_ref }}:${{ inputs.base_ref }}" || true
+      fi
+      if [[ -n "${{ inputs.head_ref }}" ]]; then
+        git fetch --no-tags --prune --depth=0 origin "+${{ inputs.head_ref }}:${{ inputs.head_ref }}" || true
+      fi
+
+  - name: Collect apps
+    id: collect
+    shell: bash
+    run: |
+      set -euo pipefail
+      base='${{ inputs.base_ref }}'
+      head='${{ inputs.head_ref }}'
+      apps_dir='${{ inputs.apps_dir }}'
+
+      if [[ -z "$base" || -z "$head" ]]; then
+        # No refs provided - find all apps (for workflow_dispatch or similar)
+        echo "No refs provided - finding all ArgoCD applications"
+        apps=$(find "$apps_dir" -name "*.yaml" -exec basename {} .yaml \; | tr '\n' ' ' | sed 's/ $//')
+        count=$(echo "$apps" | wc -w)
+        echo "Found $count applications: $apps"
+      else
+        # Refs provided - detect changed apps
+        echo "Detecting changed applications between $base and $head"
+        mapfile -t files < <(git diff --name-only "$base" "$head" -- "kubernetes/**")
+
+        declare -A seen
+        apps_array=()
+        for f in "${files[@]}"; do
+          if [[ "$f" =~ ^${apps_dir}/([^/]+)\.ya?ml$ ]]; then
+            app="${BASH_REMATCH[1]}"
+            if [[ -z "${seen[$app]:-}" ]]; then
+              apps_array+=("$app")
+              seen[$app]=1
+            fi
+          fi
+        done
+
+        apps="${apps_array[*]}"
+        count=${#apps_array[@]}
+        echo "Detected $count changed apps: $apps"
+      fi
+
+      echo "apps=$apps" >> "$GITHUB_OUTPUT"
+      echo "app_count=$count" >> "$GITHUB_OUTPUT"
+
+  - name: Comment if no apps found
+    if: steps.collect.outputs.app_count == '0'
+    shell: bash
+    env:
+      GH_TOKEN: ${{ github.token }}
+    run: |-
+      action_type="${{ inputs.action_type }}"
+      pr_number="${{ inputs.pr_number }}"
+
+      message="📋 No ArgoCD applications detected in changed files - nothing to ${action_type}."
+
+      if [[ -n "$pr_number" ]]; then
+        gh pr comment "$pr_number" --body "$message"
+      else
+        echo "$message"
+      fi

--- a/.github/actions/setup-argocd/action.yml
+++ b/.github/actions/setup-argocd/action.yml
@@ -1,0 +1,62 @@
+---
+name: Setup ArgoCD env
+description: Connect to Tailscale and ensure argocd CLI is available
+
+inputs:
+  tailscale_oauth_client_id:
+    required: true
+  tailscale_oauth_secret:
+    required: true
+
+outputs:
+  argocd_path:
+    description: Absolute path to installed ArgoCD CLI
+    value: ${{ steps.set-path.outputs.argocd_path }}
+
+runs:
+  using: composite
+  steps:
+  - name: Connect to Tailscale
+    uses: tailscale/github-action@main
+    with:
+      oauth-client-id: ${{ inputs.tailscale_oauth_client_id }}
+      oauth-secret: ${{ inputs.tailscale_oauth_secret }}
+      tags: tag:github-actions
+      use-cache: true
+
+  - name: Cache ArgoCD CLI
+    id: cache-argocd
+    uses: actions/cache@v4
+    with:
+      path: ${{ github.workspace }}/.cache/argocd/cli
+      key: argocd-cli-${{ runner.os }}-v1
+
+  - name: Install ArgoCD CLI
+    id: install
+    shell: bash
+    run: |
+      set -euo pipefail
+      CACHE="${{ github.workspace }}/.cache/argocd"
+      BIN="$CACHE/cli"
+      mkdir -p "$CACHE"
+      if [[ ! -f "$BIN" ]]; then
+        echo "Downloading ArgoCD CLI"
+        # Fixed-delay retries (non-exponential)
+        curl -fsSL \
+          --retry 5 \
+          --retry-all-errors \
+          --retry-connrefused \
+          --retry-delay 2 \
+          --retry-max-time 60 \
+          -o "$BIN" \
+          https://argocd.cow-banjo.ts.net/download/argocd-linux-amd64
+        chmod +x "$BIN"
+      else
+        echo "Using cached ArgoCD CLI"
+      fi
+      sudo cp "$BIN" /usr/local/bin/argocd
+
+  - name: Set ArgoCD path output
+    id: set-path
+    shell: bash
+    run: echo "argocd_path=/usr/local/bin/argocd" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/argocd-diff.yml
+++ b/.github/workflows/argocd-diff.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   argocd-diff:
     runs-on: ubuntu-latest
+    env:
+      ARGOCD_SERVER: argocd.cow-banjo.ts.net
+      ARGOCD_OPTS: --grpc-web
 
     steps:
     - name: Ensure this is a PR comment
@@ -20,14 +23,15 @@ jobs:
           echo "Not a PR – skipping"
           exit 1
         fi
+
     - name: Check for diff command
       id: diff
       uses: xt0rted/slash-command-action@v2.0.0
+      continue-on-error: true
       with:
         command: diff
         permission-level: admin
 
-      # heck out the PR HEAD, not default branch
     - name: Checkout PR head
       if: steps.diff.outputs.command-name
       uses: actions/checkout@v4
@@ -35,49 +39,64 @@ jobs:
         fetch-depth: 0
         ref: refs/pull/${{ github.event.issue.number }}/head
 
-    # Make sure the base branch ref exists locally for your script’s diff
-    - name: Fetch base branch
+    - name: Determine base ref
       if: steps.diff.outputs.command-name
+      id: base
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         # Query PR base dynamically instead of assuming 'main'
         BASE=$(gh pr view ${{ github.event.issue.number }} --json baseRefName -q .baseRefName)
-        echo "BASE_REF=$BASE" >> $GITHUB_ENV
+        echo "base=$BASE" >> $GITHUB_OUTPUT
         git fetch origin "$BASE:$BASE"
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Detect Changed Apps
       if: steps.diff.outputs.command-name
-      id: detect-apps
-      run: |-
-        ./scripts/argocd-detect-apps --base-ref "$BASE_REF" --head-ref HEAD
-
-    - name: Comment No Apps Found
-      if: steps.diff.outputs.command-name && steps.detect-apps.outputs.app_count ==
-        '0'
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        gh pr comment "${{ github.event.issue.number }}" \
-          --body "📋 No ArgoCD applications detected in changed files - nothing to diff."
-
-    - name: Connect to Tailscale
-      if: steps.diff.outputs.command-name && steps.detect-apps.outputs.app_count !=
-        '0'
-      uses: tailscale/github-action@main
+      id: detect
+      uses: ./.github/actions/detect-apps
       with:
-        oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-        oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
-        tags: tag:github-actions
-        use-cache: true
+        base_ref: ${{ steps.base.outputs.base }}
+        head_ref: HEAD
+        pr_number: ${{ github.event.issue.number }}
+        action_type: diff
+
+    - name: Setup ArgoCD environment
+      if: steps.diff.outputs.command-name && steps.detect.outputs.app_count != '0'
+      id: setup-argocd
+      uses: ./.github/actions/setup-argocd
+      with:
+        tailscale_oauth_client_id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+        tailscale_oauth_secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
 
     - name: ArgoCD Diff
-      if: steps.diff.outputs.command-name && steps.detect-apps.outputs.app_count !=
-        '0'
-      uses: argocd-diff-action/argocd-diff-action@0.5.3
-      with:
-        argocd-server-fqdn: argocd.cow-banjo.ts.net
-        argocd-token: ${{ secrets.ARGOCD_AUTH_TOKEN }}
-        # Workaround for assertion error with empty headers - https://github.com/argocd-diff-action/argocd-diff-action/issues/166
-        argocd-headers: 'Content-Type: application/json'
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+      if: steps.diff.outputs.command-name && steps.detect.outputs.app_count != '0'
+      env:
+        ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |-
+        # Split apps into array for processing
+        IFS=' ' read -ra APPS_ARRAY <<< "${{ steps.detect.outputs.apps }}"
+
+        echo "🔍 Running ArgoCD diff for apps: ${{ steps.detect.outputs.apps }}"
+
+        # Create diff output for each app
+        diff_output=""
+        for app in "${APPS_ARRAY[@]}"; do
+          echo "Generating diff for $app..."
+          if app_diff=$(argocd app diff "$app" --local-repo-root . 2>&1); then
+            if [[ -n "$app_diff" ]]; then
+              diff_output="${diff_output}## 📋 $app\n\n\`\`\`diff\n$app_diff\n\`\`\`\n\n"
+            else
+              diff_output="${diff_output}## 📋 $app\n\nNo changes detected.\n\n"
+            fi
+          else
+            diff_output="${diff_output}## 📋 $app\n\n❌ Failed to generate diff: $app_diff\n\n"
+          fi
+        done
+
+        # Comment the diff results on the PR
+        if [[ -n "$diff_output" ]]; then
+          gh pr comment "${{ github.event.issue.number }}" --body "$(echo -e "$diff_output")"
+        else
+          gh pr comment "${{ github.event.issue.number }}" --body "📋 No ArgoCD diffs to display."
+        fi

--- a/.github/workflows/deploy-reset-commands.yml
+++ b/.github/workflows/deploy-reset-commands.yml
@@ -44,21 +44,6 @@ jobs:
         command: reset
         permission-level: admin
 
-    - name: Connect to Tailscale
-      if: steps.deploy.outputs.command-name || steps.reset.outputs.command-name
-      uses: tailscale/github-action@main
-      with:
-        oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-        oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
-        tags: tag:github-actions
-        use-cache: true
-
-    - name: Test ArgoCD connectivity
-      if: steps.deploy.outputs.command-name || steps.reset.outputs.command-name
-      run: |
-        echo "Testing connectivity to ArgoCD server..."
-        curl -v --connect-timeout 10 --max-time 30 https://argocd.cow-banjo.ts.net/api/version || echo "Curl failed with exit code $?"
-
     - name: Checkout PR head
       if: steps.deploy.outputs.command-name || steps.reset.outputs.command-name
       uses: actions/checkout@v4
@@ -66,18 +51,18 @@ jobs:
         fetch-depth: 0
         ref: refs/pull/${{ github.event.issue.number }}/head
 
-    # Make sure the base branch ref exists locally for the script's diff
-    - name: Fetch base branch
+    - name: Determine base ref
       if: steps.deploy.outputs.command-name || steps.reset.outputs.command-name
+      id: base
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         # Query PR base dynamically instead of assuming 'main'
         BASE=$(gh pr view ${{ github.event.issue.number }} --json baseRefName -q .baseRefName)
-        echo "BASE_REF=$BASE" >> $GITHUB_ENV
+        echo "base=$BASE" >> $GITHUB_OUTPUT
         git fetch origin "$BASE:$BASE"
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Get PR Info and Detect Changed Apps
+    - name: Get PR Info
       if: steps.deploy.outputs.command-name || steps.reset.outputs.command-name
       id: pr-info
       env:
@@ -95,51 +80,33 @@ jobs:
         fi
         echo "target-revision=$TARGET_REVISION" >> $GITHUB_OUTPUT
 
-        # Detect affected ArgoCD applications
-        ./scripts/argocd-detect-apps --base-ref "$BASE_REF" --head-ref HEAD
-
-    - name: Comment No Apps Found
-      if: (steps.deploy.outputs.command-name || steps.reset.outputs.command-name)
-        && steps.pr-info.outputs.app_count == '0'
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        gh pr comment "${{ github.event.issue.number }}" \
-          --body "📋 No ArgoCD applications detected in changed files - nothing to deploy/reset."
-
-    - name: Cache ArgoCD CLI
-      if: (steps.deploy.outputs.command-name || steps.reset.outputs.command-name)
-        && steps.pr-info.outputs.app_count != '0'
-      id: cache-argocd
-      uses: actions/cache@v4
+    - name: Detect Changed Apps
+      if: steps.deploy.outputs.command-name || steps.reset.outputs.command-name
+      id: detect
+      uses: ./.github/actions/detect-apps
       with:
-        path: ${{ github.workspace }}/.cache/argocd/cli
-        key: argocd-cli-${{ runner.os }}-v1
+        base_ref: ${{ steps.base.outputs.base }}
+        head_ref: HEAD
+        pr_number: ${{ github.event.issue.number }}
+        action_type: deploy/reset
 
-    - name: Install ArgoCD CLI
+    - name: Setup ArgoCD environment
       if: (steps.deploy.outputs.command-name || steps.reset.outputs.command-name)
-        && steps.pr-info.outputs.app_count != '0'
-      run: |
-        mkdir -p "${{ github.workspace }}/.cache/argocd"
-        if [[ "${{ steps.cache-argocd.outputs.cache-hit }}" != "true" ]]; then
-          echo "Cache miss - downloading ArgoCD CLI from server"
-          curl -sSL -o "${{ github.workspace }}/.cache/argocd/cli" https://argocd.cow-banjo.ts.net/download/argocd-linux-amd64
-          chmod +x "${{ github.workspace }}/.cache/argocd/cli"
-        else
-          echo "Cache hit - using cached ArgoCD CLI"
-        fi
-
-        # Copy binary to PATH
-        sudo cp "${{ github.workspace }}/.cache/argocd/cli" /usr/local/bin/argocd
+        && steps.detect.outputs.app_count != '0'
+      id: setup-argocd
+      uses: ./.github/actions/setup-argocd
+      with:
+        tailscale_oauth_client_id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+        tailscale_oauth_secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
 
     - name: Execute Command
       if: (steps.deploy.outputs.command-name || steps.reset.outputs.command-name)
-        && steps.pr-info.outputs.app_count != '0'
+        && steps.detect.outputs.app_count != '0'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
       run: |-
         ./scripts/argocd-deploy \
-          --apps "${{ steps.pr-info.outputs.apps }}" \
+          --apps "${{ steps.detect.outputs.apps }}" \
           --target-revision "${{ steps.pr-info.outputs.target-revision }}" \
           --comment-pr "${{ github.event.issue.number }}"

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [main]
     paths: [kubernetes/**]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,6 +17,9 @@ concurrency:
 jobs:
   production-deploy:
     runs-on: ubuntu-latest
+    env:
+      ARGOCD_SERVER: argocd.cow-banjo.ts.net
+      ARGOCD_OPTS: --grpc-web
 
     steps:
     - name: Checkout code
@@ -23,33 +27,27 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Connect to Tailscale
-      uses: tailscale/github-action@main
-      with:
-        oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-        oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
-        tags: tag:github-actions
-
     - name: Detect Changed Apps
-      id: detect-apps
-      run: |
-        ./scripts/detect-argocd-apps.sh --base-ref HEAD~1 --head-ref HEAD
-      env:
-        GH_TOKEN: ${{ github.token }}
-
-    - name: Login to ArgoCD
-      if: steps.detect-apps.outputs.app_count != '0'
-      uses: clowdhaus/argo-cd-action/@main
-      env:
-        ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
+      id: detect
+      uses: ./.github/actions/detect-apps
       with:
-        version: 2.12.3
-        command: login
-        options: argocd
+        base_ref: ${{ github.event_name == 'workflow_dispatch' && '' || github.event.before }}
+        head_ref: ${{ github.event_name == 'workflow_dispatch' && '' || github.sha }}
+        action_type: deploy
+
+    - name: Setup ArgoCD environment
+      if: steps.detect.outputs.app_count != '0'
+      id: setup-argocd
+      uses: ./.github/actions/setup-argocd
+      with:
+        tailscale_oauth_client_id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+        tailscale_oauth_secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
 
     - name: Deploy Applications to Main
-      if: steps.detect-apps.outputs.app_count != '0'
+      if: steps.detect.outputs.app_count != '0'
+      env:
+        ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
       run: |-
-        ./scripts/argocd-deploy.sh \
-          --apps "${{ steps.detect-apps.outputs.apps }}" \
+        ./scripts/argocd-deploy \
+          --apps "${{ steps.detect.outputs.apps }}" \
           --target-revision "main"


### PR DESCRIPTION
Added two reusable composite actions:
- setup-argocd: Connects to Tailscale and installs ArgoCD CLI
- detect-apps: Finds changed apps and comments when none found

Updated all three workflows to use these actions instead of duplicating
the same setup code everywhere. Makes the workflows cleaner and easier
to maintain.
