### PR TITLE
Upgrade Kubernetes from 1.29.15 to 1.30.14

### DIFF
--- a/ansible/group_vars/kubernetes.yaml
+++ b/ansible/group_vars/kubernetes.yaml
@@ -4,12 +4,12 @@ kernel_parameters: "nofb vga=normal"
 
 node_exporter_enabled: true
 
-kubernetes_short_version: "1.29"
-kubernetes_version: "1.29.15"
-kubeadm_version: "1.29.15-1.1"
-kubelet_version: "1.29.15-1.1"
-kubectl_version: "1.29.15-1.1"
-cri_tools_version: "1.29.0-1.1"
+kubernetes_short_version: "1.30"
+kubernetes_version: "1.30.14"
+kubeadm_version: "1.30.14-1.1"
+kubelet_version: "1.30.14-1.1"
+kubectl_version: "1.30.14-1.1"
+cri_tools_version: "1.30.0-1.1"
 kubernetes_cni_version: "1.3.0-1.1"
 
 kubernetes_master: "k1.oneill.net"

--- a/ansible/roles/kubeadm/templates/kubeadm.conf.j2
+++ b/ansible/roles/kubeadm/templates/kubeadm.conf.j2
@@ -20,6 +20,7 @@ apiServer:
   - {{ ansible_fqdn }}
   - k1.oneill.net
 clusterName: kubernetes
+controlPlaneEndpoint: "{{ ansible_fqdn }}:6443"
 controllerManager:
   extraArgs:
     allocate-node-cidrs: "true"


### PR DESCRIPTION
## Summary
• Update all Kubernetes package versions to 1.30.14
• Configure controlPlaneEndpoint in kubeadm config

Upgrade successfully completed on all nodes (k1, k2, k4, k5).