### PR TITLE
Add ArgoCD management for services with existing image overrides

### DIFF
--- a/kubernetes/ddns-route53/kustomization.yaml
+++ b/kubernetes/ddns-route53/kustomization.yaml
@@ -6,6 +6,9 @@ resources:
 - deploy.yaml
 - externalsecret.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 labels:
 
 - pairs:

--- a/kubernetes/pihole/deploy.yaml
+++ b/kubernetes/pihole/deploy.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: pihole
-        image: pihole/pihole:latest
+        image: pihole/pihole
         imagePullPolicy: Always
         env:
         - name: TZ

--- a/kubernetes/pihole/kustomization.yaml
+++ b/kubernetes/pihole/kustomization.yaml
@@ -12,6 +12,9 @@ resources:
 - pvc-dnsmasq.yaml
 - externalsecret.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 labels:
 
 - pairs:

--- a/kubernetes/resticprofile/kustomization.yaml
+++ b/kubernetes/resticprofile/kustomization.yaml
@@ -9,6 +9,9 @@ resources:
 - pvc.yaml
 - externalsecret.yaml
 
+commonAnnotations:
+  argoManaged: 'true'
+
 configMapGenerator:
 
 - files:


### PR DESCRIPTION
## Summary
- Add ArgoCD management to ddns-route53, pihole, and resticprofile
- Remove image tag from pihole deployment to ensure kustomization.yaml controls version
- Verify qbittorrent already has ArgoCD management

Completes Phase 4 of ArgoCD migration.