### PR TITLE
Add Cachix nix store caching to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,12 @@ jobs:
       with:
         github_access_token: ${{ github.token }}
 
+    - name: Setup Cachix
+      uses: cachix/cachix-action@v14
+      with:
+        name: claytono
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
     - name: Cache pre-commit
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4
       with:

--- a/.github/workflows/render-helm.yaml
+++ b/.github/workflows/render-helm.yaml
@@ -45,6 +45,13 @@ jobs:
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Setup Cachix
+      if: steps.changes.outputs.need-render-helm == 'true'
+      uses: cachix/cachix-action@v14
+      with:
+        name: claytono
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
     - name: Cache pre-commit
       if: steps.changes.outputs.need-render-helm == 'true'
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4

--- a/.github/workflows/renovate-lint-fix.yaml
+++ b/.github/workflows/renovate-lint-fix.yaml
@@ -40,6 +40,12 @@ jobs:
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Setup Cachix
+      uses: cachix/cachix-action@v14
+      with:
+        name: claytono
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
     - name: Cache pre-commit
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4
       with:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -33,6 +33,13 @@ jobs:
       with:
         github_access_token: ${{ github.token }}
 
+    - name: Setup Cachix
+      if: steps.changes.outputs.terraform == 'true'
+      uses: cachix/cachix-action@v14
+      with:
+        name: claytono
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
     - name: Cache pre-commit
       if: steps.changes.outputs.terraform == 'true'
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4

--- a/opentofu/github-repos.tf
+++ b/opentofu/github-repos.tf
@@ -1,0 +1,26 @@
+# GitHub repository secrets management
+
+# Infra repository secrets
+resource "github_actions_secret" "infra_argocd_auth_token" {
+  repository      = "infra"
+  secret_name     = "ARGOCD_AUTH_TOKEN"
+  plaintext_value = data.onepassword_item.argocd_github_actions_token.password
+}
+
+resource "github_actions_secret" "infra_cachix_auth_token" {
+  repository      = "infra"
+  secret_name     = "CACHIX_AUTH_TOKEN"
+  plaintext_value = data.onepassword_item.cachix_auth_token.password
+}
+
+resource "github_actions_secret" "infra_tailscale_oauth_client_id" {
+  repository      = "infra"
+  secret_name     = "TAILSCALE_OAUTH_CLIENT_ID"
+  plaintext_value = tailscale_oauth_client.github_actions.id
+}
+
+resource "github_actions_secret" "infra_tailscale_oauth_client_secret" {
+  repository      = "infra"
+  secret_name     = "TAILSCALE_OAUTH_CLIENT_SECRET"
+  plaintext_value = tailscale_oauth_client.github_actions.key
+}

--- a/opentofu/secrets.tf
+++ b/opentofu/secrets.tf
@@ -33,6 +33,12 @@ data "onepassword_item" "argocd_github_actions_token" {
   title = "argocd-github-actions-token"
 }
 
+# Cachix auth token from 1Password
+data "onepassword_item" "cachix_auth_token" {
+  vault = data.onepassword_vault.kubernetes.uuid
+  title = "cachix-auth-token"
+}
+
 # Clean field mapping for B2 credentials
 locals {
   b2_fields = {

--- a/opentofu/tailscale.tf
+++ b/opentofu/tailscale.tf
@@ -155,23 +155,3 @@ resource "onepassword_item" "tailscale_github_actions" {
     }
   }
 }
-
-# Create GitHub repository secrets for Tailscale OAuth
-resource "github_actions_secret" "tailscale_oauth_client_id" {
-  repository      = "infra"
-  secret_name     = "TAILSCALE_OAUTH_CLIENT_ID"
-  plaintext_value = tailscale_oauth_client.github_actions.id
-}
-
-resource "github_actions_secret" "tailscale_oauth_client_secret" {
-  repository      = "infra"
-  secret_name     = "TAILSCALE_OAUTH_CLIENT_SECRET"
-  plaintext_value = tailscale_oauth_client.github_actions.key
-}
-
-# Create GitHub repository secret for ArgoCD auth token
-resource "github_actions_secret" "argocd_auth_token" {
-  repository      = "infra"
-  secret_name     = "ARGOCD_AUTH_TOKEN"
-  plaintext_value = data.onepassword_item.argocd_github_actions_token.password
-}


### PR DESCRIPTION
## Summary
- Add Cachix binary cache setup to all nix-using workflows (ci, terraform, render-helm, renovate-lint-fix)
- Configure CACHIX_AUTH_TOKEN secret managed via 1Password and OpenTofu
- Reorganize GitHub secrets management into dedicated github-repos.tf file