### PR TITLE
Change renovate digest delay to 0 days

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -136,7 +136,7 @@
       "matchManagers": [
         "kustomize"
       ],
-      "minimumReleaseAge": "2 days",
+      "minimumReleaseAge": "0 days",
       "automerge": true,
       "automergeType": "pr",
       "addLabels": [
@@ -157,7 +157,7 @@
       "matchManagers": [
         "custom.regex"
       ],
-      "minimumReleaseAge": "2 days",
+      "minimumReleaseAge": "0 days",
       "automerge": true,
       "automergeType": "pr",
       "addLabels": [


### PR DESCRIPTION
We're not reviewing these so waiting doesn't really provide much value. A release from two days ago seems just as likely to be broken as the one today.