### PR TITLE
Update nginx proxy body size limits

### DIFF
--- a/kubernetes/homebox/helm/homebox/ingress.yaml
+++ b/kubernetes/homebox/helm/homebox/ingress.yaml
@@ -17,6 +17,7 @@ metadata:
     gethomepage.dev/group: Home Lab
     gethomepage.dev/icon: homebox.png
     gethomepage.dev/name: HomeBox
+    nginx.ingress.kubernetes.io/proxy-body-size: 500m
 spec:
   ingressClassName: nginx
   tls:

--- a/kubernetes/homebox/values.yaml
+++ b/kubernetes/homebox/values.yaml
@@ -24,6 +24,7 @@ ingress:
   className: nginx
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+    nginx.ingress.kubernetes.io/proxy-body-size: 500m
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: HomeBox
     gethomepage.dev/description: Inventory and Organization System

--- a/kubernetes/ingress-nginx/helm/controller-configmap.yaml
+++ b/kubernetes/ingress-nginx/helm/controller-configmap.yaml
@@ -14,4 +14,4 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 data:
-  proxy-body-size: "5m"
+  proxy-body-size: "100m"

--- a/kubernetes/ingress-nginx/values.yaml
+++ b/kubernetes/ingress-nginx/values.yaml
@@ -4,7 +4,7 @@ controller:
   extraArgs:
     enable-ssl-passthrough: ''
   config:
-    proxy-body-size: 5m
+    proxy-body-size: 100m
   admissionWebhooks:
     enabled: false
   updateStrategy:


### PR DESCRIPTION
• Increase global ingress-nginx default from 5m to 100m
• Add 500m limit for homebox to support large file uploads
