### PR TITLE
Ignore Python cache directories (__pycache__)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ kubernetes/resticprofile/.cache
 kubernetes/resticprofile/.tmp
 kubernetes/network-storage-benchmark/results/
 
+# Python
+__pycache__/
+
 # ESPHome
 esphome/secrets.yaml
 .DS_Store


### PR DESCRIPTION
Add __pycache__/ to gitignore to prevent Python bytecode cache
directories from being committed anywhere in the tree.
