### PR TITLE
Set OAUTH_PROVIDER_NAME to Authentik for karakeep

### DIFF
--- a/kubernetes/karakeep/helm/karakeep/common.yaml
+++ b/kubernetes/karakeep/helm/karakeep/common.yaml
@@ -242,6 +242,8 @@ spec:
             value: http://karakeep-meilisearch:7700
           - name: NEXTAUTH_URL
             value: https://karakeep.k.oneill.net
+          - name: OAUTH_PROVIDER_NAME
+            value: Authentik
           - name: OAUTH_WELLKNOWN_URL
             value: https://auth.k.oneill.net/application/o/karakeep/.well-known/openid-configuration
           envFrom:

--- a/kubernetes/karakeep/values.yaml
+++ b/kubernetes/karakeep/values.yaml
@@ -48,6 +48,7 @@ controllers:
                 name: karakeep-postgres-app
                 key: uri
           OAUTH_WELLKNOWN_URL: https://auth.k.oneill.net/application/o/karakeep/.well-known/openid-configuration
+          OAUTH_PROVIDER_NAME: Authentik
           DISABLE_PASSWORD_AUTH: 'true'
           CRAWLER_FULL_PAGE_ARCHIVE: 'true'
           CRAWLER_NUM_WORKERS: '2'


### PR DESCRIPTION
Set the OAuth provider display name in karakeep to 'Authentik' for better user experience in the login interface.