### PR TITLE
Add ArgoCD management for core monitoring services

### DIFF
--- a/kubernetes/alertmanager/kustomization.yaml
+++ b/kubernetes/alertmanager/kustomization.yaml
@@ -2,12 +2,21 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deploy.yaml
 - ingress.yaml
 - service.yaml
 - pvc.yaml
 - externalsecret.yaml
+
+images:
+- name: hairyhenderson/gomplate
+  newTag: v4.3.3
+- name: prom/alertmanager
+  newTag: v0.9.1
 
 labels:
 

--- a/kubernetes/blackbox-exporter/kustomization.yaml
+++ b/kubernetes/blackbox-exporter/kustomization.yaml
@@ -3,9 +3,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: blackbox-
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deploy.yaml
 - service.yaml
+
+images:
+- name: prom/blackbox-exporter
+  newTag: v0.24.0
 
 labels:
 

--- a/kubernetes/grafana/kustomization.yaml
+++ b/kubernetes/grafana/kustomization.yaml
@@ -2,11 +2,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deploy.yaml
 - pvc.yaml
 - ingress.yaml
 - service.yaml
+
+images:
+- name: grafana/grafana
+  newTag: 9.1.7
 
 labels:
 

--- a/kubernetes/prometheus/kustomization.yaml
+++ b/kubernetes/prometheus/kustomization.yaml
@@ -3,6 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deploy.yaml
 - ingress.yaml
@@ -10,6 +13,10 @@ resources:
 - rbac.yaml
 - service.yaml
 - externalsecret.yaml
+
+images:
+- name: prom/prometheus
+  newTag: v3.5.0
 
 labels:
 

--- a/kubernetes/pushgateway/kustomization.yaml
+++ b/kubernetes/pushgateway/kustomization.yaml
@@ -2,10 +2,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deploy.yaml
 - ingress.yaml
 - service.yaml
+
+images:
+- name: prom/pushgateway
+  newTag: v1.11.1
 
 labels:
 


### PR DESCRIPTION
Add image overrides and ArgoCD management for core monitoring infrastructure:

- **grafana**: Add image override (9.1.7) + argoManaged annotation
- **prometheus**: Add image override (v3.5.0) + argoManaged annotation  
- **alertmanager**: Add image override (v4.3.3, v0.9.1) + argoManaged annotation
- **blackbox-exporter**: Add image override (v0.24.0) + argoManaged annotation
- **pushgateway**: Add image override (v1.11.1) + argoManaged annotation

Each service now has:
- Image version pinned in kustomization.yaml (keeping existing pins, upgrading latest tags)
- ArgoCD ApplicationSet management enabled via argoManaged annotation
- Validated kustomization builds

This brings the total ArgoCD-managed applications to 14 (from 9).