### PR TITLE
Fix Tautulli health checks and SABnzbd API exclusion

### DIFF
--- a/kubernetes/sabnzbd/ingress.yaml
+++ b/kubernetes/sabnzbd/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sabnzbd
   annotations:
     ak-type: basic-auth
-    ak-path-exclude: /api(/|$)
+    ak-path-exclude: /api.*
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: SABnzbd

--- a/kubernetes/tautulli/deploy.yaml
+++ b/kubernetes/tautulli/deploy.yaml
@@ -31,10 +31,10 @@ spec:
         - name: TZ
           value: EST5EDT
         livenessProbe:
-          failureThreshold: 10000
           httpGet:
-            path: /
+            path: /status
             port: 8181
+          failureThreshold: 3
         volumeMounts:
         - mountPath: /config
           name: config

--- a/opentofu/modules/authentik/generated-sabnzbd.tf
+++ b/opentofu/modules/authentik/generated-sabnzbd.tf
@@ -17,7 +17,7 @@ resource "authentik_provider_proxy" "sabnzbd" {
   basic_auth_password_attribute = "password"
 
   skip_path_regex = <<-EOT
-^https://sabnzbd.k.oneill.net/api(/|$)
+^https://sabnzbd.k.oneill.net/api.*
   EOT
 }
 


### PR DESCRIPTION
- Tautulli: Use /status endpoint for liveness probe instead of /
  The / endpoint was returning 401 after Authentik auth, causing
  constant probe failures. The /status endpoint is designed for
  health checks and doesn't require authentication.

- Tautulli: Reduce failureThreshold from 10000 to 3
  The extremely high value was effectively disabling pod restarts.
  Now that we're using the correct health check endpoint, we can
  use a sensible threshold.

- SABnzbd: Update API path exclusion from /api(/|$) to /api.*
  The previous regex didn't match query parameters like /api?mode=...
  which is how SABnzbd's API actually works. The new pattern excludes
  all API calls from Authentik authentication.
