### PR TITLE
Use self-cleaning versioned Kubernetes APT repositories

### DIFF
--- a/ansible/group_vars/kubernetes.yaml
+++ b/ansible/group_vars/kubernetes.yaml
@@ -12,6 +12,11 @@ kubectl_version: "1.32.8-1.1"
 cri_tools_version: "1.32.0-1.1"
 kubernetes_cni_version: "1.6.0-1.1"
 
+# Kubernetes repository versions to maintain (current + previous for rollback)
+kubernetes_repo_versions:
+  - "1.32" # Current
+  - "1.31" # Previous
+
 kubernetes_master: "k1.oneill.net"
 
 kubeadm_bootstrap_token: !vault |

--- a/ansible/roles/kubeadm/tasks/common.yaml
+++ b/ansible/roles/kubeadm/tasks/common.yaml
@@ -79,11 +79,43 @@
     dest: "/etc/apt/trusted.gpg.d/kubernetes-apt-keyring.gpg"
     mode: "0644"
 
-- name: "Add Kubernetes APT repo"
+- name: "Remove old unversioned Kubernetes sources file"
+  ansible.builtin.file:
+    path: "/etc/apt/sources.list.d/kubernetes.list"
+    state: absent
+
+- name: "Find existing Kubernetes APT source files"
+  ansible.builtin.find:
+    paths: /etc/apt/sources.list.d/
+    patterns: "kubernetes-v*.list"
+  register: kubeadm_existing_repo_files
+
+- name: "Extract version numbers from existing files"
+  ansible.builtin.set_fact:
+    kubeadm_existing_versions: "{{ kubeadm_existing_repo_files.files | map(attribute='path') | map('basename') | map('regex_replace', '^kubernetes-v([0-9.]+)\\.list$',
+      '\\1') | list }}"
+
+- name: "Remove unmanaged Kubernetes APT repositories"
+  ansible.builtin.file:
+    path: "/etc/apt/sources.list.d/kubernetes-v{{ item }}.list"
+    state: absent
+  loop: "{{ kubeadm_existing_versions }}"
+  when: item not in kubernetes_repo_versions
+  register: kubeadm_remove_repos
+
+- name: "Add managed Kubernetes APT repositories"
   ansible.builtin.apt_repository:
-    repo: "deb [signed-by=/etc/apt/trusted.gpg.d/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_short_version }}/deb/ /"
-    filename: "kubernetes"
+    repo: "deb [signed-by=/etc/apt/trusted.gpg.d/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v{{ item }}/deb/ /"
+    filename: "kubernetes-v{{ item }}"
+    state: present
+    update_cache: false
+  loop: "{{ kubernetes_repo_versions }}"
+  register: kubeadm_add_repos
+
+- name: "Update APT cache"
+  ansible.builtin.apt:
     update_cache: true
+  when: kubeadm_remove_repos is changed or kubeadm_add_repos is changed
 
 - name: "Create kubeadm package pin for version"
   ansible.builtin.copy:


### PR DESCRIPTION
Replace single unversioned kubernetes.list with versioned files
(kubernetes-v1.32.list, kubernetes-v1.31.list) that are automatically
managed based on kubernetes_repo_versions list.

Benefits:
- Maintains current + previous version for safe rollback
- Automatically removes stale repository versions
- Prevents apt-update failures from old/invalid repository URLs
- Format-agnostic (relies on apt_repository module)
