### PR TITLE
Replace Renovate Nix with update-flake-lock action

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -1,0 +1,35 @@
+---
+name: Update Nix Flake Lock
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 5am UTC Monday = midnight ET Monday (matches Renovate schedule)
+  - cron: 0 5 * * 1
+
+jobs:
+  update-flake-lock:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5
+
+    - name: Install Nix
+      uses: DeterminateSystems/determinate-nix-action@2b30e20d523cfa36118f26933c9ec8dcf75cc8d3  # v3
+
+    - name: Update flake.lock
+      uses: DeterminateSystems/update-flake-lock@v27
+      id: update-flake-lock
+      with:
+        token: ${{ secrets.PAT }}
+        pr-title: Update Nix flake inputs
+        pr-labels: |-
+          nix
+          automerge
+
+    - name: Enable automerge
+      if: steps.update-flake-lock.outputs.pull-request-number != ''
+      run: gh pr merge --auto --rebase "${{ steps.update-flake-lock.outputs.pull-request-number }}"
+      env:
+        GH_TOKEN: ${{ secrets.PAT }}

--- a/.renovaterc
+++ b/.renovaterc
@@ -19,9 +19,6 @@
   "pre-commit": {
     "enabled": true
   },
-  "nix": {
-    "enabled": true
-  },
   "lockFileMaintenance": {
     "enabled": true
   },
@@ -135,23 +132,6 @@
         "automerge"
       ],
       "description": "Auto-merge Docker image digest updates in Kubernetes if CI passes"
-    },
-    {
-      "matchManagers": [
-        "nix"
-      ],
-      "matchUpdateTypes": [
-        "lockFileMaintenance"
-      ],
-      "enabled": true,
-      "minimumReleaseAge": "0 days",
-      "automerge": true,
-      "automergeType": "pr",
-      "addLabels": [
-        "nix",
-        "automerge"
-      ],
-      "description": "Enable and auto-merge Nix flake.lock maintenance if CI passes"
     },
     {
       "matchDatasources": [


### PR DESCRIPTION
Disable Renovate's Nix manager and use DeterminateSystems/update-flake-lock instead:
- Disable nix in Renovate config
- Remove nix lockFileMaintenance packageRule
- Add GitHub workflow that runs weekly (Monday midnight ET) or manually
- Uses existing PAT secret for CI triggering
- Automatically enables automerge on created PRs

Closes #475
