### PR TITLE
Add ArgoCD management for utility services and clean up image tags

### DIFF
--- a/kubernetes/alertmanager/deploy.yaml
+++ b/kubernetes/alertmanager/deploy.yaml
@@ -41,7 +41,7 @@ spec:
           mountPath: /config
       containers:
       - name: alertmanager
-        image: prom/alertmanager:latest
+        image: prom/alertmanager
         args:
         - --config.file=/config/config.yaml
         - --storage.path=/alertmanager

--- a/kubernetes/autobrr/deployment.yaml
+++ b/kubernetes/autobrr/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: autobrr
-        image: ghcr.io/autobrr/autobrr:latest
+        image: ghcr.io/autobrr/autobrr
         ports:
         - containerPort: 7474
         volumeMounts:

--- a/kubernetes/blackbox-exporter/deploy.yaml
+++ b/kubernetes/blackbox-exporter/deploy.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: blackbox-exporter
-        image: prom/blackbox-exporter:v0.24.0
+        image: prom/blackbox-exporter
         imagePullPolicy: Always
         args: [--config.file=/config/config.yaml]
         volumeMounts:

--- a/kubernetes/changedetection/deploy.yaml
+++ b/kubernetes/changedetection/deploy.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: changedetection
-        image: dgtlmoon/changedetection.io:latest
+        image: dgtlmoon/changedetection.io
         ports:
         - name: changedetection
           containerPort: 5000
@@ -35,7 +35,7 @@ spec:
         - name: PLAYWRIGHT_DRIVER_URL
           value: ws://localhost:3000/
       - name: browserless
-        image: dgtlmoon/sockpuppetbrowser:latest
+        image: dgtlmoon/sockpuppetbrowser
         resources:
           limits:
             memory: 2Gi

--- a/kubernetes/changedetection/kustomization.yaml
+++ b/kubernetes/changedetection/kustomization.yaml
@@ -8,6 +8,15 @@ resources:
 - service.yaml
 - pvc.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
+images:
+- name: dgtlmoon/changedetection.io
+  newTag: 0.50.8
+- name: dgtlmoon/sockpuppetbrowser
+  newTag: 0.0.2
+
 labels:
 
 - pairs:

--- a/kubernetes/channels/deploy.yaml
+++ b/kubernetes/channels/deploy.yaml
@@ -24,7 +24,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: channels
-        image: fancybits/channels-dvr:tve
+        image: fancybits/channels-dvr
         imagePullPolicy: Always
 
 #        command: ['sleep', 'infinity']

--- a/kubernetes/channels/kustomization.yaml
+++ b/kubernetes/channels/kustomization.yaml
@@ -10,6 +10,13 @@ resources:
 - pvc.yaml
 - service.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
+images:
+- name: fancybits/channels-dvr
+  newTag: tve
+
 labels:
 
 - pairs:

--- a/kubernetes/cluster-backup/cronjob.yaml
+++ b/kubernetes/cluster-backup/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: cluster-backup
-            image: debian:stable
+            image: debian
             imagePullPolicy: Always
             command:
             - /script/backup.sh

--- a/kubernetes/cluster-backup/kustomization.yaml
+++ b/kubernetes/cluster-backup/kustomization.yaml
@@ -6,6 +6,13 @@ namespace: kube-system
 resources:
 - cronjob.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
+images:
+- name: debian
+  newTag: stable
+
 labels:
 
 - pairs:

--- a/kubernetes/cross-seed/deployment.yaml
+++ b/kubernetes/cross-seed/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: cross-seed
-        image: ghcr.io/cross-seed/cross-seed:latest
+        image: ghcr.io/cross-seed/cross-seed
         command: [cross-seed, daemon]
         ports:
         - containerPort: 2468

--- a/kubernetes/got-your-back/cronjob-full.yaml
+++ b/kubernetes/got-your-back/cronjob-full.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
           - name: got-your-back
-            image: debian:stable-slim
+            image: debian
             command: [/run.sh]
             imagePullPolicy: Always
             env:

--- a/kubernetes/got-your-back/cronjob-incremental.yaml
+++ b/kubernetes/got-your-back/cronjob-incremental.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
           - name: got-your-back
-            image: debian:stable-slim
+            image: debian
             command: [/run.sh, --fast-incremental]
             imagePullPolicy: Always
             env:

--- a/kubernetes/got-your-back/kustomization.yaml
+++ b/kubernetes/got-your-back/kustomization.yaml
@@ -8,6 +8,13 @@ resources:
 - externalsecret.yaml
 - pvc.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
