### PR TITLE
Add docker-registry-proxy with containerd integration

### DIFF
--- a/ansible/group_vars/kubernetes.yaml
+++ b/ansible/group_vars/kubernetes.yaml
@@ -1,5 +1,12 @@
 ---
 
+# Enable docker-registry-proxy for containerd
+# Set to false when bootstrapping cluster or if proxy is unavailable
+enable_docker_registry_proxy: true
+
+# Docker registry proxy configuration (external-dns will create DNS record)
+docker_registry_proxy_url: "http://docker-proxy.k.oneill.net:3128"
+
 kernel_parameters: "nofb vga=normal"
 
 node_exporter_enabled: true

--- a/ansible/roles/containerd-registry-proxy/handlers/main.yaml
+++ b/ansible/roles/containerd-registry-proxy/handlers/main.yaml
@@ -1,0 +1,26 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+  become: true
+
+- name: Restart containerd
+  ansible.builtin.systemd:
+    name: containerd
+    state: restarted
+  become: true
+
+- name: Add proxy CA certificate to ca-certificates.conf
+  ansible.builtin.lineinfile:
+    path: /etc/ca-certificates.conf
+    line: "docker_registry_proxy.crt"
+    create: true
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  notify: Update CA certificates
+
+- name: Update CA certificates
+  ansible.builtin.command: update-ca-certificates --fresh
+  become: true

--- a/ansible/roles/containerd-registry-proxy/tasks/main.yaml
+++ b/ansible/roles/containerd-registry-proxy/tasks/main.yaml
@@ -1,0 +1,35 @@
+---
+# Configure containerd to use docker-registry-proxy via HTTPS_PROXY
+- name: Create containerd systemd service.d directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/containerd.service.d
+    state: directory
+    mode: "0755"
+    owner: root
+    group: root
+  become: true
+
+- name: Download CA certificate from docker-registry-proxy
+  ansible.builtin.get_url:
+    url: "{{ docker_registry_proxy_url }}/ca.crt"
+    dest: /usr/share/ca-certificates/docker_registry_proxy.crt
+    mode: "0644"
+    owner: root
+    group: root
+  become: true
+  notify: Add proxy CA certificate to ca-certificates.conf
+
+- name: Configure containerd systemd service environment
+  ansible.builtin.copy:
+    content: |
+      [Service]
+      Environment="HTTPS_PROXY={{ docker_registry_proxy_url }}/"
+      Environment="HTTP_PROXY={{ docker_registry_proxy_url }}/"
+    dest: /etc/systemd/system/containerd.service.d/http-proxy.conf
+    mode: "0644"
+    owner: root
+    group: root
+  become: true
+  notify:
+    - Reload systemd
+    - Restart containerd

--- a/ansible/site.yaml
+++ b/ansible/site.yaml
@@ -96,6 +96,9 @@
   roles:
     - role: kubeadm
       tags: kubernetes
+    - role: containerd-registry-proxy
+      when: enable_docker_registry_proxy | default(false) | bool
+      tags: [kubernetes, containerd, registry-proxy]
 
 - name: Prometheus node exporter
   hosts: all

--- a/kubernetes/docker-registry-proxy/configmap.yaml
+++ b/kubernetes/docker-registry-proxy/configmap.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: docker-registry-proxy-config
+
+data:
+  REGISTRIES: quay.io ghcr.io registry.k8s.io gcr.io us-docker.pkg.dev oci.external-secrets.io
+  ENABLE_MANIFEST_CACHE: 'true'

--- a/kubernetes/docker-registry-proxy/deployment.yaml
+++ b/kubernetes/docker-registry-proxy/deployment.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: docker-registry-proxy
+  annotations:
+    reloader.stakater.com/auto: 'true'
+
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: docker-registry-proxy
+      app.kubernetes.io/instance: docker-registry-proxy
+  template:
+    metadata:
+      name: docker-registry-proxy
+      labels:
+        app.kubernetes.io/name: docker-registry-proxy
+        app.kubernetes.io/instance: docker-registry-proxy
+    spec:
+      containers:
+      - name: docker-registry-proxy
+        image: ghcr.io/rpardini/docker-registry-proxy:0.6.5
+        ports:
+        - name: proxy
+          containerPort: 3128
+        envFrom:
+        - configMapRef:
+            name: docker-registry-proxy-config
+        volumeMounts:
+        - name: cache-volume
+          mountPath: /docker_mirror_cache
+        - name: ca-certs
+          mountPath: /ca
+        resources:
+          requests:
+            cpu: 500m
+            memory: 1Gi
+          limits:
+            cpu: '2'
+            memory: 4Gi
+      volumes:
+      - name: cache-volume
+        persistentVolumeClaim:
+          claimName: docker-registry-proxy-cache
+      - name: ca-certs
+        persistentVolumeClaim:
+          claimName: docker-registry-proxy-ca

--- a/kubernetes/docker-registry-proxy/kustomization.yaml
+++ b/kubernetes/docker-registry-proxy/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: docker-registry-proxy
+
+resources:
+- namespace.yaml
+- pvc.yaml
+- configmap.yaml
+- deployment.yaml
+- service.yaml

--- a/kubernetes/docker-registry-proxy/namespace.yaml
+++ b/kubernetes/docker-registry-proxy/namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: docker-registry-proxy

--- a/kubernetes/docker-registry-proxy/pvc.yaml
+++ b/kubernetes/docker-registry-proxy/pvc.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+
+metadata:
+  name: docker-registry-proxy-cache
+
+spec:
+  accessModes:
+  - ReadWriteOncePod
+  resources:
+    requests:
+      storage: 50Gi
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+
+metadata:
+  name: docker-registry-proxy-ca
+
+spec:
+  accessModes:
+  - ReadWriteOncePod
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/docker-registry-proxy/service.yaml
+++ b/kubernetes/docker-registry-proxy/service.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: docker-registry-proxy
+  labels:
+    app.kubernetes.io/name: docker-registry-proxy
+    app.kubernetes.io/instance: docker-registry-proxy
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: docker-proxy.k.oneill.net
+
+spec:
+  selector:
+    app.kubernetes.io/name: docker-registry-proxy
+    app.kubernetes.io/instance: docker-registry-proxy
+  ports:
+  - port: 3128
+    targetPort: 3128
+    protocol: TCP
+    name: proxy
+  type: LoadBalancer


### PR DESCRIPTION
• Deploy rpardini/docker-registry-proxy as LoadBalancer service
• Add Ansible role to configure containerd with HTTPS_PROXY
• Automatically download and install proxy CA certificate
• Configure external DNS for docker-proxy.k.oneill.net
• Add toggle in kubernetes.yaml to enable/disable proxy
