### PR TITLE
Add automated certificate management with acme.sh

### DIFF
--- a/kubernetes/acme-sh/acme-renew.sh
+++ b/kubernetes/acme-sh/acme-renew.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+echo "Starting acme.sh renewal check..."
+
+# Run cron to handle renewal and deployment for all certificates
+echo "Running cron for renewal and deployment..."
+/usr/local/bin/acme.sh --cron
+
+echo "Renewal check completed successfully"

--- a/kubernetes/acme-sh/acme-synology.sh
+++ b/kubernetes/acme-sh/acme-synology.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -e
+
+echo "Starting acme.sh certificate management for fs2.oneill.net"
+
+# Register account with ZeroSSL (will succeed if not already registered)
+echo "Ensuring account is registered with ZeroSSL..."
+/usr/local/bin/acme.sh --register-account \
+  --eab-kid "$ACME_EAB_KID" \
+  --eab-hmac-key "$ACME_EAB_HMAC_KEY" \
+  -m clayton@oneill.net || true
+
+# Check if certificate exists, issue if not
+echo "Checking certificate status..."
+if ! /usr/local/bin/acme.sh --info -d fs2.oneill.net | grep "^Le_" > /dev/null; then
+  echo "Certificate does not exist, issuing new certificate..."
+  if ! /usr/local/bin/acme.sh --issue --dns dns_aws -d fs2.oneill.net; then
+    echo "Certificate issuance failed"
+    exit 1
+  fi
+else
+  echo "Certificate found"
+fi
+
+# Check if deploy hook is set, deploy if not
+echo "Checking deploy hook status..."
+if ! /usr/local/bin/acme.sh --info -d fs2.oneill.net | grep "^Le_DeployHook=" > /dev/null; then
+  echo "Deploy hook not set, deploying certificate..."
+  if ! /usr/local/bin/acme.sh --deploy -d fs2.oneill.net --deploy-hook synology_dsm; then
+    echo "Certificate deployment failed"
+    exit 1
+  fi
+  echo "Certificate deployed successfully"
+else
+  echo "Deploy hook already configured"
+fi
+
+echo "Certificate setup completed successfully"

--- a/kubernetes/acme-sh/acme-udmp.sh
+++ b/kubernetes/acme-sh/acme-udmp.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -e
+
+echo "Starting acme.sh certificate management for UDM Pro"
+
+# Register account with ZeroSSL (will succeed if not already registered)
+echo "Ensuring account is registered with ZeroSSL..."
+/usr/local/bin/acme.sh --register-account \
+  --eab-kid "$ACME_EAB_KID" \
+  --eab-hmac-key "$ACME_EAB_HMAC_KEY" \
+  -m clayton@oneill.net || true
+
+# Check if certificate exists, issue if not
+echo "Checking certificate status..."
+if ! /usr/local/bin/acme.sh --info -d udmp.oneill.net | grep "^Le_" > /dev/null; then
+  echo "Certificate does not exist, issuing new certificate..."
+  if ! /usr/local/bin/acme.sh --issue --dns dns_aws -d udmp.oneill.net -d router.oneill.net -k 2048; then
+    echo "Certificate issuance failed"
+    exit 1
+  fi
+else
+  echo "Certificate found"
+fi
+
+# Check if deploy hook is set, deploy if not
+echo "Checking deploy hook status..."
+if ! /usr/local/bin/acme.sh --info -d udmp.oneill.net | grep "^Le_DeployHook=" > /dev/null; then
+  echo "Deploy hook not set, configuring SSH deployment..."
+
+  # Set up SSH deploy environment variables
+  export DEPLOY_SSH_USER="root"
+  export DEPLOY_SSH_SERVER="udmp.oneill.net"
+
+  # Set SSH key path for root user
+  export HOME=/root
+
+  # Use UnifiOS standard paths (as per official unifi deploy hook)
+  export DEPLOY_SSH_FULLCHAIN="/data/unifi-core/config/unifi-core.crt"
+  export DEPLOY_SSH_KEYFILE="/data/unifi-core/config/unifi-core.key"
+
+  # Remote command following unifi hook logic: backup originals and restart service
+  export DEPLOY_SSH_REMOTE_CMD="
+cd /data/unifi-core/config/;
+[ -f unifi-core.crt ] && [ ! -f unifi-core_original.crt ] && cp unifi-core.crt unifi-core_original.crt;
+[ -f unifi-core.key ] && [ ! -f unifi-core_original.key ] && cp unifi-core.key unifi-core_original.key;
+chmod 600 unifi-core.key;
+chown root:root unifi-core.*;
+systemctl restart unifi-core"
+  export DEPLOY_SSH_MULTI_CALL="yes"
+
+  # Deploy certificate via SSH
+  if ! /usr/local/bin/acme.sh --deploy -d udmp.oneill.net --deploy-hook ssh; then
+    echo "Certificate deployment failed"
+    exit 1
+  fi
+  echo "Certificate deployed successfully"
+else
+  echo "Deploy hook already configured"
+fi
+
+echo "Certificate setup completed successfully"

