### PR TITLE
Switch from gpt-5 to gpt-4o for AI inference

### DIFF
--- a/.github/workflows/renovate-chart-analysis.yaml
+++ b/.github/workflows/renovate-chart-analysis.yaml
@@ -104,7 +104,7 @@ jobs:
       id: ai-analysis
       uses: actions/ai-inference@v1
       with:
-        model: gpt-5
+        model: gpt-4o
         prompt: |
           You are analyzing Helm Chart changes from a Renovate dependency update pull request.
 


### PR DESCRIPTION
The actions/ai-inference@v1 action doesn't yet support GPT-5's new
max_completion_tokens parameter, causing API errors. Switch to gpt-4o
which is confirmed to work with the action.
