### PR TITLE
Add Huntarr app with iSCSI config; tweak Prowlarr API

### DIFF
--- a/kubernetes/authentik/generated/huntarr.yaml
+++ b/kubernetes/authentik/generated/huntarr.yaml
@@ -1,0 +1,33 @@
+---
+version: 1
+
+metadata:
+  name: huntarr-config
+
+entries:
+- identifiers:  # huntarr Proxy Provider
+    name: huntarr
+  id: huntarr_provider
+  model: authentik_providers_proxy.proxyprovider
+  state: present
+  attrs:
+    name: huntarr
+    mode: forward_domain
+    external_host: https://huntarr.k.oneill.net
+    internal_host: http://huntarr.default.svc.cluster.local:9705
+    intercept_header_auth: true
+    cookie_domain: oneill.net
+    authorization_flow: !Find
+    - authentik_flows.flow
+    - [slug, default-provider-authorization-implicit-consent]
+    invalidation_flow: !Find
+    - authentik_flows.flow
+    - [slug, default-provider-invalidation-flow]
+- identifiers:  # huntarr Application
+    slug: huntarr
+  id: huntarr_app
+  model: authentik_core.application
+  state: present
+  attrs:
+    name: huntarr
+    provider: !KeyOf huntarr_provider

--- a/kubernetes/authentik/generated/outpost.yaml
+++ b/kubernetes/authentik/generated/outpost.yaml
@@ -24,6 +24,9 @@ entries:
       - [name, goldilocks]
     - !Find
       - authentik_providers_proxy.proxyprovider
+      - [name, huntarr]
+    - !Find
+      - authentik_providers_proxy.proxyprovider
       - [name, prometheus]
     - !Find
       - authentik_providers_proxy.proxyprovider

--- a/kubernetes/authentik/generated/prowlarr.yaml
+++ b/kubernetes/authentik/generated/prowlarr.yaml
@@ -21,6 +21,7 @@ entries:
     cookie_domain: oneill.net
     skip_path_regex: |-
       ^https://prowlarr.k.oneill.net/\d+/api.*
+      ^https://prowlarr.k.oneill.net/api.*
     authorization_flow: !Find
     - authentik_flows.flow
     - [slug, default-provider-authorization-implicit-consent]

--- a/kubernetes/authentik/kustomization.yaml
+++ b/kubernetes/authentik/kustomization.yaml
@@ -42,6 +42,7 @@ configMapGenerator:
   - generated/tautulli.yaml
   - generated/alertmanager.yaml
   - generated/goldilocks.yaml
+  - generated/huntarr.yaml
   - generated/prometheus.yaml
   - generated/qbit-manage.yaml
   - generated/outpost.yaml

--- a/kubernetes/huntarr/deployment.yaml
+++ b/kubernetes/huntarr/deployment.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: huntarr
+  annotations:
+    reloader.stakater.com/auto: 'true'
+    secret.reloader.stakater.com/reload: iscsi-chap-secret
+
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: huntarr
+  template:
+    metadata:
+      labels:
+        app: huntarr
+    spec:
+      enableServiceLinks: false
+      containers:
+      - name: huntarr
+        image: ghcr.io/plexguide/huntarr
+        ports:
+        - containerPort: 9705
+        volumeMounts:
+        - mountPath: /config
+          name: config
+        env:
+        - name: TZ
+          value: EST5EDT
+      volumes:
+      - name: config
+        iscsi:
+          targetPortal: 172.19.74.139
+          iqn: iqn.2000-01.com.synology:fs2.Target-1.05f22bcf4f5
+          lun: 1
+          fsType: ext4
+          chapAuthDiscovery: false
+          chapAuthSession: true
+          secretRef:
+            name: iscsi-chap-secret

--- a/kubernetes/huntarr/ingress.yaml
+++ b/kubernetes/huntarr/ingress.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+
+metadata:
+  name: huntarr
+  annotations:
+    ak-type: simple
+    cert-manager.io/cluster-issuer: letsencrypt
+    gethomepage.dev/enabled: 'true'
+    gethomepage.dev/name: Huntarr
+    gethomepage.dev/description: Missing and Upgrade Hunter
+    gethomepage.dev/group: Media
+
+spec:
+  tls:
+  - hosts:
+    - huntarr.k.oneill.net
+    secretName: huntarr-tls
+  rules:
+  - host: huntarr.k.oneill.net
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: huntarr
+            port:
+              number: 9705
+  ingressClassName: nginx

--- a/kubernetes/huntarr/kustomization.yaml
+++ b/kubernetes/huntarr/kustomization.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+
+commonAnnotations:
+  argoManaged: 'true'
+
+components:
+- ../components/authentik
+
+resources:
+- deployment.yaml
+- service.yaml
+- ingress.yaml
+
+images:
+- name: ghcr.io/plexguide/huntarr
+  newTag: 8.2.10@sha256:b5a47c2b43806165f433d308d69a21e74a687ce59f4fcccb612d6a7acb3af6d7
+
+labels:
+
+- pairs:
+    app.kubernetes.io/name: huntarr
+    app.kubernetes.io/instance: huntarr
+  includeSelectors: true

--- a/kubernetes/huntarr/service.yaml
+++ b/kubernetes/huntarr/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: huntarr
+
+spec:
+  ports:
+  - port: 9705
+    targetPort: 9705
+    protocol: TCP
+    name: http
+  selector:
+    app: huntarr

--- a/kubernetes/prowlarr/ingress.yaml
+++ b/kubernetes/prowlarr/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     ak-type: basic-auth
     ak-path-exclude: |-
       /\d+/api.*
+      /api.*
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Prowlarr


### PR DESCRIPTION
- Add kubernetes/huntarr kustomize (deployment, service, ingress)
- Pin ghcr.io/plexguide/huntarr:8.2.10 by digest
- Mount /config via iSCSI (provided IQN)
- Disable service links; set HOST/PORT env
- Set ak-type simple on Huntarr ingress; homepage annotations
- Add Authentik blueprint entry and reference
- Expand Prowlarr ak-path-exclude to also match /api
