### PR TITLE
Authentik: derive provider skip_path_regex from ingress

### DIFF
--- a/kubernetes/authentik/blueprint-templates/basic.yaml.j2
+++ b/kubernetes/authentik/blueprint-templates/basic.yaml.j2
@@ -19,6 +19,12 @@ entries:
     basic_auth_username_attribute: username
     basic_auth_password_attribute: password
     cookie_domain: oneill.net
+{%- if skip_path_regex %}
+    skip_path_regex: |-
+{%- for line in skip_path_regex.split('\n') %}
+      {{ line }}
+{%- endfor %}
+{%- endif %}
     authorization_flow: !Find
     - authentik_flows.flow
     - [slug, default-provider-authorization-implicit-consent]

--- a/kubernetes/authentik/blueprint-templates/simple.yaml.j2
+++ b/kubernetes/authentik/blueprint-templates/simple.yaml.j2
@@ -17,6 +17,12 @@ entries:
     internal_host: {{ internal_host }}
     intercept_header_auth: true
     cookie_domain: oneill.net
+{%- if skip_path_regex %}
+    skip_path_regex: |-
+{%- for line in skip_path_regex.split('\n') %}
+      {{ line }}
+{%- endfor %}
+{%- endif %}
     authorization_flow: !Find
     - authentik_flows.flow
     - [slug, default-provider-authorization-implicit-consent]

--- a/kubernetes/authentik/generated-blueprints/radarr.yaml
+++ b/kubernetes/authentik/generated-blueprints/radarr.yaml
@@ -19,6 +19,8 @@ entries:
     basic_auth_username_attribute: username
     basic_auth_password_attribute: password
     cookie_domain: oneill.net
+    skip_path_regex: |-
+      ^https://radarr.k.oneill.net/api(/|$)
     authorization_flow: !Find
     - authentik_flows.flow
     - [slug, default-provider-authorization-implicit-consent]

--- a/kubernetes/authentik/generated-blueprints/sonarr.yaml
+++ b/kubernetes/authentik/generated-blueprints/sonarr.yaml
@@ -19,6 +19,8 @@ entries:
     basic_auth_username_attribute: username
     basic_auth_password_attribute: password
     cookie_domain: oneill.net
+    skip_path_regex: |-
+      ^https://sonarr.k.oneill.net/api(/|$)
     authorization_flow: !Find
     - authentik_flows.flow
     - [slug, default-provider-authorization-implicit-consent]

--- a/kubernetes/radarr/ingress.yaml
+++ b/kubernetes/radarr/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     ak-basic: 'true'
     cert-manager.io/cluster-issuer: letsencrypt
+    ak-path-exclude: /api(/|$)
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Radarr
     gethomepage.dev/description: Movie Manager

--- a/kubernetes/scripts/ak-collect-blueprints
+++ b/kubernetes/scripts/ak-collect-blueprints
@@ -137,6 +137,30 @@ def extract_ingress_info(ingress: Dict[str, Any], file_path: Path) -> Dict[str, 
 
     internal_host = f"http://{k8s_service_name}.{namespace}.svc.cluster.local:{port}"
 
+    # Optional path exclusions from annotation "ak-path-exclude"
+    annotations = metadata.get("annotations", {})
+    raw_excludes = annotations.get("ak-path-exclude", "")
+
+    exclude_patterns: List[str] = []
+    if raw_excludes:
+        # Split by newlines or commas to support multi-line annotation values
+        for piece in re.split(r"[\n,]", str(raw_excludes)):
+            p = piece.strip()
+            if not p:
+                continue
+            # If pattern looks like a full URL (with optional leading ^), leave as-is
+            if re.match(r"^\^?https?://", p):
+                # Ensure patterns are anchored at start
+                if not p.startswith("^"):
+                    p = f"^{p}"
+                exclude_patterns.append(p)
+                continue
+            # Treat as a path-based regex; ensure it starts with '/'
+            if not p.startswith("/"):
+                p = "/" + p
+            # Anchor at the service external host
+            exclude_patterns.append(f"^{external_host}{p}")
+
     return {
         "service_name": service_name,
         "ingress_name": ingress_name,
@@ -145,6 +169,7 @@ def extract_ingress_info(ingress: Dict[str, Any], file_path: Path) -> Dict[str, 
         "external_host": external_host,
         "internal_host": internal_host,
         "auth_type": ingress["_auth_type"],
+        "skip_path_regex": "\n".join(exclude_patterns),
     }
 
 

--- a/kubernetes/sonarr/ingress.yaml
+++ b/kubernetes/sonarr/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     ak-basic: 'true'
     cert-manager.io/cluster-issuer: letsencrypt
+    ak-path-exclude: /api(/|$)
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Sonarr
     gethomepage.dev/description: TV Manager


### PR DESCRIPTION
- Collector: parse ak-path-exclude; anchor full URLs; prefix host for path regexes
- Templates: render skip_path_regex in proxy providers
- Ingress: add ak-path-exclude '/api(/|$)' for Sonarr/Radarr
- Blueprints: regenerate Sonarr/Radarr