### PR TITLE
Use response-file output to avoid bash variable expansion issues

### DIFF
--- a/.github/workflows/renovate-chart-analysis.yaml
+++ b/.github/workflows/renovate-chart-analysis.yaml
@@ -157,17 +157,14 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |-
-        ANALYSIS="${{ steps.ai-analysis.outputs.response }}"
-
-        # Create comment body
-        cat > /tmp/comment.md <<EOF
-        ## 🤖 Chart.yaml Change Analysis
-
-        $ANALYSIS
-
-        ---
-        *This analysis was automatically generated using AI to help reviewers understand the scope of changes.*
-        EOF
+        {
+          echo "## 🤖 Chart.yaml Change Analysis"
+          echo ""
+          cat "${{ steps.ai-analysis.outputs.response-file }}"
+          echo ""
+          echo "---"
+          echo "*This analysis was automatically generated using AI to help reviewers understand the scope of changes.*"
+        } > /tmp/comment.md
 
         # Post or update comment
         gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/comment.md --edit-last || \


### PR DESCRIPTION
The AI response contains multi-line text with special characters that
breaks bash heredoc syntax when expanded via GitHub Actions expressions.
Use the response-file output from ai-inference action instead to safely
read the AI response from a file.
