### PR TITLE
Enable automatic filesystem checks in democratic-csi

### DIFF
--- a/kubernetes/democratic-csi/values.yaml
+++ b/kubernetes/democratic-csi/values.yaml
@@ -19,6 +19,12 @@ node:
     image:
       registry: docker.io/democraticcsi/democratic-csi
       tag: v1.9.0
+  # Enable automatic filesystem checks on mount to handle unclean shutdowns
+  # from network-induced iSCSI disconnects
+  mount:
+    checkFilesystem:
+      ext4:
+        enabled: true
 
 storageClasses:
 - name: synology-iscsi


### PR DESCRIPTION
Enable ext4 filesystem checking on mount to handle unclean shutdowns from
network-induced iSCSI disconnects. When network issues cause I/O timeouts,
the iSCSI session can disconnect before proper cleanup, leaving the
filesystem in an inconsistent state (typically minor metadata issues like
incorrect free block counts).

The CSI driver will now run e2fsck before mounting volumes, automatically
repairing minor inconsistencies without manual intervention. For serious
corruption requiring review, the mount will fail and alert via pod startup
failure.
