### PR TITLE
Add ArgoCD management for core infrastructure components

### DIFF
--- a/kubernetes/argocd-apps/argocd.yaml
+++ b/kubernetes/argocd-apps/argocd.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+
+metadata:
+  name: argocd
+  namespace: argocd
+
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/claytono/infra.git
+    targetRevision: main
+    path: kubernetes/argocd
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true

--- a/kubernetes/argocd-apps/external-secrets.yaml
+++ b/kubernetes/argocd-apps/external-secrets.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+
+metadata:
+  name: external-secrets
+  namespace: argocd
+
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/claytono/infra.git
+    targetRevision: main
+    path: kubernetes/external-secrets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-secrets
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true

--- a/kubernetes/argocd-apps/flannel.yaml
+++ b/kubernetes/argocd-apps/flannel.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+
+metadata:
+  name: flannel
+  namespace: argocd
+
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/claytono/infra.git
+    targetRevision: main
+    path: kubernetes/0-flannel
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-flannel
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true

--- a/kubernetes/argocd-apps/homepage.yaml
+++ b/kubernetes/argocd-apps/homepage.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+
+metadata:
+  name: homepage
+  namespace: argocd
+
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/claytono/infra.git
+    targetRevision: main
+    path: kubernetes/homepage
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true


### PR DESCRIPTION
## Summary
- Add ArgoCD Application manifests for argo-cd, flannel, homepage, and external-secrets
- Configure automated sync with pruning enabled for each application
- Deploy applications to their appropriate namespaces (argocd, kube-flannel, default, external-secrets)