### PR TITLE
Fix ArgoCD workflow execution for apps without ApplicationSet management

### DIFF
--- a/.github/actions/detect-apps/action.yml
+++ b/.github/actions/detect-apps/action.yml
@@ -25,9 +25,6 @@ outputs:
   apps:
     description: Space-separated list of app names
     value: ${{ steps.collect.outputs.apps }}
-  app_count:
-    description: Integer count of detected apps
-    value: ${{ steps.collect.outputs.app_count }}
 
 runs:
   using: composite
@@ -54,17 +51,15 @@ runs:
         # No refs provided - find all apps (for workflow_dispatch or similar)
         echo "No refs provided - finding all ArgoCD applications"
         apps=$(find "kubernetes/argocd-apps" -name "*.yaml" -exec basename {} .yaml \; | tr '\n' ' ' | sed 's/ $//')
-        count=$(echo "$apps" | wc -w)
-        echo "Found $count applications: $apps"
+        echo "Found applications: $apps"
         echo "apps=$apps" >> "$GITHUB_OUTPUT"
-        echo "app_count=$count" >> "$GITHUB_OUTPUT"
       else
         # Use the argocd-detect-apps script for change detection
         "${GITHUB_WORKSPACE}/trusted-main/scripts/argocd-detect-apps" --base-ref "$base" --head-ref "$head" --scan-root "${GITHUB_WORKSPACE}"
       fi
 
   - name: Comment if no apps found
-    if: steps.collect.outputs.app_count == '0'
+    if: steps.collect.outputs.apps == ''
     shell: bash
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/actions/detect-apps/action.yml
+++ b/.github/actions/detect-apps/action.yml
@@ -60,7 +60,7 @@ runs:
         echo "app_count=$count" >> "$GITHUB_OUTPUT"
       else
         # Use the argocd-detect-apps script for change detection
-        "${GITHUB_WORKSPACE}/trusted-main/scripts/argocd-detect-apps" --base-ref "$base" --head-ref "$head"
+        "${GITHUB_WORKSPACE}/trusted-main/scripts/argocd-detect-apps" --base-ref "$base" --head-ref "$head" --scan-root "${GITHUB_WORKSPACE}"
       fi
 
   - name: Comment if no apps found

--- a/.github/workflows/deploy-reset-commands.yml
+++ b/.github/workflows/deploy-reset-commands.yml
@@ -109,7 +109,7 @@ jobs:
 
     - name: Setup ArgoCD environment
       if: (steps.deploy.outputs.command-name || steps.reset.outputs.command-name)
-        && steps.detect.outputs.app_count != '0'
+        && steps.detect.outputs.apps != ''
       id: setup-argocd
       uses: ./trusted-main/.github/actions/setup-argocd
       with:
@@ -118,7 +118,7 @@ jobs:
 
     - name: Execute Command
       if: (steps.deploy.outputs.command-name || steps.reset.outputs.command-name)
-        && steps.detect.outputs.app_count != '0'
+        && steps.detect.outputs.apps != ''
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}

--- a/scripts/argocd-deploy
+++ b/scripts/argocd-deploy
@@ -51,12 +51,19 @@ class ArgoCDDeployer:
         """Run a command and return the result"""
         print(f"Running command: {' '.join(cmd)}")
         try:
-            result = subprocess.run(cmd, capture_output=capture_output, text=True, check=False)
-            if result.returncode != 0:
-                print(f"Command failed with return code {result.returncode}")
-                if capture_output:
+            if capture_output:
+                result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+                if result.returncode != 0:
+                    print(f"Command failed with return code {result.returncode}")
                     print(f"stdout: {result.stdout}")
                     print(f"stderr: {result.stderr}")
+            else:
+                # For real-time output, capture stderr separately while showing stdout live
+                result = subprocess.run(cmd, stdout=None, stderr=subprocess.PIPE, text=True, check=False)
+                if result.returncode != 0:
+                    print(f"Command failed with return code {result.returncode}")
+                    if result.stderr:
+                        print(f"stderr: {result.stderr}")
             return result
         except Exception as e:
             raise DeploymentError(f"Failed to run command {' '.join(cmd)}: {e}")
@@ -73,7 +80,10 @@ class ArgoCDDeployer:
 
         result = self.run_command(cmd, capture_output=False)
         if result.returncode != 0:
-            raise DeploymentError(f"Failed to sync {app} to {self.target_revision} (see sync output above)")
+            error_msg = f"Failed to sync {app} to {self.target_revision}"
+            if result.stderr:
+                error_msg += f": {result.stderr.strip()}"
+            raise DeploymentError(error_msg)
 
         print(f"✅ Successfully synced {app} to {self.target_revision}")
 
@@ -85,7 +95,10 @@ class ArgoCDDeployer:
 
         result = self.run_command(cmd, capture_output=False)
         if result.returncode != 0:
-            raise DeploymentError(f"Application {app} failed to reach healthy status (see wait output above)")
+            error_msg = f"Application {app} failed to reach healthy status"
+            if result.stderr:
+                error_msg += f": {result.stderr.strip()}"
+            raise DeploymentError(error_msg)
 
         print(f"✅ Application {app} is healthy")
 

--- a/scripts/argocd-detect-apps
+++ b/scripts/argocd-detect-apps
@@ -42,6 +42,7 @@ GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/stdout}"
 # Default values
 BASE_REF="main"
 HEAD_REF="HEAD"
+SCAN_ROOT=""
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -54,13 +55,18 @@ while [[ $# -gt 0 ]]; do
       HEAD_REF="$2"
       shift 2
       ;;
+    --scan-root)
+      SCAN_ROOT="$2"
+      shift 2
+      ;;
     --help)
