### PR TITLE
Fix ddns-route53 image tag (remove v prefix)

### DIFF
--- a/kubernetes/ddns-route53/kustomization.yaml
+++ b/kubernetes/ddns-route53/kustomization.yaml
@@ -18,4 +18,4 @@ labels:
 
 images:
 - name: ghcr.io/crazy-max/ddns-route53
-  newTag: v2.13.0
+  newTag: 2.13.0


### PR DESCRIPTION
## Summary
- Fix ddns-route53 image tag from v2.13.0 to 2.13.0
- The container registry uses tags without the "v" prefix

Fixes image pull error in Phase 4 ArgoCD migration.