### PR TITLE
Upgrade Kubernetes from 1.30.14 to 1.31.12

### DIFF
--- a/ansible/group_vars/kubernetes.yaml
+++ b/ansible/group_vars/kubernetes.yaml
@@ -4,13 +4,13 @@ kernel_parameters: "nofb vga=normal"
 
 node_exporter_enabled: true
 
-kubernetes_short_version: "1.30"
-kubernetes_version: "1.30.14"
-kubeadm_version: "1.30.14-1.1"
-kubelet_version: "1.30.14-1.1"
-kubectl_version: "1.30.14-1.1"
-cri_tools_version: "1.30.0-1.1"
-kubernetes_cni_version: "1.3.0-1.1"
+kubernetes_short_version: "1.31"
+kubernetes_version: "1.31.12"
+kubeadm_version: "1.31.12-1.1"
+kubelet_version: "1.31.12-1.1"
+kubectl_version: "1.31.12-1.1"
+cri_tools_version: "1.31.1-1.1"
+kubernetes_cni_version: "1.5.1-1.1"
 
 kubernetes_master: "k1.oneill.net"
 


### PR DESCRIPTION
• Update all Kubernetes package versions to 1.31.12
• Upgrade kubernetes-cni from 1.3.0-1.1 to 1.5.1-1.1
• Upgrade cri-tools from 1.30.0-1.1 to 1.31.1-1.1
• Enhance upgrade playbook with SSH commands and apt-cache policy checks
• Add CRDs catalog support for kubeconform validation
• Improve component compatibility verification process
