### PR TITLE
Fix HEAD ambiguity in slash command workflows

### DIFF
--- a/.github/workflows/argocd-diff.yml
+++ b/.github/workflows/argocd-diff.yml
@@ -56,7 +56,7 @@ jobs:
       uses: ./.github/actions/detect-apps
       with:
         base_ref: ${{ steps.base.outputs.base }}
-        head_ref: HEAD
+        head_ref: ${{ github.sha }}
         pr_number: ${{ github.event.issue.number }}
         action_type: diff
 

--- a/.github/workflows/deploy-reset-commands.yml
+++ b/.github/workflows/deploy-reset-commands.yml
@@ -86,7 +86,7 @@ jobs:
       uses: ./.github/actions/detect-apps
       with:
         base_ref: ${{ steps.base.outputs.base }}
-        head_ref: HEAD
+        head_ref: ${{ github.sha }}
         pr_number: ${{ github.event.issue.number }}
         action_type: deploy/reset
 


### PR DESCRIPTION
Replace ambiguous HEAD reference with github.sha to fix app detection in /deploy, /reset, and /diff commands.