### PR TITLE
Authentik SSO: media basic auth + qbit-manage; script fix

### DIFF
--- a/kubernetes/authentik/generated/bazarr.yaml
+++ b/kubernetes/authentik/generated/bazarr.yaml
@@ -1,0 +1,37 @@
+---
+version: 1
+
+metadata:
+  name: bazarr-basic-config
+
+entries:
+- identifiers:  # bazarr Proxy Provider (Basic Auth)
+    name: bazarr
+  id: bazarr_provider
+  model: authentik_providers_proxy.proxyprovider
+  state: present
+  attrs:
+    name: bazarr
+    mode: forward_domain
+    external_host: https://bazarr.k.oneill.net
+    internal_host: http://bazarr.default.svc.cluster.local:6767
+    intercept_header_auth: true
+    basic_auth_username_attribute: username
+    basic_auth_password_attribute: password
+    cookie_domain: oneill.net
+    skip_path_regex: |-
+      ^https://bazarr.k.oneill.net/api(/|$)
+    authorization_flow: !Find
+    - authentik_flows.flow
+    - [slug, default-provider-authorization-implicit-consent]
+    invalidation_flow: !Find
+    - authentik_flows.flow
+    - [slug, default-provider-invalidation-flow]
+- identifiers:  # bazarr Application
+    slug: bazarr
+  id: bazarr_app
+  model: authentik_core.application
+  state: present
+  attrs:
+    name: bazarr
+    provider: !KeyOf bazarr_provider

--- a/kubernetes/authentik/generated/outpost.yaml
+++ b/kubernetes/authentik/generated/outpost.yaml
@@ -18,13 +18,28 @@ entries:
       - [name, alertmanager]
     - !Find
       - authentik_providers_proxy.proxyprovider
+      - [name, bazarr]
+    - !Find
+      - authentik_providers_proxy.proxyprovider
       - [name, goldilocks]
     - !Find
       - authentik_providers_proxy.proxyprovider
       - [name, prometheus]
     - !Find
       - authentik_providers_proxy.proxyprovider
+      - [name, prowlarr]
+    - !Find
+      - authentik_providers_proxy.proxyprovider
+      - [name, qbit-manage]
+    - !Find
+      - authentik_providers_proxy.proxyprovider
       - [name, radarr]
     - !Find
       - authentik_providers_proxy.proxyprovider
+      - [name, sabnzbd]
+    - !Find
+      - authentik_providers_proxy.proxyprovider
       - [name, sonarr]
+    - !Find
+      - authentik_providers_proxy.proxyprovider
+      - [name, tautulli]

--- a/kubernetes/authentik/generated/prowlarr.yaml
+++ b/kubernetes/authentik/generated/prowlarr.yaml
@@ -1,0 +1,37 @@
+---
+version: 1
+
+metadata:
+  name: prowlarr-basic-config
+
+entries:
+- identifiers:  # prowlarr Proxy Provider (Basic Auth)
+    name: prowlarr
+  id: prowlarr_provider
+  model: authentik_providers_proxy.proxyprovider
+  state: present
+  attrs:
+    name: prowlarr
+    mode: forward_domain
+    external_host: https://prowlarr.k.oneill.net
+    internal_host: http://prowlarr.default.svc.cluster.local:9696
+    intercept_header_auth: true
+    basic_auth_username_attribute: username
+    basic_auth_password_attribute: password
+    cookie_domain: oneill.net
+    skip_path_regex: |-
+      ^https://prowlarr.k.oneill.net/api(/|$)
+    authorization_flow: !Find
+    - authentik_flows.flow
+    - [slug, default-provider-authorization-implicit-consent]
+    invalidation_flow: !Find
+    - authentik_flows.flow
+    - [slug, default-provider-invalidation-flow]
+- identifiers:  # prowlarr Application
+    slug: prowlarr
+  id: prowlarr_app
+  model: authentik_core.application
+  state: present
+  attrs:
+    name: prowlarr
+    provider: !KeyOf prowlarr_provider

