### PR TITLE
Fix Nix lockFileMaintenance configuration

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -2,6 +2,7 @@
   "extends": [
     "config:best-practices"
   ],
+  "timezone": "America/New_York",
   "schedule": [
     "before 6am on monday"
   ],
@@ -22,7 +23,7 @@
     "enabled": true
   },
   "lockFileMaintenance": {
-    "enabled": false
+    "enabled": true
   },
   "customManagers": [
     {
@@ -85,6 +86,13 @@
   ],
   "packageRules": [
     {
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "enabled": false,
+      "description": "Disable lockFileMaintenance globally (re-enabled per-manager below)"
+    },
+    {
       "matchDatasources": [
         "helm"
       ],
@@ -132,6 +140,10 @@
       "matchManagers": [
         "nix"
       ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "enabled": true,
       "minimumReleaseAge": "0 days",
       "automerge": true,
       "automergeType": "pr",
@@ -139,13 +151,7 @@
         "nix",
         "automerge"
       ],
-      "lockFileMaintenance": {
-        "enabled": true,
-        "schedule": [
-          "before 6am on monday"
-        ]
-      },
-      "description": "Auto-merge Nix (flake.lock) updates if CI passes"
+      "description": "Enable and auto-merge Nix flake.lock maintenance if CI passes"
     },
     {
       "matchDatasources": [


### PR DESCRIPTION
Correctly configure lockFileMaintenance for Nix flake.lock updates:
- Enable lockFileMaintenance at top level (required)
- Disable globally via packageRule with matchUpdateTypes
- Re-enable only for nix manager with matchUpdateTypes
- Add timezone: America/New_York for ET scheduling
- Fix flake.nix: github:NixOS/nixpkgs (capital letters) to work around Renovate detection bug

The previous configuration had lockFileMaintenance inside a packageRule which is ignored by Renovate. This fixes that issue.

Fixes #475
