### PR TITLE
Fix ESPHome digest configuration in Renovate

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -186,17 +186,14 @@
       "description": "PostgreSQL major version upgrades require manual review"
     },
     {
-      "matchDatasources": [
-        "docker"
+      "matchManagers": [
+        "custom.regex"
       ],
       "matchPackageNames": [
         "ghcr.io/esphome/esphome"
       ],
-      "matchUpdateTypes": [
-        "digest"
-      ],
-      "enabled": false,
-      "description": "Disable digest updates for ESPHome to avoid unnecessary churn"
+      "pinDigests": false,
+      "description": "Disable digest pinning for ESPHome Docker images managed by custom regex"
     }
   ],
   "gitIgnoredAuthors": [


### PR DESCRIPTION
Replace the previous ineffective rule that disabled 'digest' updates
(which don't apply to our custom regex manager) with the correct
approach using 'pinDigests: false' for the custom.regex manager.

This properly prevents digest pinning for ESPHome Docker images
managed by our custom regex pattern.
