### PR TITLE
Add ArgoCD OIDC to Authentik and wire Dex

### DIFF
--- a/kubernetes/argocd/externalsecret-oidc-config.yaml
+++ b/kubernetes/argocd/externalsecret-oidc-config.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+  name: argocd-oidc-config
+  namespace: argocd
+
+spec:
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  data:
+  - secretKey: oidc.authentik.clientID
+    remoteRef:
+      key: argocd-oidc
+      property: client-id
+  - secretKey: oidc.authentik.clientSecret
+    remoteRef:
+      key: argocd-oidc
+      property: client-secret
+  - secretKey: dex.clientSecret
+    remoteRef:
+      key: argocd-dex
+      property: client-secret
+  target:
+    name: argocd-secret
+    creationPolicy: Merge
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      mergePolicy: Merge

--- a/kubernetes/argocd/helm/templates/argocd-application-controller/statefulset.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-application-controller/statefulset.yaml
@@ -24,8 +24,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: fe7e6e5a414758800d7e7f87c02c7add7530a5d0fb1b0767c5a6b9650dca9390
-        checksum/cm: fea1e2583200482d4f9a7d447307d6dbda7f56b3f85d7d7e3242c21995dbb4db
       labels:
         helm.sh/chart: argo-cd-8.3.3
         app.kubernetes.io/name: argocd-application-controller

--- a/kubernetes/argocd/helm/templates/argocd-applicationset/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-applicationset/deployment.yaml
@@ -23,7 +23,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: fe7e6e5a414758800d7e7f87c02c7add7530a5d0fb1b0767c5a6b9650dca9390
       labels:
         helm.sh/chart: argo-cd-8.3.3
         app.kubernetes.io/name: argocd-applicationset-controller

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-cm.yaml
@@ -42,7 +42,6 @@ data:
         issuer: https://auth.k.oneill.net/application/o/argocd/
         clientID: $oidc.authentik.clientID
         clientSecret: $oidc.authentik.clientSecret
-        #redirectURI: https://argocd.k.oneill.net/api/dex/callback
         scopes:
         - openid
         - profile

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-cm.yaml
@@ -18,6 +18,38 @@ data:
   admin.enabled: "true"
   application.instanceLabelKey: argocd.argoproj.io/instance
   application.sync.impersonation.enabled: "false"
+  dex.config: |
+    issuer: https://argocd.k.oneill.net/dex
+    storage:
+      type: memory
+    web:
+      http: 0.0.0.0:5556
+    telemetry:
+      http: 0.0.0.0:5558
+    frontend:
+      theme: argocd
+    staticClients:
+    - id: argocd
+      name: Argo CD
+      redirectURIs:
+      - https://argocd.k.oneill.net/auth/callback
+      secret: $dex.clientSecret
+    connectors:
+    - type: oidc
+      id: authentik
+      name: Authentik
+      config:
+        issuer: https://auth.k.oneill.net/application/o/argocd/
+        clientID: $oidc.authentik.clientID
+        clientSecret: $oidc.authentik.clientSecret
+        #redirectURI: https://argocd.k.oneill.net/api/dex/callback
+        scopes:
+        - openid
+        - profile
+        - email
+        - groups
+        insecureEnableGroups: true
+        getUserInfo: true
   exec.enabled: "false"
   resource.customizations.ignoreResourceUpdates.ConfigMap: |
     jqPathExpressions:

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-cmd-params-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-cmd-params-cm.yaml
@@ -31,6 +31,7 @@ data:
   controller.self.heal.timeout.seconds: "5"
   controller.status.processors: "20"
   controller.sync.timeout.seconds: "0"
+  dexserver.disable.tls: "true"
   dexserver.log.format: text
   dexserver.log.level: info
   hydrator.enabled: "false"
@@ -43,7 +44,7 @@ data:
   reposerver.log.level: info
   reposerver.parallelism.limit: "0"
   server.basehref: /
-  server.dex.server: https://argocd-dex-server:5556
+  server.dex.server: http://argocd-dex-server:5556
   server.dex.server.strict.tls: "false"
   server.disable.auth: "false"
   server.enable.gzip: "true"

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-rbac-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-rbac-cm.yaml
@@ -27,6 +27,8 @@ data:
     p, role:github-actions, projects, get, *, allow
     # Assign github-actions account to the role
     g, github-actions, role:github-actions
