### PR TITLE
Fix production deployment queue to prevent cancellations

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -7,13 +7,6 @@ on:
     paths: [kubernetes/**]
   workflow_dispatch:
 
-permissions:
-  contents: read
-
-concurrency:
-  group: argocd-production-deploy
-  cancel-in-progress: false
-
 jobs:
   production-deploy:
     runs-on: ubuntu-latest
@@ -22,6 +15,9 @@ jobs:
       ARGOCD_OPTS: --grpc-web
 
     steps:
+    - name: Wait for previous deployments
+      uses: softprops/turnstyle@9d692f15fa9f84928799bccac2dba6565e024bdf  # v3.2.0
+
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5
       with:


### PR DESCRIPTION
Replace concurrency group with Turnstyle action to ensure all
deployments run sequentially without cancellation. This is critical
since each deployment only deploys changed apps - canceling runs would
skip deploying those changes entirely.
