### PR TITLE
Add hostname management role

### DIFF
--- a/ansible/roles/hostname/defaults/main.yml
+++ b/ansible/roles/hostname/defaults/main.yml
@@ -1,0 +1,25 @@
+---
+# defaults file for hostname role
+
+# Primary hostname settings - uses domain variable from inventory
+hostname_short: "{{ inventory_hostname }}"
+hostname_fqdn: "{{ inventory_hostname }}.{{ domain }}"
+
+# /etc/hosts management
+hostname_manage_etc_hosts: true
+
+# Additional hosts entries to add to /etc/hosts
+hostname_additional_hosts: []
+# Example:
+# hostname_additional_hosts:
+#   - ip: "192.168.1.10"
+#     hostnames: ["server1.example.com", "server1"]
+
+# nsswitch.conf configuration
+hostname_manage_nsswitch: true
+hostname_nsswitch_hosts_order: "files dns"
+
+# Hostname persistence - ensures hostname survives reboots
+# Sets both the runtime hostname (hostnamectl set-hostname) and
+# writes to /etc/hostname so it persists across reboots
+hostname_persist_hostname: true

--- a/ansible/roles/hostname/handlers/main.yml
+++ b/ansible/roles/hostname/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+# handlers file for hostname role
+
+- name: Restart systemd-resolved
+  ansible.builtin.systemd:
+    name: systemd-resolved
+    state: restarted
+  when: ansible_facts['services']['systemd-resolved.service'] is defined and ansible_facts['services']['systemd-resolved.service']['state'] == 'running'
+  listen: restart systemd-resolved

--- a/ansible/roles/hostname/tasks/main.yml
+++ b/ansible/roles/hostname/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+# tasks file for hostname role
+
+- name: Set system hostname to short name
+  ansible.builtin.hostname:
+    name: "{{ hostname_short }}"
+  when: hostname_persist_hostname
+
+- name: Configure /etc/hosts
+  ansible.builtin.template:
+    src: hosts.j2
+    dest: /etc/hosts
+    mode: "0644"
+    backup: true
+  when: hostname_manage_etc_hosts
+  notify: restart systemd-resolved
+
+- name: Configure nsswitch.conf for hostname resolution order
+  ansible.builtin.lineinfile:
+    path: /etc/nsswitch.conf
+    regexp: "^hosts:"
+    line: "hosts: {{ hostname_nsswitch_hosts_order }}"
+    backup: true
+  when: hostname_manage_nsswitch
+  notify: restart systemd-resolved

--- a/ansible/roles/hostname/templates/hosts.j2
+++ b/ansible/roles/hostname/templates/hosts.j2
@@ -1,0 +1,14 @@
+127.0.0.1   localhost
+127.0.1.1   {{ hostname_fqdn }} {{ hostname_short }}
+
+# The following lines are desirable for IPv6 capable hosts
+::1     localhost ip6-localhost ip6-loopback
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+
+{% if hostname_additional_hosts is defined and hostname_additional_hosts | length > 0 %}
+# Additional host entries
+{% for host in hostname_additional_hosts %}
+{{ host.ip }}   {{ host.hostnames | join(' ') }}
+{% endfor %}
+{% endif %}

--- a/ansible/site.yaml
+++ b/ansible/site.yaml
@@ -15,6 +15,12 @@
       when: "setup_upgrade | default(false) | bool"
       tags: setup_upgrade
 
+- name: Hostname management
+  hosts: all
+  roles:
+    - role: hostname
+      tags: hostname
+
 - name: Common and network roles
   hosts: all
   roles:


### PR DESCRIPTION
## Summary
• Create hostname role to ensure proper FQDN resolution
• Configure /etc/hosts to map 127.0.1.1 to FQDN and short name  
• Set nsswitch.conf to prioritize files before DNS
• Use domain variable from inventory for per-host domains

Fixes hostname resolution issues where Tailscale MagicDNS was interfering with proper FQDN lookup.