### PR TITLE
Add force flag to kubeadm reset command

### DIFF
--- a/ansible/roles/kubeadm/tasks/nodes.yaml
+++ b/ansible/roles/kubeadm/tasks/nodes.yaml
@@ -1,6 +1,6 @@
 ---
 - name: "Reset kubeadm if requested"
-  ansible.builtin.command: "kubeadm reset"
+  ansible.builtin.command: "kubeadm reset -f"
   when: "kubeadm_reset |default(false) |bool"
 
 - name: "Run kubeadm join to master"


### PR DESCRIPTION
Prevents interactive confirmation when resetting nodes, allowing automated
cluster rebuilds without manual intervention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved kube cluster reset behavior by running the reset step with a force flag to avoid interactive confirmations. This prevents hangs during unattended operations (e.g., CI/CD or automated provisioning), ensures consistent non-interactive execution, and speeds up node re-provisioning workflows. No configuration changes are required; existing playbooks will execute resets more reliably without manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->