### PR TITLE
Renovate: 2-day delay for Kubernetes Docker digests

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -56,6 +56,20 @@
   ],
   "packageRules": [
     {
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchFileNames": [
+        "kubernetes/**"
+      ],
+      "schedule": [],
+      "minimumReleaseAge": "2 days",
+      "description": "Kubernetes Docker digests: bypass schedule, delay 2 days"
+    },
+    {
       "matchDatasources": [
         "helm"
       ],


### PR DESCRIPTION
- Apply to docker digests under kubernetes/**\n- Override schedule only for these updates\n- Keep other updates on Monday + 14-day age
