### PR TITLE
Migrate k2, k4, k5 to 10G single interface networking

### DIFF
--- a/ansible/host_vars/k2.yaml
+++ b/ansible/host_vars/k2.yaml
@@ -1,20 +1,15 @@
 ---
 manage_network: true
-manage_resolv_conf: true
-dns_nameservers: ["172.19.74.1"]
-dns_search: ["oneill.net"]
 tailscale_args: --accept-dns=false
-interfaces_bond_interfaces:
-  - device: bond0
-    bond_slaves: [enp2s0f0, enp2s0f1]
-    hwaddr: "06:bc:96:51:3a:a0"
+interfaces_ether_interfaces:
+  - device: enp1s0f0
     bootproto: static
     address: "172.19.74.112"
     netmask: "255.255.255.0"
     gateway: 172.19.74.1
-    bond_mode: 802.3ad
-    bond_miimon: 100
-    bond_downdelay: 200
-    bond_updelay: 100
-    bond_lacp_rate: 1
-    bond_xmit_hash_policy: layer3+4
+    dnsnameservers: 172.19.74.1
+    dnssearch: oneill.net
+    allowclass: allow-hotplug
+  - device: eno1
+    bootproto: manual
+    allowclass: manual

--- a/ansible/host_vars/k4.yaml
+++ b/ansible/host_vars/k4.yaml
@@ -1,20 +1,15 @@
 ---
 manage_network: true
-manage_resolv_conf: true
-dns_nameservers: ["172.19.74.1"]
-dns_search: ["oneill.net"]
 tailscale_args: --accept-dns=false
-interfaces_bond_interfaces:
-  - device: bond0
-    bond_slaves: [enp2s0f0, enp2s0f1]
-    hwaddr: "06:bc:96:51:3a:b1"
+interfaces_ether_interfaces:
+  - device: enp1s0f0
     bootproto: static
     address: "172.19.74.75"
     netmask: "255.255.255.0"
     gateway: 172.19.74.1
-    bond_mode: 802.3ad
-    bond_miimon: 100
-    bond_downdelay: 200
-    bond_updelay: 100
-    bond_lacp_rate: 1
-    bond_xmit_hash_policy: layer3+4
+    dnsnameservers: 172.19.74.1
+    dnssearch: oneill.net
+    allowclass: allow-hotplug
+  - device: eno1
+    bootproto: manual
+    allowclass: manual

--- a/ansible/host_vars/k5.yaml
+++ b/ansible/host_vars/k5.yaml
@@ -1,23 +1,18 @@
 ---
 manage_network: true
-manage_resolv_conf: true
-dns_nameservers: ["172.19.74.1"]
-dns_search: ["oneill.net"]
 tailscale_args: --accept-dns=false
-interfaces_bond_interfaces:
-  - device: bond0
-    bond_slaves: [enp2s0f0, enp2s0f1]
-    hwaddr: "06:bc:96:51:3a:b0"
+interfaces_ether_interfaces:
+  - device: enp1s0f0
     bootproto: static
     address: "172.19.74.76"
     netmask: "255.255.255.0"
     gateway: 172.19.74.1
-    bond_mode: 802.3ad
-    bond_miimon: 100
-    bond_downdelay: 200
-    bond_updelay: 100
-    bond_lacp_rate: 1
-    bond_xmit_hash_policy: layer3+4
+    dnsnameservers: 172.19.74.1
+    dnssearch: oneill.net
+    allowclass: allow-hotplug
+  - device: eno1
+    bootproto: manual
+    allowclass: manual
 
 # interfaces_ether_interfaces:
 #   - device: wlxe84e06993446

--- a/opentofu/unifi.tf
+++ b/opentofu/unifi.tf
@@ -15,7 +15,7 @@ resource "unifi_user" "k1" {
 
 # k2 - Kubernetes node
 resource "unifi_user" "k2" {
-  mac              = "06:bc:96:51:3a:a0"
+  mac              = "b4:96:91:4b:34:58"
   name             = "k2"
   note             = "Kubernetes worker node"
   fixed_ip         = "172.19.74.112"
@@ -24,7 +24,7 @@ resource "unifi_user" "k2" {
 
 # k4 - Kubernetes node
 resource "unifi_user" "k4" {
-  mac              = "06:bc:96:51:3a:b1"
+  mac              = "b4:96:91:a0:83:54"
   name             = "k4"
   note             = "Kubernetes worker node"
   fixed_ip         = "172.19.74.75"
@@ -33,7 +33,7 @@ resource "unifi_user" "k4" {
 
 # k5 - Kubernetes node
 resource "unifi_user" "k5" {
-  mac              = "06:bc:96:51:3a:b0"
+  mac              = "b4:96:91:39:e0:94"
   name             = "k5"
   note             = "Kubernetes worker node"
   fixed_ip         = "172.19.74.76"


### PR DESCRIPTION
Remove LACP bond configuration (2×1G interfaces) and configure single
10G interface (enp1s0f0) on all worker nodes.

- Update Ansible network configs to use enp1s0f0 instead of bond0
- Move DNS configuration from manage_resolv_conf to interface-level
- Update UniFi DHCP reservations with physical 10G interface MACs
  - k2: b4:96:91:4b:34:58
  - k4: b4:96:91:a0:83:54
  - k5: b4:96:91:39:e0:94

Network benchmarks confirm 7+ Gbps between all worker nodes.
