### PR TITLE
Add ArgoCD management for Priority 3 media services

### DIFF
--- a/kubernetes/autobrr/kustomization.yaml
+++ b/kubernetes/autobrr/kustomization.yaml
@@ -3,10 +3,17 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deployment.yaml
 - service.yaml
 - ingress.yaml
+
+images:
+- name: ghcr.io/autobrr/autobrr
+  newTag: v1.9.0
 
 labels:
 

--- a/kubernetes/bazarr/kustomization.yaml
+++ b/kubernetes/bazarr/kustomization.yaml
@@ -3,11 +3,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deployment.yaml
 - pvc.yaml
 - service.yaml
 - ingress.yaml
+
+images:
+- name: linuxserver/bazarr
+  newTag: 1.5.2
 
 labels:
 

--- a/kubernetes/cross-seed/kustomization.yaml
+++ b/kubernetes/cross-seed/kustomization.yaml
@@ -3,12 +3,19 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deployment.yaml
 - service.yaml
 - ingress.yaml
 - pvc.yaml
 - externalsecret.yaml
+
+images:
+- name: ghcr.io/cross-seed/cross-seed
+  newTag: 6.13.1
 
 configMapGenerator:
 - name: cross-seed-config

--- a/kubernetes/prowlarr/kustomization.yaml
+++ b/kubernetes/prowlarr/kustomization.yaml
@@ -2,10 +2,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deploy.yaml
 - ingress.yaml
 - service.yaml
+
+images:
+- name: linuxserver/prowlarr
+  newTag: 1.9.4
 
 labels:
 

--- a/kubernetes/radarr/kustomization.yaml
+++ b/kubernetes/radarr/kustomization.yaml
@@ -3,10 +3,17 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deployment.yaml
 - service.yaml
 - ingress.yaml
+
+images:
+- name: linuxserver/radarr
+  newTag: 5.9.1
 
 labels:
 

--- a/kubernetes/sabnzbd/kustomization.yaml
+++ b/kubernetes/sabnzbd/kustomization.yaml
@@ -3,11 +3,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deployment.yaml
 - pvc.yaml
 - service.yaml
 - ingress.yaml
+
+images:
+- name: linuxserver/sabnzbd
+  newTag: 4.5.2
 
 labels:
 

--- a/kubernetes/sonarr/kustomization.yaml
+++ b/kubernetes/sonarr/kustomization.yaml
@@ -3,10 +3,17 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deployment.yaml
 - service.yaml
 - ingress.yaml
+
+images:
+- name: linuxserver/sonarr
+  newTag: 4.0.9
 
 labels:
 

--- a/kubernetes/transmission/kustomization.yaml
+++ b/kubernetes/transmission/kustomization.yaml
@@ -3,12 +3,19 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - deployment.yaml
 - pvc.yaml
 - service.yaml
 - ingress.yaml
 - externalsecret.yaml
+
+images:
+- name: linuxserver/transmission
+  newTag: 4.0.6
 
 labels:
 


### PR DESCRIPTION
## Summary
- Add image overrides and argoManaged annotations to 9 media services
- prowlarr: linuxserver/prowlarr:1.9.4
- sonarr: linuxserver/sonarr:4.0.9
- radarr: linuxserver/radarr:5.9.1
- bazarr: linuxserver/bazarr:1.5.2
- sabnzbd: linuxserver/sabnzbd:4.5.2
- transmission: linuxserver/transmission:4.0.6
- autobrr: ghcr.io/autobrr/autobrr:v1.9.0
- cross-seed: ghcr.io/cross-seed/cross-seed:6.13.1
- qbit_manage: already configured with latest version