### PR TITLE
Fix external-secrets CRD sync failures with server-side apply

### DIFF
--- a/kubernetes/external-secrets/kustomization.yaml
+++ b/kubernetes/external-secrets/kustomization.yaml
@@ -44,3 +44,21 @@ labels:
 
 - pairs:
     app: external-secrets
+
+patches:
+
+- target:
+    kind: CustomResourceDefinition
+    name: clustersecretstores.external-secrets.io
+  patch: |-
+    - op: add
+      path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      value: ServerSideApply=true
+
+- target:
+    kind: CustomResourceDefinition
+    name: secretstores.external-secrets.io
+  patch: |-
+    - op: add
+      path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      value: ServerSideApply=true


### PR DESCRIPTION
Add targeted kustomize patches to enable server-side apply for the two
CRDs that exceed Kubernetes annotation size limits:
- clustersecretstores.external-secrets.io
- secretstores.external-secrets.io

This resolves ArgoCD sync failures caused by 'metadata.annotations: Too long'
errors when these large Helm-generated CRDs exceed the 262KB annotation limit.
