### PR TITLE
Fix network benchmark failures and manage Alpine via kustomize

### DIFF
--- a/kubernetes/network-storage-benchmark/job-network-benchmark.yaml.j2
+++ b/kubernetes/network-storage-benchmark/job-network-benchmark.yaml.j2
@@ -28,13 +28,13 @@ spec:
 
       containers:
       - name: iperf-client
-        image: alpine:3.18
+        image: {{ alpine_image }}
         command: [/bin/sh, -c]
         args:
         - |
-          apk add --no-cache iperf3 python3 py3-pip
+          apk add --no-cache bash iperf3 python3 py3-pip
           echo "Starting iperf3 client tests"
-          /bin/sh /scripts/run-iperf-client.sh
+          /scripts/run-iperf-client.sh
         env:
         - name: SERVER_HOST
           value: iperf-server.network-storage-benchmark.svc.cluster.local

--- a/kubernetes/network-storage-benchmark/job-storage-benchmark.yaml.j2
+++ b/kubernetes/network-storage-benchmark/job-storage-benchmark.yaml.j2
@@ -26,7 +26,7 @@ spec:
 
       containers:
       - name: test-storage
-        image: alpine:3.18
+        image: {{ alpine_image }}
         command: ["/bin/sh", "-c"]
         args:
           - |

--- a/kubernetes/network-storage-benchmark/kustomization.yaml
+++ b/kubernetes/network-storage-benchmark/kustomization.yaml
@@ -4,6 +4,10 @@ kind: Kustomization
 
 namespace: network-storage-benchmark
 
+images:
+- name: alpine
+  newTag: "3.22"
+
 resources:
 - namespace.yaml
 - pvc-iscsi.yaml

--- a/kubernetes/network-storage-benchmark/network-benchmark-server.yaml
+++ b/kubernetes/network-storage-benchmark/network-benchmark-server.yaml
@@ -43,8 +43,12 @@ spec:
 
       containers:
       - name: iperf-server
-        image: networkstatic/iperf3:latest
-        command: [/bin/sh, /scripts/run-iperf-server.sh]
+        image: alpine
+        command: [/bin/sh, -c]
+        args:
+        - |
+          apk add --no-cache bash iperf3
+          /scripts/run-iperf-server.sh
         env:
         - name: NODE_NAME
           valueFrom:

--- a/kubernetes/network-storage-benchmark/pod-results-copy.yaml.j2
+++ b/kubernetes/network-storage-benchmark/pod-results-copy.yaml.j2
@@ -11,7 +11,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: results-copy
-    image: alpine:3.18
+    image: {{ alpine_image }}
     command: [sleep, infinity]
     volumeMounts:
     - name: results


### PR DESCRIPTION
- Switch iperf-server from networkstatic/iperf3 to alpine base image
  The networkstatic image uses a minimal shell incompatible with bash
  scripts, causing CrashLoopBackOff errors

- Add bash to apk packages for server and client containers
  Ensures scripts execute with proper bash features (pipefail, etc)

- Replace mapfile with portable array read in run-benchmark.sh
  Fixes "mapfile: command not found" on older bash versions

- Manage Alpine version via kustomize images section
  Single source of truth in kustomization.yaml (currently 3.22)
  Allows Renovate to manage Alpine updates automatically
  Templates use {{ alpine_image }} placeholder substituted at runtime
  Consistent with repo pattern used in resticprofile and other apps
