### PR TITLE
Fix Ansible interface handler for manual interfaces on k2, k4, k5

### DIFF
--- a/ansible/host_vars/k2.yaml
+++ b/ansible/host_vars/k2.yaml
@@ -13,3 +13,4 @@ interfaces_ether_interfaces:
   - device: eno1
     bootproto: manual
     allowclass: manual
+    ignore_status_check: true

--- a/ansible/host_vars/k4.yaml
+++ b/ansible/host_vars/k4.yaml
@@ -13,3 +13,4 @@ interfaces_ether_interfaces:
   - device: eno1
     bootproto: manual
     allowclass: manual
+    ignore_status_check: true

--- a/ansible/host_vars/k5.yaml
+++ b/ansible/host_vars/k5.yaml
@@ -13,6 +13,7 @@ interfaces_ether_interfaces:
   - device: eno1
     bootproto: manual
     allowclass: manual
+    ignore_status_check: true
 
 # interfaces_ether_interfaces:
 #   - device: wlxe84e06993446


### PR DESCRIPTION
Add ignore_status_check: true to eno1 interfaces on k2, k4, and k5.

These interfaces are configured with bootproto: manual and allowclass:
manual, meaning they are intentionally not brought up. The
michaelrigart.interfaces role handler was checking if these interfaces
were active and failing when they weren't.

The ignore_status_check flag tells the handler to skip the active state
check for these manual interfaces, preventing "Interface eno1 is not
active" errors when running Ansible playbooks.
