### PR TITLE
Enable HA for authentik postgres cluster

### DIFF
--- a/kubernetes/authentik/authentik-postgres-cluster.yaml
+++ b/kubernetes/authentik/authentik-postgres-cluster.yaml
@@ -6,9 +6,9 @@ metadata:
   name: authentik-postgres
 
 spec:
-  instances: 1
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:17.6-standard-bookworm@sha256:8f4e09a218ba49c8e719cd7e77512f0b2a3ad7d2a6c2225cf2901bf677b482f3
-  enablePDB: false
+  enablePDB: true
 
   storage:
     size: 10Gi


### PR DESCRIPTION
Increase instances from 1 to 2 (primary + replica) and enable PDB for high availability. Authentik is a critical dependency for many services in the cluster, so this provides better resilience against node failures and maintenance windows.
