### PR TITLE
Add alert for pods stuck in non-running state

### DIFF
--- a/kubernetes/prometheus/config/rules.yml
+++ b/kubernetes/prometheus/config/rules.yml
@@ -54,3 +54,9 @@ groups:
     for: 24h
     labels:
       realert: daily
+  - alert: PodStuckNotRunning
+    expr: kube_pod_status_phase{phase!="Running", phase!="Succeeded"} == 1
+    for: 15m
+    annotations:
+      message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in {{ $labels.phase }}
+        phase for more than 15 minutes


### PR DESCRIPTION
Alert when pods remain in Pending, Failed, or Unknown phase for more than 15 minutes to catch scheduling issues, image pull failures, and other problems preventing pods from starting.
