### PR TITLE
Add AI-powered Helm chart analysis with OpenAI integration

### DIFF
--- a/.github/workflows/renovate-chart-analysis.yaml
+++ b/.github/workflows/renovate-chart-analysis.yaml
@@ -42,127 +42,21 @@ jobs:
           chart-files:
             - 'kubernetes/**/Chart.yaml'
 
-    - name: Get Chart.yaml and rendered template diffs
-      if: steps.chart-changes.outputs.chart-files == 'true'
-      id: get-diffs
-      run: |
-        BASE_SHA=${{ github.event.pull_request.base.sha }}
-        HEAD_SHA=${{ github.event.pull_request.head.sha }}
-
-        echo "Collecting Chart.yaml and helm/ changes..."
-
-        # Create a comprehensive diff that includes both Chart.yaml and rendered templates
-        DIFF_CONTENT=""
-        DIFF_CONTENT+="# Chart.yaml Changes"$'\n\n'
-
-        git diff --name-only $BASE_SHA $HEAD_SHA | grep 'Chart.yaml$' | while read -r file; do
-          echo "## $file"
-          echo ""
-          echo '```diff'
-          git diff $BASE_SHA $HEAD_SHA -- "$file"
-          echo '```'
-          echo ""
-        done > /tmp/chart-changes.txt
-
-        DIFF_CONTENT+="$(cat /tmp/chart-changes.txt)"
-
-        DIFF_CONTENT+=$'\n\n'"# Rendered Helm Template Changes"$'\n\n'
-
-        # For each changed Chart.yaml, show the corresponding helm/ directory changes
-        git diff --name-only $BASE_SHA $HEAD_SHA | grep 'Chart.yaml$' | while read -r chart_file; do
-          chart_dir=$(dirname "$chart_file")
-          helm_dir="$chart_dir/helm"
-
-          if [ -d "$helm_dir" ]; then
-            echo "## Changes in $helm_dir/"
-            echo ""
-
-            # Get stats first
-            echo "### Summary of template changes:"
-            git diff --stat $BASE_SHA $HEAD_SHA -- "$helm_dir" || echo "No changes in helm/ directory"
-            echo ""
-
-            # Show a sample of actual changes (first 100 lines to avoid overwhelming the AI)
-            echo "### Sample of template diffs (first 100 lines):"
-            echo '```diff'
-            git diff $BASE_SHA $HEAD_SHA -- "$helm_dir" | head -100
-            echo '```'
-            echo ""
-          fi
-        done > /tmp/helm-changes.txt
-
-        DIFF_CONTENT+="$(cat /tmp/helm-changes.txt)"
-
-        # Save to output for the AI step (use multiline output format)
-        echo "diff-content<<EOF" >> "$GITHUB_OUTPUT"
-        echo "$DIFF_CONTENT" >> "$GITHUB_OUTPUT"
-        echo "EOF" >> "$GITHUB_OUTPUT"
-
-        # Check if we have any diffs
-        if [ -n "$DIFF_CONTENT" ]; then
-          echo "has-diffs=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "has-diffs=false" >> "$GITHUB_OUTPUT"
-        fi
-
     - name: Analyze changes with AI
-      if: steps.get-diffs.outputs.has-diffs == 'true'
+      if: steps.chart-changes.outputs.chart-files == 'true'
       id: ai-analysis
