### PR TITLE
Drop Helm test manifests from rendered charts

### DIFF
--- a/kubernetes/1password-connect/kustomization.yaml
+++ b/kubernetes/1password-connect/kustomization.yaml
@@ -10,8 +10,3 @@ resources:
 
 commonAnnotations:
   argoManaged: 'true'
-
-images:
-- name: curlimages/curl
-  newName: curlimages/curl
-  newTag: latest

--- a/kubernetes/1password-connect/render
+++ b/kubernetes/1password-connect/render
@@ -13,3 +13,6 @@ helm_template connect connect \
 	--namespace 1password \
 	--values values.yaml \
 	--output-dir helm
+
+# Drop Helm test manifests from rendered output
+rm -rf helm/templates/tests

--- a/kubernetes/loki/render
+++ b/kubernetes/loki/render
@@ -23,3 +23,6 @@ rmdir tmp
 
 # Delete the PSP since it's a deprecated resource and we don't need the warnings.
 rm -f helm/templates/podsecuritypolicy.yaml
+
+# Drop Helm test manifests from rendered output
+rm -rf helm/templates/tests


### PR DESCRIPTION
- Remove tests in 1password-connect and loki render scripts

- Clean 1password kustomization: remove unused curl image override
