### PR TITLE
Add ArgoCD management for Priority 2 home automation services

### DIFF
--- a/kubernetes/awair-exporter/kustomization.yaml
+++ b/kubernetes/awair-exporter/kustomization.yaml
@@ -3,10 +3,17 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deploy.yaml
 - service.yaml
 - externalsecret.yaml
+
+images:
+- name: dvorak/awair_exporter
+  newTag: latest
 
 labels:
 

--- a/kubernetes/mosquitto/kustomization.yaml
+++ b/kubernetes/mosquitto/kustomization.yaml
@@ -3,11 +3,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deploy.yaml
 - externalsecret.yaml
 - pvc.yaml
 - service.yaml
+
+images:
+- name: debian
+  newTag: stable-slim
+- name: eclipse-mosquitto
+  newTag: '2.0'
 
 labels:
 

--- a/kubernetes/mqtt-log/kustomization.yaml
+++ b/kubernetes/mqtt-log/kustomization.yaml
@@ -3,9 +3,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deploy.yaml
 - externalsecret.yaml
+
+images:
+- name: eclipse-mosquitto
+  newTag: '2.0'
 
 labels:
 

--- a/kubernetes/netatmo-exporter/kustomization.yaml
+++ b/kubernetes/netatmo-exporter/kustomization.yaml
@@ -3,12 +3,19 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deploy.yaml
 - service.yaml
 - ingress.yaml
 - pvc.yaml
 - externalsecret.yaml
+
+images:
+- name: ghcr.io/xperimental/netatmo-exporter
+  newTag: 2.0.1
 
 labels:
 

--- a/kubernetes/netatmo-wunderground-agent/kustomization.yaml
+++ b/kubernetes/netatmo-wunderground-agent/kustomization.yaml
@@ -2,10 +2,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deploy.yaml
 - pvc.yaml
 - externalsecret.yaml
+
+images:
+- name: brbeaird/netatmo-wunderground-agent
+  newTag: latest
 
 labels:
 


### PR DESCRIPTION
## Summary
- Add image overrides and argoManaged annotations to 5 home automation services
- mosquitto: debian:stable-slim, eclipse-mosquitto:2.0 (keeping existing pins)  
- mqtt-log: eclipse-mosquitto:2.0 (keeping existing pin)
- netatmo-exporter: ghcr.io/xperimental/netatmo-exporter:2.0.1 (keeping existing pin)
- netatmo-wunderground-agent: brbeaird/netatmo-wunderground-agent:latest (only tag available)
- awair-exporter: dvorak/awair_exporter:latest (only tag available, from 2019)