### PR TITLE
Fix ArgoCD RBAC permissions for GitHub Actions

### DIFF
--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-rbac-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-rbac-cm.yaml
@@ -23,6 +23,8 @@ data:
     p, role:github-actions, applications, sync, *, allow
     # Allow GitHub Actions to update applications (needed for target revision changes)
     p, role:github-actions, applications, update, *, allow
+    # Allow GitHub Actions to access projects (required for app operations)
+    p, role:github-actions, projects, get, *, allow
     # Assign github-actions account to the role
     g, github-actions, role:github-actions
   policy.default: ""


### PR DESCRIPTION
## Summary
- Add missing projects access permission for GitHub Actions service account
- Resolves permission denied error: `projects, get, default`

## Problem
GitHub Actions was failing with permission denied when trying to access the default project:
```
rpc error: code = PermissionDenied desc = permission denied: projects, get, default
```

## Solution
Added `p, role:github-actions, projects, get, *, allow` to the RBAC policy to allow the GitHub Actions service account to read project information, which is required for application operations.