### PR TITLE
Adjust Prowlarr API exclusion to numbered paths only

### DIFF
--- a/kubernetes/authentik/generated/prowlarr.yaml
+++ b/kubernetes/authentik/generated/prowlarr.yaml
@@ -20,7 +20,7 @@ entries:
     basic_auth_password_attribute: password
     cookie_domain: oneill.net
     skip_path_regex: |-
-      ^https://prowlarr.k.oneill.net/\d+/api(/|$)
+      ^https://prowlarr.k.oneill.net/\d+/api.*
     authorization_flow: !Find
     - authentik_flows.flow
     - [slug, default-provider-authorization-implicit-consent]

--- a/kubernetes/prowlarr/ingress.yaml
+++ b/kubernetes/prowlarr/ingress.yaml
@@ -6,7 +6,8 @@ metadata:
   name: prowlarr
   annotations:
     ak-type: basic-auth
-    ak-path-exclude: /\d+/api(/|$)
+    ak-path-exclude: |-
+      /\d+/api.*
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Prowlarr


### PR DESCRIPTION
- Update ingress ak-path-exclude to '/\d+/api.*'
- Sync Authentik provider skip_path_regex to '^https://prowlarr.k.oneill.net/\d+/api.*'
