### PR TITLE
Use absolute paths for trusted scripts in workflows

### DIFF
--- a/.github/actions/detect-apps/action.yml
+++ b/.github/actions/detect-apps/action.yml
@@ -60,7 +60,7 @@ runs:
         echo "app_count=$count" >> "$GITHUB_OUTPUT"
       else
         # Use the argocd-detect-apps script for change detection
-        ./scripts/argocd-detect-apps --base-ref "$base" --head-ref "$head"
+        "${GITHUB_WORKSPACE}/trusted-main/scripts/argocd-detect-apps" --base-ref "$base" --head-ref "$head"
       fi
 
   - name: Comment if no apps found

--- a/.github/workflows/deploy-reset-commands.yml
+++ b/.github/workflows/deploy-reset-commands.yml
@@ -123,7 +123,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
       run: |-
-        ./trusted-main/scripts/argocd-deploy \
+        "${GITHUB_WORKSPACE}/trusted-main/scripts/argocd-deploy" \
           --apps "${{ steps.detect.outputs.apps }}" \
           --target-revision "${{ steps.pr-info.outputs.target-revision }}" \
           --comment-pr "${{ github.event.issue.number }}" \


### PR DESCRIPTION
## Summary
- Update detect-apps action to use absolute path for argocd-detect-apps script
- Update deploy workflow to use absolute path for argocd-deploy script

## Background  
Using absolute paths ensures consistent behavior and eliminates potential path resolution issues across different execution contexts.