### PR TITLE
Add fs.inotify.max_user_instances sysctl and fix ansible-lint issues

### DIFF
--- a/ansible/roles/kubeadm/tasks/common.yaml
+++ b/ansible/roles/kubeadm/tasks/common.yaml
@@ -31,12 +31,15 @@
     - { name: "net.ipv4.ip_forward", value: "1" }
     - { name: "net.bridge.bridge-nf-call-ip6tables", value: "1" }
 
-- name: "Configure sysctl for inotify watches for Kubernetes"
+- name: Configure sysctl for inotify (Grafana/K8s nodes)
   ansible.posix.sysctl:
-    name: "fs.inotify.max_user_watches"
-    value: "1048576"
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
     state: present
     reload: true
+  loop:
+    - { name: "fs.inotify.max_user_watches", value: "1048576" }
+    - { name: "fs.inotify.max_user_instances", value: "4096" }
 
 - name: "Disabling accepting ICMP redirects"
   ansible.posix.sysctl:
@@ -50,13 +53,13 @@
 
 - name: "Check if swap is enabled"
   ansible.builtin.command: "swapon --show"
-  register: swap_status
+  register: kubeadm_swap_status
   changed_when: false
   failed_when: false
 
 - name: "Turn off swap"
   ansible.builtin.command: "swapoff -a"
-  when: swap_status.stdout != ""
+  when: kubeadm_swap_status.stdout != ""
 
 - name: "Disable swap in fstab"
   ansible.builtin.replace:

--- a/ansible/roles/resticprofile/tasks/configure-client.yaml
+++ b/ansible/roles/resticprofile/tasks/configure-client.yaml
@@ -3,11 +3,11 @@
   ansible.builtin.user:
     name: "{{ resticprofile_client_user }}"
     state: present
-  register: restic_user_info
+  register: resticprofile_user_info
 
 - name: Create resticprofile configuration directory
   ansible.builtin.file:
-    path: "{{ restic_user_info.home }}/.config/resticprofile"
+    path: "{{ resticprofile_user_info.home }}/.config/resticprofile"
     state: directory
     mode: "0700"
     owner: "{{ resticprofile_client_user }}"
@@ -15,17 +15,17 @@
 - name: Write passphrase to file
   ansible.builtin.copy:
     content: "{{ restic_passphrase }}"
-    dest: "{{ restic_user_info.home }}/.config/resticprofile/passphrase.txt"
+    dest: "{{ resticprofile_user_info.home }}/.config/resticprofile/passphrase.txt"
     owner: "{{ resticprofile_client_user }}"
     mode: "0600"
 
 - name: Write config file
   ansible.builtin.template:
     src: templates/config.j2
-    dest: "{{ restic_user_info.home }}/.config/resticprofile/profiles.yaml"
+    dest: "{{ resticprofile_user_info.home }}/.config/resticprofile/profiles.yaml"
     owner: "{{ resticprofile_client_user }}"
     mode: "0600"
-  register: config_file
+  register: resticprofile_config_file
 
 - name: Check if resticprofile schedules are up to date
   ansible.builtin.command: "{{ resticprofile_bin_dir }}/resticprofile status"
@@ -39,7 +39,7 @@
     - resticprofile_enable_scheduling
     - resticprofile_install_resticprofile
     - resticprofile_status.stdout is not search('not found$')
-  register: unschedule_result
+  register: resticprofile_unschedule_result
   failed_when: false
 
 - name: Update resticprofile schedules
@@ -47,4 +47,4 @@
   when:
     - resticprofile_enable_scheduling
     - resticprofile_status is defined
-    - (resticprofile_status.stdout is search("not found$") or config_file.changed or resticprofile_install_resticprofile)
+    - (resticprofile_status.stdout is search("not found$") or resticprofile_config_file.changed or resticprofile_install_resticprofile)

--- a/ansible/roles/resticprofile/tasks/sftp-client.yaml
+++ b/ansible/roles/resticprofile/tasks/sftp-client.yaml
@@ -9,7 +9,7 @@
 
 - name: Client | fetch ssh-key
   ansible.builtin.command: "cat {{ resticprofile_ssh_key }}.pub"
-  register: sshkey
+  register: resticprofile_sshkey
   changed_when: false
 
 - name: Client | disable strict key checking for backup servers
@@ -30,7 +30,7 @@
 - name: Client | put sshpubkey on the normal backupserver
   ansible.posix.authorized_key:
     user: "{{ item.user }}"
-    key: "{{ sshkey.stdout }}"
+    key: "{{ resticprofile_sshkey.stdout }}"
   delegate_to: "{{ item.fqdn }}"
   with_items: "{{ resticprofile_sftp_servers }}"
   when: resticprofile_ssh_register

--- a/ansible/roles/resticprofile/tasks/sftp-server.yaml
+++ b/ansible/roles/resticprofile/tasks/sftp-server.yaml
@@ -40,6 +40,6 @@
     dest: "/etc/ssh/sshd_config.d/restic.conf"
     mode: "0644"
   delegate_to: "{{ item.fqdn }}"
-  register: sshd_config
+  register: resticprofile_sshd_config
   with_items: "{{ resticprofile_sftp_servers }}"
   notify: Restart sshd

--- a/ansible/site.yaml
+++ b/ansible/site.yaml
@@ -25,6 +25,7 @@
   hosts: all
   roles:
     - role: common
+      tags: common
     - role: layereight.wifi
       when: "wifi_ssid is defined"
       tags: [wifi, network]


### PR DESCRIPTION
• Increase inotify instances limit for Grafana/monitoring workloads
• Add common tag to common role for selective playbook execution
• Fix ansible-lint variable naming: add role prefixes to register variables
• Updated kubeadm_swap_status, resticprofile_* variables per linting rules
