### PR TITLE
Add discard mount option to synology-iscsi storage class

### DIFF
--- a/kubernetes/democratic-csi/helm/templates/storage-classes.yaml
+++ b/kubernetes/democratic-csi/helm/templates/storage-classes.yaml
@@ -18,6 +18,8 @@ parameters:
   fsType: "ext4"
 
 # this loop is deeply connected to the loop for Secret creation below
+mountOptions:
+- discard
 
 
 # this loop is deeply connected to the loop for secret parameter settings above

--- a/kubernetes/democratic-csi/values.yaml
+++ b/kubernetes/democratic-csi/values.yaml
@@ -27,6 +27,8 @@ storageClasses:
   allowVolumeExpansion: true
   parameters:
     fsType: ext4
+  mountOptions:
+  - discard
 
 volumeSnapshotClasses:
 - name: synology-iscsi-snapshots


### PR DESCRIPTION
Enable TRIM/discard support for iSCSI volumes to allow the filesystem to release unused blocks back to the storage array. This improves space efficiency on thin-provisioned LUNs.
