### PR TITLE
Add ArgoCD applications for reloader and ingress-nginx

### DIFF
--- a/kubernetes/argocd-apps/ingress-nginx.yaml
+++ b/kubernetes/argocd-apps/ingress-nginx.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+
+metadata:
+  name: ingress-nginx
+  namespace: argocd
+
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/claytono/infra.git
+    targetRevision: main
+    path: kubernetes/ingress-nginx
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ingress-nginx
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true

--- a/kubernetes/argocd-apps/reloader.yaml
+++ b/kubernetes/argocd-apps/reloader.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+
+metadata:
+  name: reloader
+  namespace: argocd
+
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/claytono/infra.git
+    targetRevision: main
+    path: kubernetes/reloader
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true


### PR DESCRIPTION
## Summary
- Add ArgoCD application manifest for reloader (deployed to kube-system namespace)
- Add ArgoCD application manifest for ingress-nginx (deployed to ingress-nginx namespace)

## Configuration
Both applications are configured with:
- **Automated sync**: Changes from git are automatically deployed
- **Prune enabled**: Resources not in git are automatically removed
- **Self-heal disabled**: Allows local development changes without interference
- **CreateNamespace enabled**: Ensures target namespaces exist

This enables ArgoCD to manage these core infrastructure components alongside flannel and other applications.