### PR TITLE
Fix GYB cronjobs: mount run script as file

### DIFF
--- a/kubernetes/got-your-back/cronjob-full.yaml
+++ b/kubernetes/got-your-back/cronjob-full.yaml
@@ -15,7 +15,7 @@ spec:
           containers:
           - name: got-your-back
             image: debian
-            command: [/run]
+            command: [/usr/local/bin/run]
             imagePullPolicy: Always
             env:
             - name: PING_URL
@@ -29,7 +29,7 @@ spec:
             - name: config-source
               mountPath: /config-source
             - name: run-script
-              mountPath: /run
+              mountPath: /usr/local/bin/run
               subPath: run
             - name: got-your-back-data
               mountPath: /data

--- a/kubernetes/got-your-back/cronjob-incremental.yaml
+++ b/kubernetes/got-your-back/cronjob-incremental.yaml
@@ -15,7 +15,7 @@ spec:
           containers:
           - name: got-your-back
             image: debian
-            command: [/run, --fast-incremental]
+            command: [/usr/local/bin/run, --fast-incremental]
             imagePullPolicy: Always
             env:
             - name: PING_URL
@@ -29,7 +29,7 @@ spec:
             - name: config-source
               mountPath: /config-source
             - name: run-script
-              mountPath: /run
+              mountPath: /usr/local/bin/run
               subPath: run
             - name: got-your-back-data
               mountPath: /data


### PR DESCRIPTION
- Mount run script to /usr/local/bin/run via subPath
- Update command to execute script path
- Avoid mounting over /run directory to fix OCI error

Fixes #308 