+    # Assign authentik admins to admin
+    g, authentik Admins, role:admin
   policy.default: ""
   policy.matchMode: glob
   scopes: '[groups]'

--- a/kubernetes/argocd/helm/templates/argocd-repo-server/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-repo-server/deployment.yaml
@@ -23,8 +23,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: fe7e6e5a414758800d7e7f87c02c7add7530a5d0fb1b0767c5a6b9650dca9390
-        checksum/cm: fea1e2583200482d4f9a7d447307d6dbda7f56b3f85d7d7e3242c21995dbb4db
       labels:
         helm.sh/chart: argo-cd-8.3.3
         app.kubernetes.io/name: argocd-repo-server

--- a/kubernetes/argocd/helm/templates/argocd-server/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/deployment.yaml
@@ -23,8 +23,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: fe7e6e5a414758800d7e7f87c02c7add7530a5d0fb1b0767c5a6b9650dca9390
-        checksum/cm: fea1e2583200482d4f9a7d447307d6dbda7f56b3f85d7d7e3242c21995dbb4db
       labels:
         helm.sh/chart: argo-cd-8.3.3
         app.kubernetes.io/name: argocd-server

--- a/kubernetes/argocd/helm/templates/argocd-server/ingress.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/ingress.yaml
@@ -14,6 +14,8 @@ metadata:
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/version: "v3.1.1"
   annotations:
+    ak-oidc-callback: "/api/dex/callback"
+    ak-type: "oidc"
     gethomepage.dev/description: "GitOps Continuous Delivery"
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: "Home Lab"

--- a/kubernetes/argocd/helm/templates/dex/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/dex/deployment.yaml
@@ -23,7 +23,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: fe7e6e5a414758800d7e7f87c02c7add7530a5d0fb1b0767c5a6b9650dca9390
       labels:
         helm.sh/chart: argo-cd-8.3.3
         app.kubernetes.io/name: argocd-dex-server
@@ -45,6 +44,21 @@ spec:
         args:
         - rundex
         env:
+          - name: OIDC_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                key: oidc.authentik.clientID
+                name: argocd-secret
+          - name: OIDC_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                key: oidc.authentik.clientSecret
+                name: argocd-secret
+          - name: DEX_STATIC_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                key: dex.clientSecret
+                name: argocd-secret
           - name: ARGOCD_DEX_SERVER_LOGFORMAT
             valueFrom:
               configMapKeyRef:

--- a/kubernetes/argocd/kustomization.yaml
+++ b/kubernetes/argocd/kustomization.yaml
@@ -16,6 +16,8 @@ resources:
 - namespace.yaml
 - tailscale-ingress.yaml
 - appset.yaml
+- externalsecret-oidc-config.yaml
+
 # Generated helm resources - do not edit below this line
 - helm/templates/argocd-application-controller/clusterrole.yaml
 - helm/templates/argocd-application-controller/clusterrolebinding.yaml

