### PR TITLE
Add homepage icon for huntarr

### DIFF
--- a/kubernetes/huntarr/ingress.yaml
+++ b/kubernetes/huntarr/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     gethomepage.dev/name: Huntarr
     gethomepage.dev/description: Missing and Upgrade Hunter
     gethomepage.dev/group: Media
+    gethomepage.dev/icon: huntarr.png
 
 spec:
   tls:


### PR DESCRIPTION
Set huntarr.png as the homepage icon following the same pattern as other *arr services like sonarr and radarr.