### PR TITLE
Enable high availability for authentik

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 .vscode/
 .direnv/
+.tmp/
 
 # Ansible
 ansible-vault-password

--- a/kubernetes/authentik/helm/authentik/server/deployment.yaml
+++ b/kubernetes/authentik/helm/authentik/server/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/part-of: "authentik"
     app.kubernetes.io/version: "2025.8.4"
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 3
   selector:
     matchLabels:

--- a/kubernetes/authentik/values.yaml
+++ b/kubernetes/authentik/values.yaml
@@ -18,6 +18,9 @@ authentik:
 
 # Server configuration
 server:
+  # Enable 2 replicas for high availability
+  replicas: 2
+
   # Reloader annotations to restart when secrets change
   podAnnotations:
     reloader.stakater.com/auto: 'true'


### PR DESCRIPTION
Increase authentik server replicas to 2 for application-level HA. The
database already has 2 PostgreSQL instances with PDB enabled, providing
full high availability for the identity provider.