--- a/kubernetes/argocd/render
+++ b/kubernetes/argocd/render
@@ -23,6 +23,12 @@ rmdir tmp/*
 rmdir tmp
 rm -rf helm/tests
 
+# Strip noisy Helm checksum annotations to reduce diffs/noise
+# Remove any annotation keys beginning with "checksum/" from all rendered YAML
+while IFS= read -r -d '' f; do
+  awk '!( $0 ~ /^[[:space:]]*checksum\// ) { print }' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+done < <(find helm -type f -name '*.yaml' -print0)
+
 # Update kustomization.yaml resources to match actual helm files
 # Use awk for cross-platform compatibility
 awk '/# Generated helm resources/ { exit } { print }' kustomization.yaml > kustomization.yaml.tmp && mv kustomization.yaml.tmp kustomization.yaml

--- a/kubernetes/argocd/values.yaml
+++ b/kubernetes/argocd/values.yaml
@@ -24,6 +24,8 @@ server:
       gethomepage.dev/description: GitOps Continuous Delivery
       gethomepage.dev/icon: mdi-git
       gethomepage.dev/group: Home Lab
+      ak-type: oidc
+      ak-oidc-callback: /api/dex/callback
     path: /
     pathType: Prefix
 
@@ -32,6 +34,38 @@ configs:
     url: https://argocd.k.oneill.net
     # GitHub Actions service account configuration
     accounts.github-actions: apiKey
+    dex.config: |
+      issuer: https://argocd.k.oneill.net/dex
+      storage:
+        type: memory
+      web:
+        http: 0.0.0.0:5556
+      telemetry:
+        http: 0.0.0.0:5558
+      frontend:
+        theme: argocd
+      staticClients:
+      - id: argocd
+        name: Argo CD
+        redirectURIs:
+        - https://argocd.k.oneill.net/auth/callback
+        secret: $dex.clientSecret
+      connectors:
+      - type: oidc
+        id: authentik
+        name: Authentik
+        config:
+          issuer: https://auth.k.oneill.net/application/o/argocd/
+          clientID: $oidc.authentik.clientID
+          clientSecret: $oidc.authentik.clientSecret
+          scopes:
+          - openid
+          - profile
+          - email
+          - groups
+          insecureEnableGroups: true
+          getUserInfo: true
+
   rbac:
     # RBAC policy for GitHub Actions service account - minimal required permissions
     policy.csv: |
@@ -47,5 +81,32 @@ configs:
       p, role:github-actions, projects, get, *, allow
       # Assign github-actions account to the role
       g, github-actions, role:github-actions
+      # Assign authentik admins to admin
+      g, authentik Admins, role:admin
   notifications:
     argocdUrl: https://argocd.k.oneill.net
+  params:
+    # Dex is configured to listen on plain HTTP 5556 via dex.config
+    server.dex.server: http://argocd-dex-server:5556
+    server.dex.server.strict.tls: 'false'
+    dexserver.disable.tls: 'true'
+
+dex:
+  # This is here just to ensure ESO has merged these values into the existing
+  # argocd-secret.  These aren't used in the pod.
+  env:
+  - name: OIDC_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: argocd-secret  # ESO writes into this
+        key: oidc.authentik.clientID  # required key
+  - name: OIDC_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: argocd-secret
+        key: oidc.authentik.clientSecret
+  - name: DEX_STATIC_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: argocd-secret
+        key: dex.clientSecret

--- a/kubernetes/authentik/blueprint-templates/externalsecret-oidc-blueprints.yaml.j2
+++ b/kubernetes/authentik/blueprint-templates/externalsecret-oidc-blueprints.yaml.j2
@@ -37,14 +37,25 @@ spec:
             state: present
             attrs:
               name: {{ app.app_name }}-oidc
+              slug: {{ app.app_name }}-oidc
               client_type: confidential
               client_id: '{{ '{{ .' ~ app.app_name ~ '_client_id }}' }}'
               client_secret: '{{ '{{ .' ~ app.app_name ~ '_client_secret }}' }}'
               issuer_mode: per_provider
               include_claims_in_id_token: true
+              property_mappings:
+              - !Find
+                - authentik_providers_oauth2.scopemapping
+                - [name, "authentik default OAuth Mapping: OpenID 'openid'"]
+              - !Find
+                - authentik_providers_oauth2.scopemapping
+                - [name, "authentik default OAuth Mapping: OpenID 'email'"]
+              - !Find
+                - authentik_providers_oauth2.scopemapping
+                - [name, "authentik default OAuth Mapping: OpenID 'profile'"]
               sub_mode: hashed_user_id
               signing_key: !Find
-              - authentik_crypto.certificatekey
+              - authentik_crypto.certificatekeypair
               - [name, authentik Self-signed Certificate]
               authorization_flow: !Find
               - authentik_flows.flow

--- a/kubernetes/authentik/generated/externalsecret-oidc-blueprints.yaml
+++ b/kubernetes/authentik/generated/externalsecret-oidc-blueprints.yaml
@@ -11,6 +11,14 @@ spec:
     name: production
     kind: ClusterSecretStore
   data:
+  - secretKey: argocd_client_id
+    remoteRef:
+      key: argocd-oidc
+      property: client-id
+  - secretKey: argocd_client_secret
+    remoteRef:
+      key: argocd-oidc
+      property: client-secret
   - secretKey: autobrr_client_id
     remoteRef:
       key: autobrr-oidc
@@ -25,6 +33,54 @@ spec:
       engineVersion: v2
       data:
 
+        argocd.yaml: |-
+          version: 1
+          entries:
+          - identifiers:  # argocd OIDC Provider
+              name: argocd-oidc
+            id: argocd_oidc_provider
+            model: authentik_providers_oauth2.oauth2provider
+            state: present
+            attrs:
+              name: argocd-oidc
+              slug: argocd-oidc
+              client_type: confidential
+              client_id: '{{ .argocd_client_id }}'
+              client_secret: '{{ .argocd_client_secret }}'
+              issuer_mode: per_provider
+              include_claims_in_id_token: true
+              property_mappings:
+              - !Find
+                - authentik_providers_oauth2.scopemapping
+                - [name, "authentik default OAuth Mapping: OpenID 'openid'"]
+              - !Find
+                - authentik_providers_oauth2.scopemapping
+                - [name, "authentik default OAuth Mapping: OpenID 'email'"]
+              - !Find
+                - authentik_providers_oauth2.scopemapping
+                - [name, "authentik default OAuth Mapping: OpenID 'profile'"]
+              sub_mode: hashed_user_id
+              signing_key: !Find
+              - authentik_crypto.certificatekeypair
+              - [name, authentik Self-signed Certificate]
+              authorization_flow: !Find
+              - authentik_flows.flow
+              - [slug, default-provider-authorization-implicit-consent]
+              invalidation_flow: !Find
+              - authentik_flows.flow
+              - [slug, default-provider-invalidation-flow]
+              redirect_uris:
+              - matching_mode: strict
+                url: https://argocd.k.oneill.net/api/dex/callback
+          - identifiers:  # argocd Application
+              slug: argocd
+            id: argocd_app
+            model: authentik_core.application
+            state: present
+            attrs:
+              name: argocd
+              provider: !KeyOf argocd_oidc_provider
+
         autobrr.yaml: |-
           version: 1
           entries:
@@ -35,14 +91,25 @@ spec:
             state: present
             attrs:
               name: autobrr-oidc
+              slug: autobrr-oidc
               client_type: confidential
               client_id: '{{ .autobrr_client_id }}'
               client_secret: '{{ .autobrr_client_secret }}'
               issuer_mode: per_provider
               include_claims_in_id_token: true
+              property_mappings:
+              - !Find
+                - authentik_providers_oauth2.scopemapping
+                - [name, "authentik default OAuth Mapping: OpenID 'openid'"]
+              - !Find
+                - authentik_providers_oauth2.scopemapping
+                - [name, "authentik default OAuth Mapping: OpenID 'email'"]
+              - !Find
+                - authentik_providers_oauth2.scopemapping
+                - [name, "authentik default OAuth Mapping: OpenID 'profile'"]
               sub_mode: hashed_user_id
               signing_key: !Find
-              - authentik_crypto.certificatekey
+              - authentik_crypto.certificatekeypair
               - [name, authentik Self-signed Certificate]
               authorization_flow: !Find
               - authentik_flows.flow

--- a/kubernetes/authentik/generated/prowlarr.yaml
+++ b/kubernetes/authentik/generated/prowlarr.yaml
@@ -20,7 +20,7 @@ entries:
     basic_auth_password_attribute: password
     cookie_domain: oneill.net
     skip_path_regex: |-
-      ^https://prowlarr.k.oneill.net/api(/|$)
+      ^https://prowlarr.k.oneill.net/\d+/api.+
     authorization_flow: !Find
     - authentik_flows.flow
     - [slug, default-provider-authorization-implicit-consent]

--- a/kubernetes/prowlarr/ingress.yaml
+++ b/kubernetes/prowlarr/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   name: prowlarr
   annotations:
     ak-type: basic-auth
-    ak-path-exclude: /api(/|$)
+    ak-path-exclude: /\d+/api.+
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Prowlarr


### PR DESCRIPTION
- Add argocd provider + application to consolidated Authentik blueprint (per-provider issuer, redirect to /api/dex/callback, default scope mappings; slug; certificatekeypair)
- Pull argocd client credentials from 1Password into blueprint secret
- Configure Dex connector to Authentik application issuer; enable getUserInfo; static client reads .clientSecret
- Add ExternalSecret merging OIDC + Dex client into argocd-secret (retain)
- RBAC: grant admin to “authentik Admins” and use groups scope
- Normalize Helm render annotations (remove checksum conflicts)
