### PR TITLE
Fix script context security vulnerability in ArgoCD workflows

### DIFF
--- a/.github/workflows/argocd-diff.yml
+++ b/.github/workflows/argocd-diff.yml
@@ -49,6 +49,14 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event_name == 'pull_request' && github.head_ref || format('refs/pull/{0}/head', github.event.issue.number) }}
 
+    - name: Checkout trusted scripts from main branch
+      if: steps.diff.outputs.command-name || steps.diff-pr.outputs.command-name
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: main
+        path: trusted-main
+
     - name: Determine base ref
       if: steps.diff.outputs.command-name || steps.diff-pr.outputs.command-name
       id: base
@@ -74,7 +82,7 @@ jobs:
     - name: Detect Changed Apps
       if: steps.diff.outputs.command-name || steps.diff-pr.outputs.command-name
       id: detect
-      uses: ./.github/actions/detect-apps
+      uses: ./trusted-main/.github/actions/detect-apps
       with:
         base_ref: ${{ steps.base.outputs.base }}
         head_ref: ${{ steps.pr-head.outputs.sha }}
@@ -86,7 +94,7 @@ jobs:
       if: steps.diff.outputs.command-name || steps.diff-pr.outputs.command-name &&
         steps.detect.outputs.app_count != '0'
       id: setup-argocd
-      uses: ./.github/actions/setup-argocd
+      uses: ./trusted-main/.github/actions/setup-argocd
       with:
         tailscale_oauth_client_id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
         tailscale_oauth_secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}

--- a/.github/workflows/deploy-reset-commands.yml
+++ b/.github/workflows/deploy-reset-commands.yml
@@ -51,6 +51,14 @@ jobs:
         fetch-depth: 0
         ref: refs/pull/${{ github.event.issue.number }}/head
 
+    - name: Checkout trusted scripts from main branch
+      if: steps.deploy.outputs.command-name || steps.reset.outputs.command-name
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: main
+        path: trusted-main
+
     - name: Determine base ref
       if: steps.deploy.outputs.command-name || steps.reset.outputs.command-name
       id: base
@@ -92,7 +100,7 @@ jobs:
     - name: Detect Changed Apps
       if: steps.deploy.outputs.command-name || steps.reset.outputs.command-name
       id: detect
-      uses: ./.github/actions/detect-apps
+      uses: ./trusted-main/.github/actions/detect-apps
       with:
         base_ref: ${{ steps.base.outputs.base }}
         head_ref: ${{ steps.pr-head.outputs.sha }}
@@ -103,7 +111,7 @@ jobs:
       if: (steps.deploy.outputs.command-name || steps.reset.outputs.command-name)
         && steps.detect.outputs.app_count != '0'
       id: setup-argocd
-      uses: ./.github/actions/setup-argocd
+      uses: ./trusted-main/.github/actions/setup-argocd
       with:
         tailscale_oauth_client_id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
         tailscale_oauth_secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
@@ -115,7 +123,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
       run: |-
-        ./scripts/argocd-deploy \
+        ./trusted-main/scripts/argocd-deploy \
           --apps "${{ steps.detect.outputs.apps }}" \
           --target-revision "${{ steps.pr-info.outputs.target-revision }}" \
           --comment-pr "${{ github.event.issue.number }}"


### PR DESCRIPTION
Fixes security vulnerability where workflows used scripts and composite actions from PR branch instead of trusted main branch.

Changes:
- Check out main branch to trusted-main/ directory
- Use ./trusted-main/.github/actions/* for composite actions  
- Use ./trusted-main/scripts/* for deployment scripts
- Keep PR content in working directory for analysis

This prevents malicious PRs from modifying deployment infrastructure while maintaining full functionality.