### PR TITLE
Add Overseerr k8s manifests (no Authentik)

### DIFF
--- a/kubernetes/overseerr/deployment.yaml
+++ b/kubernetes/overseerr/deployment.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: overseerr
+  annotations:
+    reloader.stakater.com/auto: 'true'
+    secret.reloader.stakater.com/reload: iscsi-chap-secret
+
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: overseerr
+      app.kubernetes.io/name: overseerr
+      app.kubernetes.io/instance: overseerr
+  template:
+    metadata:
+      labels:
+        app: overseerr
+        app.kubernetes.io/name: overseerr
+        app.kubernetes.io/instance: overseerr
+    spec:
+      containers:
+      - name: overseerr
+        image: linuxserver/overseerr
+        ports:
+        - containerPort: 5055
+        volumeMounts:
+        - mountPath: /config
+          name: config
+        env:
+        - name: PUID
+          value: '10001'
+        - name: PGID
+          value: '10001'
+        - name: TZ
+          value: EST5EDT
+      volumes:
+      - name: config
+        iscsi:
+          targetPortal: 172.19.74.139
+          iqn: iqn.2000-01.com.synology:fs2.Target-11.05f22bcf4f5
+          lun: 1
+          fsType: ext4
+          chapAuthDiscovery: false
+          chapAuthSession: true
+          secretRef:
+            name: iscsi-chap-secret
+

--- a/kubernetes/overseerr/ingress.yaml
+++ b/kubernetes/overseerr/ingress.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+
+metadata:
+  name: overseerr
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    gethomepage.dev/enabled: 'true'
+    gethomepage.dev/name: Overseerr
+    gethomepage.dev/description: Request Manager
+    gethomepage.dev/group: Media
+    gethomepage.dev/icon: overseerr.png
+
+spec:
+  tls:
+  - hosts:
+    - overseerr.k.oneill.net
+    secretName: overseerr-tls
+  rules:
+  - host: overseerr.k.oneill.net
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: overseerr
+            port:
+              number: 5055
+  ingressClassName: nginx

--- a/kubernetes/overseerr/kustomization.yaml
+++ b/kubernetes/overseerr/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+
+commonAnnotations:
+  argoManaged: 'true'
+
+resources:
+- deployment.yaml
+- service.yaml
+- ingress.yaml
+
+images:
+- name: linuxserver/overseerr
+  newTag: 1.34.0@sha256:f0bb47460bfbcf7c31dad8b62e2546fb336b4b5209a8404a23e77100da0f25f7
+
+labels:
+
+- pairs:
+    app.kubernetes.io/name: overseerr
+    app.kubernetes.io/instance: overseerr
+  includeSelectors: true

--- a/kubernetes/overseerr/service.yaml
+++ b/kubernetes/overseerr/service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: overseerr
+  labels:
+    app: overseerr
+
+spec:
+  ports:
+  - port: 5055
+    targetPort: 5055
+    protocol: TCP
+    name: http
+  selector:
+    app: overseerr
+


### PR DESCRIPTION
- Add Deployment/Service/Ingress under kubernetes/overseerr
- Pin linuxserver/overseerr to 1.34.0 with digest
- Use provided iSCSI IQN for /config volume
- Exclude Authentik component and annotations