--- a/kubernetes/authentik/generated/qbit-manage.yaml
+++ b/kubernetes/authentik/generated/qbit-manage.yaml
@@ -1,0 +1,33 @@
+---
+version: 1
+
+metadata:
+  name: qbit-manage-config
+
+entries:
+- identifiers:  # qbit-manage Proxy Provider
+    name: qbit-manage
+  id: qbit-manage_provider
+  model: authentik_providers_proxy.proxyprovider
+  state: present
+  attrs:
+    name: qbit-manage
+    mode: forward_domain
+    external_host: https://qbit-manage.k.oneill.net
+    internal_host: http://qbit-manage.default.svc.cluster.local:8080
+    intercept_header_auth: true
+    cookie_domain: oneill.net
+    authorization_flow: !Find
+    - authentik_flows.flow
+    - [slug, default-provider-authorization-implicit-consent]
+    invalidation_flow: !Find
+    - authentik_flows.flow
+    - [slug, default-provider-invalidation-flow]
+- identifiers:  # qbit-manage Application
+    slug: qbit-manage
+  id: qbit-manage_app
+  model: authentik_core.application
+  state: present
+  attrs:
+    name: qbit-manage
+    provider: !KeyOf qbit-manage_provider

--- a/kubernetes/authentik/generated/sabnzbd.yaml
+++ b/kubernetes/authentik/generated/sabnzbd.yaml
@@ -1,0 +1,37 @@
+---
+version: 1
+
+metadata:
+  name: sabnzbd-basic-config
+
+entries:
+- identifiers:  # sabnzbd Proxy Provider (Basic Auth)
+    name: sabnzbd
+  id: sabnzbd_provider
+  model: authentik_providers_proxy.proxyprovider
+  state: present
+  attrs:
+    name: sabnzbd
+    mode: forward_domain
+    external_host: https://sabnzbd.k.oneill.net
+    internal_host: http://sabnzbd.default.svc.cluster.local:8080
+    intercept_header_auth: true
+    basic_auth_username_attribute: username
+    basic_auth_password_attribute: password
+    cookie_domain: oneill.net
+    skip_path_regex: |-
+      ^https://sabnzbd.k.oneill.net/api(/|$)
+    authorization_flow: !Find
+    - authentik_flows.flow
+    - [slug, default-provider-authorization-implicit-consent]
+    invalidation_flow: !Find
+    - authentik_flows.flow
+    - [slug, default-provider-invalidation-flow]
+- identifiers:  # sabnzbd Application
+    slug: sabnzbd
+  id: sabnzbd_app
+  model: authentik_core.application
+  state: present
+  attrs:
+    name: sabnzbd
+    provider: !KeyOf sabnzbd_provider

--- a/kubernetes/authentik/generated/tautulli.yaml
+++ b/kubernetes/authentik/generated/tautulli.yaml
@@ -1,0 +1,37 @@
+---
+version: 1
+
+metadata:
+  name: tautulli-basic-config
+
+entries:
+- identifiers:  # tautulli Proxy Provider (Basic Auth)
+    name: tautulli
+  id: tautulli_provider
+  model: authentik_providers_proxy.proxyprovider
+  state: present
+  attrs:
+    name: tautulli
+    mode: forward_domain
+    external_host: https://tautulli.k.oneill.net
+    internal_host: http://tautulli.default.svc.cluster.local:8181
+    intercept_header_auth: true
+    basic_auth_username_attribute: username
+    basic_auth_password_attribute: password
+    cookie_domain: oneill.net
+    skip_path_regex: |-
+      ^https://tautulli.k.oneill.net/api(/|$)
+    authorization_flow: !Find
+    - authentik_flows.flow
+    - [slug, default-provider-authorization-implicit-consent]
+    invalidation_flow: !Find
+    - authentik_flows.flow
+    - [slug, default-provider-invalidation-flow]
+- identifiers:  # tautulli Application
+    slug: tautulli
+  id: tautulli_app
+  model: authentik_core.application
+  state: present
+  attrs:
+    name: tautulli
+    provider: !KeyOf tautulli_provider

--- a/kubernetes/authentik/kustomization.yaml
+++ b/kubernetes/authentik/kustomization.yaml
@@ -34,11 +34,16 @@ commonAnnotations:
 configMapGenerator:
 - name: authentik-blueprints
   files:
+  - generated/bazarr.yaml
+  - generated/prowlarr.yaml
   - generated/radarr.yaml
+  - generated/sabnzbd.yaml
   - generated/sonarr.yaml
+  - generated/tautulli.yaml
   - generated/alertmanager.yaml
   - generated/goldilocks.yaml
   - generated/prometheus.yaml
+  - generated/qbit-manage.yaml
   - generated/outpost.yaml
   options:
     disableNameSuffixHash: true

--- a/kubernetes/bazarr/ingress.yaml
+++ b/kubernetes/bazarr/ingress.yaml
@@ -7,6 +7,8 @@ metadata:
   labels:
     app: bazarr
   annotations:
