### PR TITLE
Fix Loki prometheus metrics port configuration

### DIFF
--- a/kubernetes/loki/helm/templates/single-binary/statefulset.yaml
+++ b/kubernetes/loki/helm/templates/single-binary/statefulset.yaml
@@ -33,7 +33,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 4af4913f10307731fce33da5b7777f0d8b1fd97eec81712f32528526576a4be2
-        prometheus.io/port: http-metrics
+        prometheus.io/port: "3100"
         prometheus.io/scrape: "true"
         reloader.stakater.com/auto: "true"
         kubectl.kubernetes.io/default-container: "loki"

--- a/kubernetes/loki/values.yaml
+++ b/kubernetes/loki/values.yaml
@@ -31,7 +31,7 @@ loki:
     max_label_names_per_series: 30  # Increase from default 15 to 30
   podAnnotations:
     prometheus.io/scrape: 'true'
-    prometheus.io/port: http-metrics
+    prometheus.io/port: '3100'
     reloader.stakater.com/auto: 'true'
 
 # If Alloy points at the gateway, keep this; otherwise you can disable it


### PR DESCRIPTION
Use explicit port number '3100' instead of 'http-metrics' for
prometheus scraping annotations to ensure consistent monitoring.