--- a/kubernetes/acme-sh/cronjob-renew.yaml
+++ b/kubernetes/acme-sh/cronjob-renew.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: acme-renew
+
+spec:
+  schedule: 0 4 * * *
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: acme-sh
+            image: neilpang/acme.sh
+            command: [/bin/sh, /scripts/acme-renew.sh]
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: false
+            volumeMounts:
+            - name: acme-data
+              mountPath: /acme.sh
+            - name: acme-script
+              mountPath: /scripts
+              readOnly: true
+            - name: ssh-key
+              mountPath: /root/.ssh
+              readOnly: true
+            - name: ssh-config
+              mountPath: /etc/ssh/ssh_config
+              subPath: ssh-config
+              readOnly: true
+            resources:
+              requests:
+                memory: 64Mi
+                cpu: 100m
+              limits:
+                memory: 128Mi
+                cpu: 200m
+          volumes:
+          - name: acme-data
+            persistentVolumeClaim:
+              claimName: acme-sh-data
+          - name: acme-script
+            configMap:
+              name: acme-sh-script
+              defaultMode: 0755
+          - name: ssh-key
+            secret:
+              secretName: acme-sh-credentials
+              items:
+              - key: udmp-ssh-key
+                path: id_rsa
+                mode: 0600
+          - name: ssh-config
+            configMap:
+              name: acme-sh-ssh-config
+          restartPolicy: OnFailure

--- a/kubernetes/acme-sh/cronjob-synology.yaml
+++ b/kubernetes/acme-sh/cronjob-synology.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: acme-synology-setup
+
+spec:
+  schedule: 0 3 * * *
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: acme-sh
+            image: neilpang/acme.sh
+            command: [/bin/sh, /scripts/acme-synology.sh]
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: false
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              value: AKIAJKAXEQX5E3OWSFHQ
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: acme-sh-credentials
+                  key: aws-secret-access-key
+            # ZeroSSL EAB credentials
+            - name: ACME_EAB_KID
+              value: 6S0Z-BQZ9KWpl7UzJlR54A
+            - name: ACME_EAB_HMAC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: acme-sh-credentials
+                  key: zerossl-eab-secret
+            # Synology deployment credentials
+            - name: SYNO_Username
+              valueFrom:
+                secretKeyRef:
+                  name: acme-sh-credentials
+                  key: syno-username
+            - name: SYNO_Password
+              valueFrom:
+                secretKeyRef:
+                  name: acme-sh-credentials
+                  key: syno-password
+            - name: SYNO_Scheme
+              value: https
+            - name: SYNO_Hostname
+              value: fs2.oneill.net
+            - name: SYNO_Port
+              value: '5001'
+            volumeMounts:
+            - name: acme-data
+              mountPath: /acme.sh
+            - name: acme-script
+              mountPath: /scripts
+              readOnly: true
+            resources:
+              requests:
+                memory: 64Mi
+                cpu: 100m
+              limits:
+                memory: 128Mi
+                cpu: 200m
+          volumes:
+          - name: acme-data
+            persistentVolumeClaim:
+              claimName: acme-sh-data
+          - name: acme-script
+            configMap:
+              name: acme-sh-script
+              defaultMode: 0755
+          restartPolicy: OnFailure