+    ak-type: basic-auth
+    ak-path-exclude: /api(/|$)
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Bazarr

--- a/kubernetes/bazarr/kustomization.yaml
+++ b/kubernetes/bazarr/kustomization.yaml
@@ -6,6 +6,9 @@ namespace: default
 commonAnnotations:
   argoManaged: 'true'
 
+components:
+- ../components/authentik
+
 resources:
 - deployment.yaml
 - pvc.yaml

--- a/kubernetes/prowlarr/ingress.yaml
+++ b/kubernetes/prowlarr/ingress.yaml
@@ -5,6 +5,8 @@ kind: Ingress
 metadata:
   name: prowlarr
   annotations:
+    ak-type: basic-auth
+    ak-path-exclude: /api(/|$)
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Prowlarr

--- a/kubernetes/prowlarr/kustomization.yaml
+++ b/kubernetes/prowlarr/kustomization.yaml
@@ -5,6 +5,9 @@ kind: Kustomization
 commonAnnotations:
   argoManaged: 'true'
 
+components:
+- ../components/authentik
+
 resources:
 - deploy.yaml
 - ingress.yaml

--- a/kubernetes/qbit-manage/ingress.yaml
+++ b/kubernetes/qbit-manage/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: qbit-manage
   annotations:
+    ak-type: simple
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: qBit Manage

--- a/kubernetes/qbit-manage/kustomization.yaml
+++ b/kubernetes/qbit-manage/kustomization.yaml
@@ -6,6 +6,9 @@ namespace: default
 commonAnnotations:
   argoManaged: 'true'
 
+components:
+- ../components/authentik
+
 images:
 - name: qbit-manage
   newName: ghcr.io/stuffanthings/qbit_manage

--- a/kubernetes/sabnzbd/ingress.yaml
+++ b/kubernetes/sabnzbd/ingress.yaml
@@ -5,6 +5,8 @@ kind: Ingress
 metadata:
   name: sabnzbd
   annotations:
+    ak-type: basic-auth
+    ak-path-exclude: /api(/|$)
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: SABnzbd

--- a/kubernetes/sabnzbd/kustomization.yaml
+++ b/kubernetes/sabnzbd/kustomization.yaml
@@ -6,6 +6,9 @@ namespace: default
 commonAnnotations:
   argoManaged: 'true'
 
+components:
+- ../components/authentik
+
 resources:
 - deployment.yaml
 - pvc.yaml

--- a/kubernetes/scripts/ak-collect-blueprints
+++ b/kubernetes/scripts/ak-collect-blueprints
@@ -572,7 +572,8 @@ def write_oidc_externalsecret(
     # Compare ignoring trailing whitespace/newlines to reduce needless diffs
     if old_content.rstrip() != new_content.rstrip():
         _write_text_ensure_newline(file_path, new_content)
-        print(f"  • Updated: {file_path.relative_to(authentik_dir.parent)}")
+        # Print a simple relative path to avoid relative_to errors in different environments
+        print(f"  • Updated: {file_path}")
         return True
     return False
 
@@ -664,7 +665,8 @@ def main():
             print(
                 f"  • Updated: {kustomization_file.name}{' + externalsecret-oidc-blueprints.yaml' if es_changed else ''}"
             )
-            print(f"  • Output: {output_dir.relative_to(base_dir)}")
+            # Print path directly; avoid Path.relative_to which can raise in some contexts
+            print(f"  • Output: {output_dir}")
             sys.exit(1)
         else:
             print("Blueprint files are up to date")

--- a/kubernetes/tautulli/ingress.yaml
+++ b/kubernetes/tautulli/ingress.yaml
@@ -7,6 +7,8 @@ metadata:
   labels:
     k8s-app: tautulli
   annotations:
+    ak-type: basic-auth
+    ak-path-exclude: /api(/|$)
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Tautulli

--- a/kubernetes/tautulli/kustomization.yaml
+++ b/kubernetes/tautulli/kustomization.yaml
@@ -5,6 +5,9 @@ kind: Kustomization
 commonAnnotations:
   argoManaged: 'true'
 
+components:
+- ../components/authentik
+
 resources:
 - deploy.yaml
 - ingress.yaml


### PR DESCRIPTION
- Add basic-auth to Bazarr, Prowlarr, SABnzbd, Tautulli; exclude /api

- Add forward-auth to qbit-manage

- Remove qBittorrent from SSO scope

- Add Authentik component to service kustomizations

- Regenerate blueprints; update Authentik kustomization

- Fix ak-collect-blueprints path printing
