### PR TITLE
Remove explicit refreshInterval from ExternalSecrets

### DIFF
--- a/kubernetes/alertmanager/externalsecret.yaml
+++ b/kubernetes/alertmanager/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   data:
   - secretKey: smtp-password
     remoteRef:

--- a/kubernetes/authentik/blueprint-templates/externalsecret-oidc-blueprints.yaml.j2
+++ b/kubernetes/authentik/blueprint-templates/externalsecret-oidc-blueprints.yaml.j2
@@ -10,7 +10,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   data:
 {%- for app in oidc_apps %}
   - secretKey: {{ app.app_name }}_client_id

--- a/kubernetes/authentik/externalsecret.yaml
+++ b/kubernetes/authentik/externalsecret.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: authentik
 
 spec:
-  refreshInterval: 1h
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
@@ -32,7 +31,6 @@ metadata:
   name: authentik-valkey-config
 
 spec:
-  refreshInterval: 1h
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
@@ -56,7 +54,6 @@ metadata:
   name: authentik-valkey
 
 spec:
-  refreshInterval: 1h
   secretStoreRef:
     name: production
     kind: ClusterSecretStore

--- a/kubernetes/authentik/generated/externalsecret-oidc-blueprints.yaml
+++ b/kubernetes/authentik/generated/externalsecret-oidc-blueprints.yaml
@@ -10,7 +10,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   data:
   - secretKey: autobrr_client_id
     remoteRef:

--- a/kubernetes/autobrr/externalsecret.yaml
+++ b/kubernetes/autobrr/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   data:
   - secretKey: AUTOBRR__OIDC_CLIENT_ID
     remoteRef:

--- a/kubernetes/awair-exporter/externalsecret.yaml
+++ b/kubernetes/awair-exporter/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   target:
     name: awair-exporter
   dataFrom:

--- a/kubernetes/cert-manager/externalsecret.yaml
+++ b/kubernetes/cert-manager/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   dataFrom:
   - extract:
       key: cert-manager

--- a/kubernetes/cross-seed/externalsecret.yaml
+++ b/kubernetes/cross-seed/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   dataFrom:
   - extract:
       key: cross-seed-secrets

--- a/kubernetes/ddns-route53/externalsecret.yaml
+++ b/kubernetes/ddns-route53/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   dataFrom:
   - extract:
       key: ddns-route53-fnord
@@ -25,7 +24,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   dataFrom:
   - extract:
       key: ddns-route53-oneill

--- a/kubernetes/external-dns/externalsecret.yaml
+++ b/kubernetes/external-dns/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   target:
     name: external-dns
   dataFrom:

--- a/kubernetes/external-secrets/iscsi-external-secret.yaml
+++ b/kubernetes/external-secrets/iscsi-external-secret.yaml
@@ -11,7 +11,6 @@ spec:
     secretStoreRef:
       kind: ClusterSecretStore
       name: production
-    refreshInterval: 1h
     target:
       creationPolicy: Owner
       deletionPolicy: Retain

--- a/kubernetes/got-your-back/externalsecret.yaml
+++ b/kubernetes/got-your-back/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   dataFrom:
   - extract:
       key: gyb-files

--- a/kubernetes/hass/externalsecret.yaml
+++ b/kubernetes/hass/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   target:
     name: hass-ssh-key
     template:
@@ -35,7 +34,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   data:
   - secretKey: smtp-password
     remoteRef:
@@ -50,7 +48,6 @@ metadata:
   name: hass-secrets
 
 spec:
-  refreshInterval: 1h
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
@@ -68,7 +65,6 @@ metadata:
   name: hass-caseta-certificates
 
 spec:
-  refreshInterval: 1h
   secretStoreRef:
     name: production
     kind: ClusterSecretStore

--- a/kubernetes/mosquitto/externalsecret.yaml
+++ b/kubernetes/mosquitto/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   dataFrom:
   - extract:
       key: mosquitto-users

--- a/kubernetes/mqtt-log/externalsecret.yaml
+++ b/kubernetes/mqtt-log/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   dataFrom:
   - extract:
       key: mqtt-log

--- a/kubernetes/n8n/externalsecret.yaml
+++ b/kubernetes/n8n/externalsecret.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: n8n
 
 spec:
-  refreshInterval: 1h
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
@@ -32,7 +31,6 @@ metadata:
   name: n8n-valkey-config
 
 spec:
-  refreshInterval: 1h
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
@@ -56,7 +54,6 @@ metadata:
   name: n8n-valkey
 
 spec:
-  refreshInterval: 1h
   secretStoreRef:
     name: production
     kind: ClusterSecretStore

--- a/kubernetes/netatmo-exporter/externalsecret.yaml
+++ b/kubernetes/netatmo-exporter/externalsecret.yaml
@@ -6,7 +6,6 @@ metadata:
   name: netatmo-exporter
 
 spec:
-  refreshInterval: 1h
   secretStoreRef:
     name: production
     kind: ClusterSecretStore

--- a/kubernetes/netatmo-wunderground-agent/externalsecret.yaml
+++ b/kubernetes/netatmo-wunderground-agent/externalsecret.yaml
@@ -6,7 +6,6 @@ metadata:
   name: netatmo-wunderground-agent
 
 spec:
-  refreshInterval: 1h
   secretStoreRef:
     name: production
     kind: ClusterSecretStore

--- a/kubernetes/plexmediaserver/externalsecret.yaml
+++ b/kubernetes/plexmediaserver/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   dataFrom:
   - extract:
       key: plexmediaserver

--- a/kubernetes/prometheus/externalsecret.yaml
+++ b/kubernetes/prometheus/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   dataFrom:
   - extract:
       key: prometheus

--- a/kubernetes/qbit-manage/externalsecret.yaml
+++ b/kubernetes/qbit-manage/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   dataFrom:
   - extract:
       key: qbittorrent

--- a/kubernetes/resticprofile/externalsecret.yaml
+++ b/kubernetes/resticprofile/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   dataFrom:
   - extract:
       key: resticprofile
@@ -25,7 +24,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   data:
   # B2 backend credentials
   - secretKey: RCLONE_CONFIG_B2_ACCOUNT

--- a/kubernetes/tailscale-operator/externalsecret.yaml
+++ b/kubernetes/tailscale-operator/externalsecret.yaml
@@ -9,7 +9,6 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  refreshInterval: 1h
   target:
     name: operator-oauth
   dataFrom:


### PR DESCRIPTION
- Drop refreshInterval: 1h from manifests to rely on default\n- Keep behavior unchanged (defaults to 1h)\n- Closes #98
