### PR TITLE
Disable PodDisruptionBudgets for single-instance PostgreSQL clusters

### DIFF
--- a/kubernetes/authentik/authentik-postgres-cluster.yaml
+++ b/kubernetes/authentik/authentik-postgres-cluster.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:17.6-standard-bookworm@sha256:8f4e09a218ba49c8e719cd7e77512f0b2a3ad7d2a6c2225cf2901bf677b482f3
+  enablePDB: false
 
   storage:
     size: 10Gi

--- a/kubernetes/homebox/homebox-postgres-cluster.yaml
+++ b/kubernetes/homebox/homebox-postgres-cluster.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:17.6-standard-bookworm@sha256:8f4e09a218ba49c8e719cd7e77512f0b2a3ad7d2a6c2225cf2901bf677b482f3
+  enablePDB: false
 
   storage:
     size: 10Gi

--- a/kubernetes/karakeep/postgres-cluster.yaml
+++ b/kubernetes/karakeep/postgres-cluster.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:17.6-standard-bookworm@sha256:8f4e09a218ba49c8e719cd7e77512f0b2a3ad7d2a6c2225cf2901bf677b482f3
+  enablePDB: false
 
   storage:
     size: 10Gi

--- a/kubernetes/n8n/n8n-postgres-cluster.yaml
+++ b/kubernetes/n8n/n8n-postgres-cluster.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:17.6-standard-bookworm@sha256:8f4e09a218ba49c8e719cd7e77512f0b2a3ad7d2a6c2225cf2901bf677b482f3
+  enablePDB: false
 
   storage:
     size: 10Gi

--- a/kubernetes/openarchiver/postgres-cluster.yaml
+++ b/kubernetes/openarchiver/postgres-cluster.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:17.6-standard-bookworm@sha256:8f4e09a218ba49c8e719cd7e77512f0b2a3ad7d2a6c2225cf2901bf677b482f3
+  enablePDB: false
 
   storage:
     size: 20Gi


### PR DESCRIPTION
Single-instance databases (instances: 1) have no replicas to protect,
so PodDisruptionBudgets only block node drains without providing value.

Set enablePDB: false for all singleton CloudNativePG clusters to allow
smooth node maintenance and rolling reboots.
