### PR TITLE
Enable lockFileMaintenance for Nix flake.lock updates

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -21,6 +21,9 @@
   "nix": {
     "enabled": true
   },
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -136,6 +139,12 @@
         "nix",
         "automerge"
       ],
+      "lockFileMaintenance": {
+        "enabled": true,
+        "schedule": [
+          "before 6am on monday"
+        ]
+      },
       "description": "Auto-merge Nix (flake.lock) updates if CI passes"
     },
     {


### PR DESCRIPTION
Configure Renovate to refresh flake.lock weekly via lockFileMaintenance, scoped only to the nix manager. This keeps nixpkgs and other flake inputs up to date without affecting other lock files.

Fixes #475
