### PR TITLE
Prevent Tailscale from overriding DNS on Kubernetes nodes

### DIFF
--- a/ansible/host_vars/k1.yaml
+++ b/ansible/host_vars/k1.yaml
@@ -1,0 +1,2 @@
+---
+tailscale_args: --accept-dns=false

--- a/ansible/host_vars/k2.yaml
+++ b/ansible/host_vars/k2.yaml
@@ -1,5 +1,6 @@
 ---
 manage_network: true
+tailscale_args: --accept-dns=false
 interfaces_bond_interfaces:
   - device: bond0
     bond_slaves: [enp2s0f0, enp2s0f1]

--- a/ansible/host_vars/k4.yaml
+++ b/ansible/host_vars/k4.yaml
@@ -1,5 +1,6 @@
 ---
 manage_network: true
+tailscale_args: --accept-dns=false
 interfaces_bond_interfaces:
   - device: bond0
     bond_slaves: [enp2s0f0, enp2s0f1]

--- a/ansible/host_vars/k5.yaml
+++ b/ansible/host_vars/k5.yaml
@@ -1,5 +1,6 @@
 ---
 manage_network: true
+tailscale_args: --accept-dns=false
 interfaces_bond_interfaces:
   - device: bond0
     bond_slaves: [enp2s0f0, enp2s0f1]


### PR DESCRIPTION
Tailscale's MagicDNS was overriding /etc/resolv.conf with 100.100.100.100,
which failed to resolve public domains, breaking image pulls and cluster DNS.

Add --accept-dns=false to keep configured DNS server (172.19.74.1).
