### PR TITLE
Add ArgoCD management for Helm services and clean up image tags

### DIFF
--- a/kubernetes/0-nfs-client-provisioner/kustomization.yaml
+++ b/kubernetes/0-nfs-client-provisioner/kustomization.yaml
@@ -12,6 +12,9 @@ resources:
 - helm/templates/clusterrolebinding.yaml
 - helm/templates/deployment.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 labels:
 
 - pairs:

--- a/kubernetes/cert-manager/kustomization.yaml
+++ b/kubernetes/cert-manager/kustomization.yaml
@@ -25,6 +25,9 @@ resources:
 - self-signed.yaml
 - externalsecret.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 patches:
 - patch: |-
     apiVersion: apps/v1

--- a/kubernetes/descheduler/kustomization.yaml
+++ b/kubernetes/descheduler/kustomization.yaml
@@ -11,6 +11,9 @@ resources:
 - helm/templates/cronjob.yaml
 - helm/templates/configmap.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 labels:
 
 - pairs:

--- a/kubernetes/external-dns/kustomization.yaml
+++ b/kubernetes/external-dns/kustomization.yaml
@@ -12,6 +12,9 @@ resources:
 - helm/templates/clusterrolebinding.yaml
 - externalsecret.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 commonLabels:
   app: external-dns
 

--- a/kubernetes/goldilocks/kustomization.yaml
+++ b/kubernetes/goldilocks/kustomization.yaml
@@ -16,6 +16,9 @@ resources:
 - helm/templates/dashboard-service.yaml
 - helm/templates/dashboard-serviceaccount.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 labels:
 
 - pairs:

--- a/kubernetes/homebox/kustomization.yaml
+++ b/kubernetes/homebox/kustomization.yaml
@@ -21,6 +21,9 @@ resources:
 - helm/postgresql/primary/statefulset.yaml
 - helm/postgresql/primary/svc-headless.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 patches:
 
 - target:

--- a/kubernetes/kube-state-metrics/kustomization.yaml
+++ b/kubernetes/kube-state-metrics/kustomization.yaml
@@ -9,6 +9,9 @@ resources:
 - helm/templates/deployment.yaml
 - helm/templates/service.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 labels:
 
 - pairs:

--- a/kubernetes/loki/helm/templates/statefulset.yaml
+++ b/kubernetes/loki/helm/templates/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
         []
       containers:
         - name: loki
-          image: "grafana/loki:2.6.1"
+          image: "grafana/loki"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/loki/loki.yaml"

--- a/kubernetes/metallb/kustomization.yaml
+++ b/kubernetes/metallb/kustomization.yaml
@@ -15,6 +15,9 @@ resources:
 - helm/templates/exclude-l2-config.yaml
 - config.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 labels:
 
 - pairs:

--- a/kubernetes/metrics-server/kustomization.yaml
+++ b/kubernetes/metrics-server/kustomization.yaml
@@ -15,6 +15,9 @@ resources:
 - helm/service.yaml
 - helm/serviceaccount.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 labels:
 
 - pairs:

--- a/kubernetes/mosquitto/deploy.yaml
+++ b/kubernetes/mosquitto/deploy.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       initContainers:
       - name: init-password-file
-        image: debian:stable-slim
+        image: debian
         command: [/bin/sh, -c, /scripts/create-password-file.sh > /generated/passwd]
         volumeMounts:
         - name: script

--- a/kubernetes/n8n/kustomization.yaml
+++ b/kubernetes/n8n/kustomization.yaml
@@ -31,6 +31,9 @@ resources:
 - helm/valkey/templates/primary/service.yaml
 - helm/valkey/templates/primary/serviceaccount.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 patches:
 
 - target:

--- a/kubernetes/node-feature-discovery/kustomization.yaml
+++ b/kubernetes/node-feature-discovery/kustomization.yaml
@@ -18,6 +18,9 @@ resources:
 - helm/templates/serviceaccount.yaml
 - helm/templates/worker.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 labels:
 
 - pairs:

--- a/kubernetes/plexmediaserver/deploy.yaml
+++ b/kubernetes/plexmediaserver/deploy.yaml
@@ -24,7 +24,7 @@ spec:
       hostNetwork: true
       containers:
       - name: plexmediaserver
-        image: plexinc/pms-docker:plexpass
+        image: plexinc/pms-docker
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/kubernetes/promtail/helm/templates/daemonset.yaml
+++ b/kubernetes/promtail/helm/templates/daemonset.yaml
@@ -34,7 +34,7 @@ spec:
         runAsUser: 0
       containers:
         - name: promtail
-          image: "docker.io/grafana/promtail:2.5.0"
+          image: "docker.io/grafana/promtail"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/promtail/promtail.yaml"

--- a/kubernetes/tailscale-operator/kustomization.yaml
+++ b/kubernetes/tailscale-operator/kustomization.yaml
@@ -19,6 +19,9 @@ resources:
 - helm/templates/proxygroup.yaml
 - helm/templates/recorder.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 patches:
 
 - target:

--- a/kubernetes/vpa/kustomization.yaml
+++ b/kubernetes/vpa/kustomization.yaml
@@ -11,6 +11,9 @@ resources:
 - helm/templates/recommender-deployment.yaml
 - helm/templates/recommender-service-account.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 labels:
 
 - pairs:


### PR DESCRIPTION
## Summary

Adds ArgoCD management for Helm services and completes comprehensive image tag cleanup across all ArgoCD-managed services.

**New ArgoCD-managed Helm services (13):**
- **Core Infrastructure:** cert-manager, external-dns, metallb, metrics-server, kube-state-metrics, node-feature-discovery
- **Supporting Services:** descheduler, goldilocks, vpa, tailscale-operator, 0-nfs-client-provisioner
- **Application Services:** homebox, n8n

**Image tag cleanup:**
Removed image tags from deployment files where Helm charts or kustomization.yaml now control versions:
- **loki** - Remove :2.6.1 from statefulset  
- **promtail** - Remove :2.5.0 from daemonset
- **plexmediaserver** - Remove :plexpass from deployment
- **mosquitto** - Remove :stable-slim from init container

All services now have consistent version management:
- **Helm services:** Chart.yaml controls versions
- **Non-Helm services:** kustomization.yaml image pinning controls versions
- **No deployment files contain version tags** for ArgoCD-managed services