### PR TITLE
Fix Renovate qbittorrent version detection to avoid Ubuntu LTS tags

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -44,6 +44,11 @@
       "matchDatasources": ["helm"],
       "matchManagers": ["helmv3"],
       "matchFileNames": ["kubernetes/**/Chart.yaml"]
+    },
+    {
+      "matchPackageNames": ["ghcr.io/linuxserver/qbittorrent"],
+      "allowedVersions": "< 14",
+      "description": "Only allow qbittorrent versions < 14 to avoid Ubuntu LTS tags"
     }
   ],
   "gitIgnoredAuthors": ["github-actions[bot]@users.noreply.github.com"]


### PR DESCRIPTION
## Summary
- Add package rule to restrict qbittorrent versions to < 14
- Prevents Renovate from suggesting Ubuntu LTS tags like 20.04.1
- Ensures only actual qbittorrent versions (5.x) are considered

Fixes issue where Renovate was suggesting downgrades to old Ubuntu-based tags.