### PR TITLE
Optimize renovate lint performance

### DIFF
--- a/.github/workflows/renovate-lint-fix.yaml
+++ b/.github/workflows/renovate-lint-fix.yaml
@@ -45,13 +45,11 @@ jobs:
       with:
         path: ~/.cache/pre-commit
         key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-precommit-
 
-    - name: Run pre-commit hooks on all files
+    - name: Run pre-commit hooks on changed files
       run: |
         # Run pre-commit hooks and capture the exit code
-        nix develop --command pre-commit run --all-files || true
+        nix develop --command pre-commit run || true
 
     - name: Check for changes
       id: check-changes


### PR DESCRIPTION
## Summary
- Remove `--all-files` flag to only process files changed by renovate
- Remove cache `restore-keys` to use exact cache matches only  
- Update step name to reflect it now runs on changed files only

## Performance Impact
The renovate lint workflow was running slowly due to processing all repository files instead of just the dependency files that renovate typically modifies. This change should significantly reduce runtime since renovate PRs usually only change package.json, requirements.txt, and similar dependency manifests.

The cache optimization ensures we get exact matches when `.pre-commit-config.yaml` is unchanged, avoiding unnecessary cache misses from partial key matching.