### PR TITLE
Fix helm templates after Phase 3 ArgoCD migration

### DIFF
--- a/kubernetes/loki/helm/templates/statefulset.yaml
+++ b/kubernetes/loki/helm/templates/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
         []
       containers:
         - name: loki
-          image: "grafana/loki"
+          image: "grafana/loki:2.6.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/loki/loki.yaml"

--- a/kubernetes/promtail/helm/templates/daemonset.yaml
+++ b/kubernetes/promtail/helm/templates/daemonset.yaml
@@ -34,7 +34,7 @@ spec:
         runAsUser: 0
       containers:
         - name: promtail
-          image: "docker.io/grafana/promtail"
+          image: "docker.io/grafana/promtail:2.5.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/promtail/promtail.yaml"


### PR DESCRIPTION
Fixes helm templates that were incorrectly modified during the Phase 3 ArgoCD migration.

Fixed loki and promtail templates to restore proper image tags that were removed. Helm templates should contain version tags as controlled by Chart.yaml.