### PR TITLE
Fix ArgoCD RBAC permissions by updating values.yaml

### DIFF
--- a/kubernetes/argocd/values.yaml
+++ b/kubernetes/argocd/values.yaml
@@ -43,6 +43,8 @@ configs:
       p, role:github-actions, applications, sync, *, allow
       # Allow GitHub Actions to update applications (needed for target revision changes)
       p, role:github-actions, applications, update, *, allow
+      # Allow GitHub Actions to access projects (required for app operations)
+      p, role:github-actions, projects, get, *, allow
       # Assign github-actions account to the role
       g, github-actions, role:github-actions
   notifications:


### PR DESCRIPTION
Add projects access permission for GitHub Actions service account
in values.yaml and regenerate templates. This resolves the permission
denied error when GitHub Actions tries to access projects.