-      echo "Usage: $0 [--base-ref BASE_REF] [--head-ref HEAD_REF]"
+      echo "Usage: $0 [--base-ref BASE_REF] [--head-ref HEAD_REF] [--scan-root PATH]"
       echo "Detects ArgoCD applications affected by file changes"
       echo ""
       echo "Options:"
       echo "  --base-ref REF     Base reference for comparison (default: main)"
       echo "  --head-ref REF     Head reference for comparison (default: HEAD)"
+      echo "  --scan-root PATH   Root directory to scan for kubernetes/ (default: auto-detect)"
       echo "  --help             Show this help message"
       exit 0
       ;;
@@ -92,7 +98,7 @@ extract_app_names() {
         local raw_app_name="${BASH_REMATCH[1]}"
 
         # Only consider it an app if the directory has a kustomization.yaml
-        if [[ -f "$REPO_ROOT/kubernetes/$raw_app_name/kustomization.yaml" ]]; then
+        if [[ -f "$EFFECTIVE_ROOT/kubernetes/$raw_app_name/kustomization.yaml" ]]; then
           app_name="$raw_app_name"
           # Strip numeric prefixes like "0-flannel" -> "flannel"
           if [[ "$app_name" =~ ^[0-9]+-(.+)$ ]]; then
@@ -121,11 +127,11 @@ validate_apps() {
     local kustomization_file=""
 
     # Check for kustomization.yaml in the original directory (with potential numeric prefix)
-    if [[ -f "$REPO_ROOT/kubernetes/$app/kustomization.yaml" ]]; then
-      kustomization_file="$REPO_ROOT/kubernetes/$app/kustomization.yaml"
+    if [[ -f "$EFFECTIVE_ROOT/kubernetes/$app/kustomization.yaml" ]]; then
+      kustomization_file="$EFFECTIVE_ROOT/kubernetes/$app/kustomization.yaml"
     else
       # Check with numeric prefixes (0-app, 1-app, etc.)
-      for prefix_dir in "$REPO_ROOT/kubernetes/"[0-9]*-"$app"; do
+      for prefix_dir in "$EFFECTIVE_ROOT/kubernetes/"[0-9]*-"$app"; do
         if [[ -f "$prefix_dir/kustomization.yaml" ]]; then
           kustomization_file="$prefix_dir/kustomization.yaml"
           break
@@ -134,7 +140,7 @@ validate_apps() {
     fi
 
     if [[ -n "$kustomization_file" ]]; then
-      if yq eval '.commonAnnotations.argoManaged == "true"' "$kustomization_file" 2>/dev/null | grep -q "true"; then
+      if yq eval '.commonAnnotations.argoManaged == "true"' "$kustomization_file" --exit-status >/dev/null 2>&1; then
         valid_apps+=("$app")
       else
         echo "Warning: Application '$app' found but not managed by ApplicationSet (missing argoManaged: true annotation)" >&2
@@ -147,7 +153,9 @@ validate_apps() {
   printf '%s\n' "${valid_apps[@]}"
 }
 
-cd "$REPO_ROOT"
+# Use scan root if provided, otherwise use auto-detected repo root
+EFFECTIVE_ROOT="${SCAN_ROOT:-$REPO_ROOT}"
+cd "$EFFECTIVE_ROOT"
 changed_files=$(get_changed_files)
 
 if [[ -z "$changed_files" ]]; then

--- a/scripts/argocd-detect-apps
+++ b/scripts/argocd-detect-apps
@@ -161,7 +161,6 @@ changed_files=$(get_changed_files)
 if [[ -z "$changed_files" ]]; then
   echo "No kubernetes files changed"
   echo "apps=" >> "$GITHUB_OUTPUT"
-  echo "app_count=0" >> "$GITHUB_OUTPUT"
   exit 0
 fi
 
@@ -171,7 +170,6 @@ readarray -t app_names < <(extract_app_names "$changed_files")
 if [[ ${#app_names[@]} -eq 0 ]]; then
   echo "No ArgoCD applications detected in changed files"
   echo "apps=" >> "$GITHUB_OUTPUT"
-  echo "app_count=0" >> "$GITHUB_OUTPUT"
   exit 0
 fi
 
@@ -182,9 +180,7 @@ readarray -t valid_apps < <(validate_apps "${app_names[@]}")
 if [[ ${#valid_apps[@]} -gt 0 ]]; then
   echo "Detected applications: ${valid_apps[*]}"
   echo "apps=${valid_apps[*]}" >> "$GITHUB_OUTPUT"
-  echo "app_count=${#valid_apps[@]}" >> "$GITHUB_OUTPUT"
 else
   echo "No valid ArgoCD applications found"
   echo "apps=" >> "$GITHUB_OUTPUT"
-  echo "app_count=0" >> "$GITHUB_OUTPUT"
 fi


### PR DESCRIPTION
## Summary
- Fixes issue where deploy workflow runs even when no valid ApplicationSet-managed apps are detected
- Improves error message capture from ArgoCD CLI commands 
- Adds scan-root parameter to detect-apps script for GitHub Actions path resolution

## Changes
- Remove app_count logic and use apps list for workflow execution decisions
- Update workflow conditions to check `apps \!= ''` instead of `app_count \!= '0'`
- Capture stderr from ArgoCD commands for better error reporting
- Add --scan-root parameter to argocd-detect-apps script

This ensures the deploy step only runs when there are actual ApplicationSet-managed applications to deploy.