--- a/kubernetes/acme-sh/cronjob-udmp.yaml
+++ b/kubernetes/acme-sh/cronjob-udmp.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: acme-udmp-setup
+
+spec:
+  schedule: 0 3 * * *
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: acme-sh
+            image: neilpang/acme.sh
+            command: [/bin/sh, /scripts/acme-udmp.sh]
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: false
+            env:
+                # AWS Route53 credentials (same as cert-manager)
+            - name: AWS_ACCESS_KEY_ID
+              value: AKIAJKAXEQX5E3OWSFHQ
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: acme-sh-credentials
+                  key: aws-secret-access-key
+                # ZeroSSL EAB credentials
+            - name: ACME_EAB_KID
+              value: 6S0Z-BQZ9KWpl7UzJlR54A
+            - name: ACME_EAB_HMAC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: acme-sh-credentials
+                  key: zerossl-eab-secret
+                # UDM Pro hostname (SSH key auth used for deployment)
+            - name: UDMP_Hostname
+              value: udmp.oneill.net
+            volumeMounts:
+            - name: acme-data
+              mountPath: /acme.sh
+            - name: acme-script
+              mountPath: /scripts
+              readOnly: true
+            - name: ssh-key
+              mountPath: /root/.ssh
+              readOnly: true
+            - name: ssh-config
+              mountPath: /etc/ssh/ssh_config
+              subPath: ssh-config
+              readOnly: true
+            resources:
+              requests:
+                memory: 64Mi
+                cpu: 100m
+              limits:
+                memory: 128Mi
+                cpu: 200m
+          volumes:
+          - name: acme-data
+            persistentVolumeClaim:
+              claimName: acme-sh-data
+          - name: acme-script
+            configMap:
+              name: acme-sh-script
+              defaultMode: 0755
+          - name: ssh-key
+            secret:
+              secretName: acme-sh-credentials
+              items:
+              - key: udmp-ssh-key
+                path: id_rsa
+                mode: 0600
+          - name: ssh-config
+            configMap:
+              name: acme-sh-ssh-config
+          restartPolicy: OnFailure

--- a/kubernetes/acme-sh/externalsecret.yaml
+++ b/kubernetes/acme-sh/externalsecret.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+  name: acme-sh-credentials
+
+spec:
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  target:
+    name: acme-sh-credentials
+  data:
+  - secretKey: syno-username
+    remoteRef:
+      key: synology-acme
+      property: username
+  - secretKey: syno-password
+    remoteRef:
+      key: synology-acme
+      property: password
+  - secretKey: aws-secret-access-key
+    remoteRef:
+      key: cert-manager
+      property: aws-secret-access-key
+  - secretKey: zerossl-eab-secret
+    remoteRef:
+      key: cert-manager
+      property: zerossl-eab-secret
+  - secretKey: udmp-ssh-key
+    remoteRef:
+      key: udmp-acme
+      property: udmp-acme.key

--- a/kubernetes/acme-sh/kustomization.yaml
+++ b/kubernetes/acme-sh/kustomization.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: acme-sh
+
+resources:
+- namespace.yaml
+- pvc.yaml
+- externalsecret.yaml
+- cronjob-synology.yaml
+- cronjob-udmp.yaml
+- cronjob-renew.yaml
+
+configMapGenerator:
+- name: acme-sh-script
+  files:
+  - acme-synology.sh
+  - acme-udmp.sh
+  - acme-renew.sh
+  options:
+    disableNameSuffixHash: true
+- name: acme-sh-ssh-config
+  files:
+  - ssh-config
+  options:
+    disableNameSuffixHash: true
+
+images:
+- name: neilpang/acme.sh
+  newTag: 3.1.0

--- a/kubernetes/acme-sh/kustomization.yaml
+++ b/kubernetes/acme-sh/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 
 namespace: acme-sh
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - namespace.yaml
 - pvc.yaml

--- a/kubernetes/acme-sh/namespace.yaml
+++ b/kubernetes/acme-sh/namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: acme-sh

--- a/kubernetes/acme-sh/pvc.yaml
+++ b/kubernetes/acme-sh/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
 
 spec:
   accessModes:
-  - ReadWriteOnce
+  - ReadWriteOncePod
   resources:
     requests:
       storage: 1Gi

--- a/kubernetes/acme-sh/pvc.yaml
+++ b/kubernetes/acme-sh/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+
+metadata:
+  name: acme-sh-data
+
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/acme-sh/ssh-config
+++ b/kubernetes/acme-sh/ssh-config
@@ -1,0 +1,3 @@
+Host *
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null


### PR DESCRIPTION
- Set up acme.sh for automatic certificate issuance and deployment
- Support for Synology NAS (fs2.oneill.net) via Synology DSM API
- Support for UDM Pro (udmp.oneill.net + router.oneill.net SAN) via SSH
- ZeroSSL ACME provider with EAB authentication
- Route53 DNS validation for all certificates
- Daily certificate setup checks (3 AM) and renewal (4 AM)
- External Secrets integration with 1Password
