### PR TITLE
Fix argocd-detect-apps annotation detection using yq

### DIFF
--- a/scripts/argocd-detect-apps
+++ b/scripts/argocd-detect-apps
@@ -134,8 +134,7 @@ validate_apps() {
     fi
 
     if [[ -n "$kustomization_file" ]]; then
-      # Check if the kustomization.yaml has argoManaged annotation
-      if grep -q "argoManaged:[[:space:]]*['\"]true['\"]" "$kustomization_file"; then
+      if yq eval '.commonAnnotations.argoManaged == "true"' "$kustomization_file" 2>/dev/null | grep -q "true"; then
         valid_apps+=("$app")
       else
         echo "Warning: Application '$app' found but not managed by ApplicationSet (missing argoManaged: true annotation)" >&2


### PR DESCRIPTION
Replace grep-based YAML parsing with yq for reliable detection of commonAnnotations.argoManaged annotation.

**Issue:** The current grep regex fails to properly match YAML annotations, causing apps to be incorrectly rejected.

**Fix:** Use yq to parse YAML reliably instead of regex matching.

**Testing:** After merge, this will fix the /deploy command for ApplicationSet-managed apps.