### PR TITLE
Fix DNS resolution for Kubernetes nodes

### DIFF
--- a/ansible/host_vars/k2.yaml
+++ b/ansible/host_vars/k2.yaml
@@ -1,5 +1,8 @@
 ---
 manage_network: true
+manage_resolv_conf: true
+dns_nameservers: ["172.19.74.1"]
+dns_search: ["oneill.net"]
 tailscale_args: --accept-dns=false
 interfaces_bond_interfaces:
   - device: bond0
@@ -9,8 +12,6 @@ interfaces_bond_interfaces:
     address: "172.19.74.112"
     netmask: "255.255.255.0"
     gateway: 172.19.74.1
-    dnsnameservers: 172.19.74.1
-    dnssearch: oneill.net
     bond_mode: 802.3ad
     bond_miimon: 100
     bond_downdelay: 200

--- a/ansible/host_vars/k4.yaml
+++ b/ansible/host_vars/k4.yaml
@@ -1,5 +1,8 @@
 ---
 manage_network: true
+manage_resolv_conf: true
+dns_nameservers: ["172.19.74.1"]
+dns_search: ["oneill.net"]
 tailscale_args: --accept-dns=false
 interfaces_bond_interfaces:
   - device: bond0
@@ -9,8 +12,6 @@ interfaces_bond_interfaces:
     address: "172.19.74.75"
     netmask: "255.255.255.0"
     gateway: 172.19.74.1
-    dnsnameservers: 172.19.74.1
-    dnssearch: oneill.net
     bond_mode: 802.3ad
     bond_miimon: 100
     bond_downdelay: 200

--- a/ansible/host_vars/k5.yaml
+++ b/ansible/host_vars/k5.yaml
@@ -1,5 +1,8 @@
 ---
 manage_network: true
+manage_resolv_conf: true
+dns_nameservers: ["172.19.74.1"]
+dns_search: ["oneill.net"]
 tailscale_args: --accept-dns=false
 interfaces_bond_interfaces:
   - device: bond0
@@ -9,8 +12,6 @@ interfaces_bond_interfaces:
     address: "172.19.74.76"
     netmask: "255.255.255.0"
     gateway: 172.19.74.1
-    dnsnameservers: 172.19.74.1
-    dnssearch: oneill.net
     bond_mode: 802.3ad
     bond_miimon: 100
     bond_downdelay: 200

--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -27,3 +27,16 @@
     state: present
     regexp: "^%sudo"
     line: "%sudo ALL=(ALL) NOPASSWD: ALL"
+
+# Note: This task exists because the michaelrigart.interfaces galaxy role's
+# bond_Debian.j2 template doesn't support dnsnameservers/dnssearch variables
+# (unlike ethernet_Debian.j2 which does). Rather than patching the galaxy role,
+# we manage resolv.conf directly for hosts that need it.
+- name: "Manage /etc/resolv.conf"
+  ansible.builtin.template:
+    src: resolv.conf.j2
+    dest: /etc/resolv.conf
+    mode: "0644"
+    owner: root
+    group: root
+  when: manage_resolv_conf | default(false) | bool

--- a/ansible/roles/common/templates/resolv.conf.j2
+++ b/ansible/roles/common/templates/resolv.conf.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+# DNS configuration managed by Ansible
+
+{% for nameserver in dns_nameservers %}
+nameserver {{ nameserver }}
+{% endfor %}
+{% if dns_search is defined and dns_search | length > 0 %}
+search {{ dns_search | join(' ') }}
+{% endif %}


### PR DESCRIPTION
The michaelrigart.interfaces galaxy role's bond_Debian.j2 template doesn't
support dnsnameservers/dnssearch variables (unlike ethernet_Debian.j2).

Rather than patch the upstream role, manage /etc/resolv.conf directly via
the common role for nodes that need it (k2, k4, k5). This fixes
metrics-server DNS resolution failures when resolving short hostnames.
