### PR TITLE
Manage Argo CD secrets via ExternalSecrets

### DIFF
--- a/kubernetes/argocd/externalsecret-server-secretkey.yaml
+++ b/kubernetes/argocd/externalsecret-server-secretkey.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+  name: argocd-server-secretkey
+  namespace: argocd
+
+spec:
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  target:
+    name: argocd-secret
+    creationPolicy: Merge
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+  data:
+  - secretKey: server.secretkey
+    remoteRef:
+      key: argocd-server
+      property: server-secretkey

--- a/kubernetes/argocd/kustomization.yaml
+++ b/kubernetes/argocd/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
 - tailscale-ingress.yaml
 - appset.yaml
 - externalsecret-oidc-config.yaml
+- externalsecret-server-secretkey.yaml
 
 # Generated helm resources - do not edit below this line
 - helm/templates/argocd-application-controller/clusterrole.yaml

--- a/kubernetes/argocd/values.yaml
+++ b/kubernetes/argocd/values.yaml
@@ -92,9 +92,8 @@ configs:
     dexserver.disable.tls: 'true'
 
 dex:
-  # Ensure External Secrets merged keys into Secret 'argocd-secret'.
-  # Source: ExternalSecret 'argocd-oidc-config' (1Password items 'argocd-oidc' and 'argocd-dex').
-  # Not used by the pod; only materializes keys.
+  # This is here just to ensure ESO has merged these values into the existing
+  # argocd-secret.  These aren't used in the pod.
   env:
   - name: OIDC_CLIENT_ID
     valueFrom:

--- a/kubernetes/argocd/values.yaml
+++ b/kubernetes/argocd/values.yaml
@@ -92,9 +92,9 @@ configs:
     dexserver.disable.tls: 'true'
 
 dex:
-  # Ensure External Secrets has merged these values into argocd-secret.
-  # Populated from 1Password item "argocd" via ExternalSecret "argocd-secret".
-  # These envs are not used by the pod itself; they only materialize keys.
+  # Ensure External Secrets merged keys into Secret 'argocd-secret'.
+  # Source: ExternalSecret 'argocd-oidc-config' (1Password items 'argocd-oidc' and 'argocd-dex').
+  # Not used by the pod; only materializes keys.
   env:
   - name: OIDC_CLIENT_ID
     valueFrom:

--- a/kubernetes/argocd/values.yaml
+++ b/kubernetes/argocd/values.yaml
@@ -92,8 +92,9 @@ configs:
     dexserver.disable.tls: 'true'
 
 dex:
-  # This is here just to ensure ESO has merged these values into the existing
-  # argocd-secret.  These aren't used in the pod.
+  # Ensure External Secrets has merged these values into argocd-secret.
+  # Populated from 1Password item "argocd" via ExternalSecret "argocd-secret".
+  # These envs are not used by the pod itself; they only materialize keys.
   env:
   - name: OIDC_CLIENT_ID
     valueFrom:


### PR DESCRIPTION
- Add ExternalSecret for server.secretkey from 1Password (argocd-server)
- Keep OIDC and Dex ExternalSecret using argocd-oidc and argocd-dex
- Update argocd kustomization to include both resources
- Clarify values.yaml comments about secret sourcing