-      uses: actions/ai-inference@a1c11829223a786afe3b5663db904a3aa1eac3a2  # v2
-      with:
-        model: gpt-4o
-        prompt: |
-          You are analyzing Helm Chart changes from a Renovate dependency update pull request.
-
-          This repository uses a GitOps approach where Helm charts are pre-rendered into static YAML
-          manifests stored in helm/ directories. When Chart.yaml is updated (usually a version bump),
-          the render script regenerates all the templates in helm/, which can result in many file changes.
-
-          Your task is to determine if the changes are:
-          1. **ROUTINE** - Only version/hash updates in Chart.yaml, and the helm/ template changes are
-             only metadata updates (labels, annotations, helm chart version references) that don't
-             change the actual deployed resources or configuration.
-          2. **SIGNIFICANT** - Changes that affect what gets deployed, including:
-             - Image tag changes (new versions of deployed applications)
-             - New dependencies or removed dependencies
-             - Changes to repository URLs
-             - Structural changes to deployed resources
-             - New or removed Kubernetes resources
-             - Changes to resource configurations (replicas, limits, etc.)
-             - Breaking changes or deprecations
-             - Security-relevant changes
-
-          Respond EXACTLY in this format (include the emoji but minimal markdown):
-
-          🟢 ROUTINE
-
-          [1-2 sentences describing what changed]
-
-          OR
-
-          🔴 SIGNIFICANT
-
-          [Brief intro sentence, then list the key changes as bullet points with details]
-          - Change 1: [describe what changed and why it matters]
-          - Change 2: [describe what changed and why it matters]
-          - etc.
-
-          IMPORTANT: Do not use bold (**), italics (*), headers (#), or code blocks in your response.
-          For ROUTINE changes: 1-2 sentence plain text description.
-          For SIGNIFICANT changes: intro sentence + detailed bullet points explaining what changed and impact.
-
-          ---
-
-          Here are the changes to review:
-
-          ${{ steps.get-diffs.outputs.diff-content }}
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        python3 scripts/analyze-chart-changes.py
 
     - name: Post analysis comment and apply labels
-      if: steps.get-diffs.outputs.has-diffs == 'true'
+      if: steps.ai-analysis.outputs.response != ''
       env:
         GH_TOKEN: ${{ github.token }}
         AI_RESPONSE: ${{ steps.ai-analysis.outputs.response }}
-        DIFF_CONTENT: ${{ steps.get-diffs.outputs.diff-content }}
+        DIFF_CONTENT: ${{ steps.ai-analysis.outputs.diff-content }}
       run: |-
         # Create comment
         {

--- a/kubernetes/karakeep/externalsecret.yaml
+++ b/kubernetes/karakeep/externalsecret.yaml
@@ -20,8 +20,7 @@ spec:
       property: nextauth_secret
   - secretKey: OPENAI_API_KEY
     remoteRef:
-      key: karakeep
-      property: openai_api_key
+      key: karakeep-openai-api-key
   - secretKey: PROMETHEUS_AUTH_TOKEN
     remoteRef:
       key: karakeep

--- a/kubernetes/karakeep/helm/karakeep/common.yaml
+++ b/kubernetes/karakeep/helm/karakeep/common.yaml
@@ -203,6 +203,7 @@ spec:
     metadata:
       annotations: 
         checksum/secrets: 142519ce4ec524bde8adda3fc765d9968ce7a4b024b37b9ca1c0231899e2cefc
+        reloader.stakater.com/auto: "true"
       labels: 
         app.kubernetes.io/component: karakeep
         app.kubernetes.io/instance: karakeep

--- a/kubernetes/karakeep/values.yaml
+++ b/kubernetes/karakeep/values.yaml
@@ -39,6 +39,9 @@ secrets:
 
 controllers:
   karakeep:
+    pod:
+      annotations:
+        reloader.stakater.com/auto: 'true'
     containers:
       karakeep:
         env:
@@ -71,6 +74,3 @@ meilisearch:
   persistence:
     enabled: true
     size: 10Gi
-
-podAnnotations:
-  reloader.stakater.com/auto: 'true'

--- a/opentofu/.terraform.lock.hcl
+++ b/opentofu/.terraform.lock.hcl
@@ -182,3 +182,18 @@ provider "registry.opentofu.org/vultr/vultr" {
     "zh:ff6ffae0eed9953dd68939f484460a58670c881fb9b7d828352b142dced662f7",
   ]
 }
+
+provider "registry.terraform.io/mkdev-me/openai" {
+  version     = "1.1.1"
+  constraints = "~> 1.1"
+  hashes = [
+    "h1:o6T0Bt/hsMRT3urwMYX2p+rUdE5OrtiiKH+B8bnSB+A=",
+    "h1:wnSuwFinWx5OloHZ27b91VmYajNpEWboMxh1phQG6Sg=",
+    "zh:04b1688746ada1bf61653227d55f08d88452478f6b554dab4462e92746de725b",
+    "zh:107f7798b9556b2048eeffce6543f829c43e57336a127485fa3e8345f8d3fa11",
+    "zh:3d74d1143a58a664b61ef242dc871bc8b905730ab5eff8de8a736423898e5382",
+    "zh:4f70ef117972a695c15607d77954f483f307702766875b9f32a8b6ea6f88a381",
+    "zh:6ee0a9268635914b70ec1cba40b3b3181c51f8365b58f0cdca1177f760d3b79f",
+    "zh:77be78b52b1b3714ff071398f0b5a356dfa3868fbecdf7d7ea1f46f408c95bba",
+  ]
+}

--- a/opentofu/main.tf
+++ b/opentofu/main.tf
@@ -30,6 +30,10 @@ terraform {
       source  = "goauthentik/authentik"
       version = "~> 2025.8.0"
     }
+    openai = {
+      source  = "registry.terraform.io/mkdev-me/openai"
+      version = "~> 1.1"
+    }
   }
 
   backend "s3" {
@@ -71,6 +75,10 @@ provider "tailscale" {
 
 provider "github" {
   token = local.github_token
+}
+
+provider "openai" {
+  api_key = local.openai_api_key
 }
 
 module "dns" {

--- a/opentofu/openai.tf
+++ b/opentofu/openai.tf
@@ -1,0 +1,61 @@
+# List all projects to find the default project
+data "openai_projects" "all" {}
+
+# Find the default project (usually named "Default project")
+locals {
+  default_project = try(
+    [
+      for project in data.openai_projects.all.projects :
+      project if project.name == "Default project"
+    ][0],
+    null
+  )
+}
+
+# Validate that we found the default project
+resource "terraform_data" "validate_default_project" {
+  lifecycle {
+    precondition {
+      condition     = local.default_project != null
+      error_message = "Could not find 'Default project' in OpenAI projects. Available projects: ${join(", ", [for p in data.openai_projects.all.projects : p.name])}"
+    }
+  }
+}
+
+# Service account for GitHub Actions in the default project
+# This automatically creates an API key that can be used by the renovate-chart-analysis workflow
+resource "openai_project_service_account" "github_actions" {
+  project_id = local.default_project.id
+  name       = "github-actions-chart-analysis"
+}
+
+# Store the API key in 1Password
+resource "onepassword_item" "openai_github_actions" {
+  vault    = data.onepassword_vault.infra.uuid
+  title    = "openai-github-actions"
+  category = "password"
+
+  password = openai_project_service_account.github_actions.api_key_value
+}
+
+# Store the API key in GitHub Actions secrets
+resource "github_actions_secret" "openai_api_key" {
+  repository      = "infra"
+  secret_name     = "OPENAI_API_KEY"
+  plaintext_value = openai_project_service_account.github_actions.api_key_value
+}
+
+# Service account for karakeep application
+resource "openai_project_service_account" "karakeep" {
+  project_id = local.default_project.id
+  name       = "karakeep"
+}
+
+# Store the karakeep OpenAI API key in its own 1Password item
+resource "onepassword_item" "karakeep_openai" {
+  vault    = data.onepassword_vault.infra.uuid
+  title    = "karakeep-openai-api-key"
+  category = "password"
+
+  password = openai_project_service_account.karakeep.api_key_value
+}

--- a/opentofu/secrets.tf
+++ b/opentofu/secrets.tf
@@ -39,6 +39,12 @@ data "onepassword_item" "cachix_auth_token" {
   title = "cachix-auth-token"
 }
 
+# OpenAI admin API key from 1Password (for managing API keys)
+data "onepassword_item" "openai_admin_api" {
+  vault = data.onepassword_vault.infra.uuid
+  title = "terraform-openai-admin-key"
+}
+
 # Clean field mapping for B2 credentials
 locals {
   b2_fields = {
@@ -68,6 +74,9 @@ locals {
 
   # GitHub token for managing repository secrets
   github_token = data.onepassword_item.github_opentofu.password
+
+  # OpenAI admin API key for managing API keys
+  openai_api_key = data.onepassword_item.openai_admin_api.password
 }
 
 # Authentik credentials from 1Password (used to configure provider)

--- a/scripts/analyze-chart-changes.py
+++ b/scripts/analyze-chart-changes.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""
+Analyze Helm Chart.yaml changes using OpenAI's API.
+
+This script analyzes Chart.yaml and rendered Helm template changes to determine
+if they are routine (metadata/version updates) or significant (functional changes).
+
+Can be run in GitHub Actions or standalone for testing.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+import urllib.error
+from typing import Optional
+
+
+def exponential_backoff_retry(
+    func, max_attempts: int = 5, base_wait: int = 10, max_wait: int = 300
+):
+    """
+    Retry a function with exponential backoff.
+
+    Args:
+        func: Function to retry
+        max_attempts: Maximum number of retry attempts
+        base_wait: Base wait time in seconds
+        max_wait: Maximum wait time in seconds
+
+    Returns:
+        Result from successful function call
+
+    Raises:
+        Last exception if all retries fail
+    """
+    for attempt in range(max_attempts):
+        try:
+            return func()
+        except Exception as e:
+            if attempt == max_attempts - 1:
+                raise
+
+            wait_time = min(base_wait * (2**attempt), max_wait)
+            print(
+                f"Attempt {attempt + 1} failed: {e}",
+                file=sys.stderr,
+            )
+            print(f"Retrying in {wait_time} seconds...", file=sys.stderr)
+            time.sleep(wait_time)
+
+
+def get_chart_diffs(pr_number: Optional[int] = None) -> str:
+    """
+    Get diffs for Chart.yaml files and corresponding helm/ directories.
+
+    Args:
+        pr_number: PR number to get diffs for (optional, for standalone mode)
+
+    Returns:
+        Formatted diff content with Chart.yaml and helm/ changes
+    """
+    # Get full diff using gh pr diff
+    cmd = ["gh", "pr", "diff"]
+    if pr_number:
+        cmd.append(str(pr_number))
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    full_diff = result.stdout
+
+    # Parse the diff to extract Chart.yaml and helm/ changes
+    diff_content = "# Chart.yaml Changes\n\n"
+
+    lines = full_diff.splitlines()
+    i = 0
+    chart_files = []
+    helm_sections = []
+
+    while i < len(lines):
+        line = lines[i]
+
+        # Look for diff headers for Chart.yaml files
+        if line.startswith("diff --git") and "Chart.yaml" in line:
+            # Extract filename
+            parts = line.split()
+            filename = parts[2].replace("a/", "")
+            chart_files.append(filename)
+
+            # Collect this diff section
+            diff_section = []
+            i += 1
+            while i < len(lines) and not lines[i].startswith("diff --git"):
+                diff_section.append(lines[i])
+                i += 1
+
+            diff_content += f"## {filename}\n\n"
+            diff_content += "```diff\n"
+            diff_content += "\n".join(diff_section)
+            diff_content += "\n```\n\n"
+            continue
+
+        # Look for diff headers for helm/ directories
+        elif line.startswith("diff --git") and "/helm/" in line:
+            # Collect helm diff sections
+            helm_section = [line]
+            i += 1
+            while i < len(lines) and not lines[i].startswith("diff --git"):
+                helm_section.append(lines[i])
+                i += 1
+            helm_sections.append(helm_section)
+            continue
+
+        i += 1
+
+    # Add helm template changes summary
+    if helm_sections:
+        diff_content += "\n# Rendered Helm Template Changes\n\n"
+        diff_content += (
+            f"### Summary: {len(helm_sections)} template file(s) changed\n\n"
+        )
+
+        # Show first 100 lines of helm changes as sample
+        diff_content += "### Sample of template diffs (first 100 lines):\n"
+        diff_content += "```diff\n"
+
+        all_helm_lines = []
+        for section in helm_sections:
+            all_helm_lines.extend(section)
+
+        sample_lines = all_helm_lines[:100]
+        diff_content += "\n".join(sample_lines)
+        diff_content += "\n```\n\n"
+
+    return diff_content
+
+
+def get_openai_api_key() -> str:
+    """
+    Get OpenAI API key from environment variable or 1Password.
+
+    Returns:
+        OpenAI API key
+
+    Raises:
+        ValueError: If API key cannot be found
+    """
+    # Try environment variable first
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if api_key:
+        return api_key
+
+    # Try 1Password CLI if available
+    try:
+        result = subprocess.run(
+            ["op", "read", "op://infra/openai-github-actions/password"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        api_key = result.stdout.strip()
+        if api_key:
+            return api_key
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # op command not available or failed
+        pass
+
+    raise ValueError(
+        "OPENAI_API_KEY not found. Set OPENAI_API_KEY environment variable or "
+        "ensure 'op' CLI is installed and configured with access to "
+        "op://infra/openai-github-actions/password"
+    )
+
+
+def call_openai_api(prompt: str, api_key: str, model: str = "gpt-5") -> str:
+    """
+    Call OpenAI API with the given prompt.
+
+    Args:
+        prompt: The prompt to send to the AI
+        api_key: OpenAI API key
+        model: The model to use (default: gpt-5)
+
+    Returns:
+        AI response content
+
+    Raises:
+        urllib.error.HTTPError: If API call fails
+        KeyError: If response format is unexpected
+    """
+    url = "https://api.openai.com/v1/chat/completions"
+
+    data = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(data).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req) as response:
+            response_data = json.loads(response.read().decode("utf-8"))
+            return response_data["choices"][0]["message"]["content"]
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode("utf-8")
+        raise Exception(f"OpenAI API error (HTTP {e.code}): {error_body}")
+
+
+def analyze_changes(diff_content: str, api_key: str, model: str = "gpt-5") -> str:
+    """
+    Analyze chart changes using OpenAI API.
+
+    Args:
+        diff_content: The diff content to analyze
+        api_key: OpenAI API key
+        model: The model to use (default: gpt-5)
+
+    Returns:
+        AI analysis response
+    """
+    prompt = f"""You are analyzing Helm Chart changes from a Renovate dependency update pull request.
+
+This repository uses a GitOps approach where Helm charts are pre-rendered into static YAML
+manifests stored in helm/ directories. When Chart.yaml is updated (usually a version bump),
+the render script regenerates all the templates in helm/, which can result in many file changes.
+
+Your task is to determine if the changes are:
+1. **ROUTINE** - Only version/hash updates in Chart.yaml, and the helm/ template changes are
+   only metadata updates (labels, annotations, helm chart version references) that don't
+   change the actual deployed resources or configuration.
+2. **SIGNIFICANT** - Changes that affect what gets deployed, including:
+   - Image tag changes (new versions of deployed applications)
+   - New dependencies or removed dependencies
+   - Changes to repository URLs
+   - Structural changes to deployed resources
+   - New or removed Kubernetes resources
+   - Changes to resource configurations (replicas, limits, etc.)
+   - Breaking changes or deprecations
+   - Security-relevant changes
+
+Respond EXACTLY in this format (include the emoji but minimal markdown):
+
+🟢 ROUTINE
+
+[1-2 sentences describing what changed]
+
+OR
+
+🔴 SIGNIFICANT
+
+[Brief intro sentence, then list the key changes as bullet points with details]
+- Change 1: [describe what changed and why it matters]
+- Change 2: [describe what changed and why it matters]
+- etc.
+
+IMPORTANT: Do not use bold (**), italics (*), headers (#), or code blocks in your response.
+For ROUTINE changes: 1-2 sentence plain text description.
+For SIGNIFICANT changes: intro sentence + detailed bullet points explaining what changed and impact.
+
+---
+
+Here are the changes to review:
+
+{diff_content}
+"""
+
+    def api_call():
+        return call_openai_api(prompt, api_key, model)
+
+    return exponential_backoff_retry(api_call)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze Helm Chart.yaml changes with AI"
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        help="PR number to analyze (for standalone testing)",
+    )
+    parser.add_argument(
+        "--model",
+        default="gpt-5",
+        help="AI model to use (default: gpt-5)",
+    )
+    parser.add_argument(
+        "--output-file",
+        help="Output file for GitHub Actions (defaults to GITHUB_OUTPUT env var)",
+    )
+
+    args = parser.parse_args()
+
+    # Get OpenAI API key
+    print("Getting OpenAI API key...", file=sys.stderr)
+    api_key = get_openai_api_key()
+
+    # Get diffs
+    print("Collecting Chart.yaml and helm/ changes...", file=sys.stderr)
+    diff_content = get_chart_diffs(args.pr)
+
+    if (
+        not diff_content.strip()
+        or diff_content.strip()
+        == "# Chart.yaml Changes\n\n\n# Rendered Helm Template Changes"
+    ):
+        print("No Chart.yaml changes found", file=sys.stderr)
+        sys.exit(0)
+
+    # Analyze changes
+    print("Analyzing changes with AI...", file=sys.stderr)
+    response = analyze_changes(diff_content, api_key, args.model)
+
+    # Output results
+    output_file = args.output_file or os.environ.get("GITHUB_OUTPUT")
+
+    if output_file:
+        # GitHub Actions output format
+        with open(output_file, "a") as f:
+            f.write("response<<EOF\n")
+            f.write(response)
+            f.write("\nEOF\n")
+            f.write("diff-content<<EOF\n")
+            f.write(diff_content)
+            f.write("\nEOF\n")
+        print("Analysis complete. Results written to output file.", file=sys.stderr)
+    else:
+        # Standalone output
+        print("\n=== AI Analysis ===\n")
+        print(response)
+
+        # Only print diff for ROUTINE changes
+        if "ROUTINE" in response:
+            print("\n=== Diff Content ===\n")
+            print(diff_content)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Workflow improvements:
- Replace GitHub AI inference with custom Python script using OpenAI API
- Add exponential backoff retry logic for 429 rate limit errors
- Use gh pr diff for simpler diff extraction
- Embed diff in PR comments for routine changes only
- Use GPT-5 for analysis

OpenAI key management:
- Provision OpenAI service accounts via Terraform
- Store API keys in 1Password automatically
- Sync keys to GitHub Actions secrets
- Create separate service account for karakeep app

Karakeep updates:
- Use dedicated 1Password item for OpenAI key
- Add reloader annotation to auto-restart on secret changes
- Update ExternalSecret to reference new key location

Script features:
- Falls back to 1Password CLI if env var not set
- Can be run standalone with --pr flag for testing
- Only prints diff for routine changes in interactive mode