+images:
+- name: debian
+  newTag: stable-slim
+
 labels:
 
 - pairs:

--- a/kubernetes/grafana/deploy.yaml
+++ b/kubernetes/grafana/deploy.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: grafana/grafana:9.1.7
+        image: grafana/grafana
         ports:
         - containerPort: 3000
           protocol: TCP

--- a/kubernetes/meshcentral/kustomization.yaml
+++ b/kubernetes/meshcentral/kustomization.yaml
@@ -8,6 +8,13 @@ resources:
 - ingress.yaml
 - pvc.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
+images:
+- name: typhonragewind/meshcentral
+  newTag: 1.1.48
+
 labels:
 
 - pairs:

--- a/kubernetes/mosquitto/deploy.yaml
+++ b/kubernetes/mosquitto/deploy.yaml
@@ -32,7 +32,7 @@ spec:
           mountPath: /generated
       containers:
       - name: mosquitto
-        image: eclipse-mosquitto:2.0
+        image: eclipse-mosquitto
         imagePullPolicy: Always
         resources:
           limits:

--- a/kubernetes/mqtt-log/deploy.yaml
+++ b/kubernetes/mqtt-log/deploy.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: mqtt-log
-        image: eclipse-mosquitto:2.0
+        image: eclipse-mosquitto
         env:
         - name: MQTT_USERNAME
           valueFrom:

--- a/kubernetes/netatmo-exporter/deploy.yaml
+++ b/kubernetes/netatmo-exporter/deploy.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: netatmo-exporter
-        image: ghcr.io/xperimental/netatmo-exporter:2.0.1
+        image: ghcr.io/xperimental/netatmo-exporter
         env:
         - name: NETATMO_EXPORTER_TOKEN_FILE
           value: /data/token.json

--- a/kubernetes/prometheus/deploy.yaml
+++ b/kubernetes/prometheus/deploy.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: prometheus
       containers:
       - name: prometheus
-        image: prom/prometheus:latest
+        image: prom/prometheus
         args:
         - --config.file=/etc/prometheus/prometheus.yml
         - --web.external-url=https://prometheus.k.oneill.net

--- a/kubernetes/prowlarr/deploy.yaml
+++ b/kubernetes/prowlarr/deploy.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: sonarr
-        image: linuxserver/prowlarr:develop
+        image: linuxserver/prowlarr
         ports:
         - containerPort: 9696
         volumeMounts:

--- a/kubernetes/pushgateway/deploy.yaml
+++ b/kubernetes/pushgateway/deploy.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: pushgateway
-        image: prom/pushgateway:v1.11.1
+        image: prom/pushgateway
         ports:
         - name: web
           containerPort: 9091

--- a/kubernetes/smokeping/kustomization.yaml
+++ b/kubernetes/smokeping/kustomization.yaml
@@ -8,6 +8,13 @@ resources:
 - pvc.yaml
 - ingress.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
+images:
+- name: dvorak/docker-smokeping
+  newTag: latest
+
 labels:
 
 - pairs:

--- a/kubernetes/transmission/deployment.yaml
+++ b/kubernetes/transmission/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: transmission
-        image: linuxserver/transmission:version-3.00-r8
+        image: linuxserver/transmission
         imagePullPolicy: Always
         ports:
         - containerPort: 9091

--- a/kubernetes/vrroom-daily-reboot/kustomization.yaml
+++ b/kubernetes/vrroom-daily-reboot/kustomization.yaml
@@ -1,3 +1,20 @@
 ---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - cronjob.yaml
+
+commonAnnotations:
+  argoManaged: 'true'
+
+images:
+- name: alpine
+  newTag: 3.22.1
+
+labels:
+
+- pairs:
+    app.kubernetes.io/name: vrroom-daily-reboot
+    app.kubernetes.io/instance: vrroom-daily-reboot
+  includeSelectors: true


### PR DESCRIPTION
This completes Phase 2 Priority 4 of the ArgoCD migration plan:

**New ArgoCD-managed services (7):**
- changedetection: Pin to 0.50.8 and sockpuppetbrowser 0.0.2
- channels: Pin to tve tag for specific features
- meshcentral: Pin to 1.1.48
- smokeping: Pin to latest (only available tag)
- got-your-back: Pin to stable-slim
- cluster-backup: Pin to stable
- vrroom-daily-reboot: Pin to alpine 3.22.1

**Image tag cleanup:**
Remove image tags from deployment/cronjob files where versions are now pinned in kustomization.yaml to avoid confusion and ensure single source of truth for version management.

All services now have argoManaged: 'true' annotation for ApplicationSet management and consistent image version pinning via kustomization.yaml.