### PR TITLE
Add recyclarr and managarr tools for managing Radarr/Sonarr

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -11,8 +11,14 @@ PATH_add scripts
 PATH_add ansible/scripts
 PATH_add esphome/scripts
 PATH_add kubernetes/scripts
+PATH_add tools/recyclarr
+PATH_add tools/managarr
 
 if on_git_branch; then
   echo && git status --short --branch &&
   echo && git fetch --verbose
 fi
+
+# Load secrets from 1Password
+export RADARR_API_KEY=$(op read "op://infra/radarr/api_key")
+export SONARR_API_KEY=$(op read "op://infra/sonarr/api_key")

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,13 @@ __pycache__/
 # ESPHome
 esphome/secrets.yaml
 .DS_Store
+
+# Tools - Recyclarr
+tools/recyclarr/data/cache/
+tools/recyclarr/data/configs/
+tools/recyclarr/data/includes/
+tools/recyclarr/data/logs/
+tools/recyclarr/data/repositories/
+tools/recyclarr/data/settings.yml
+
+# Tools - Managarr (nothing to ignore - config.yml is committed)

--- a/flake.nix
+++ b/flake.nix
@@ -17,40 +17,55 @@
     {
 
       # Development environments
-      devShells = forEachSupportedSystem ({ pkgs }: {
-        default = pkgs.mkShell {
-          # Pinned packages available in the environment
-          packages = with pkgs; [
-            act
-            ansible
-            ansible-lint
-            awscli2
-            curl
-            jq
-            kopia
-            kubeconform
-            kubecolor
-            kubectl
-            kustomize
-            mosquitto
-            nodejs_24
-            opentofu
-            pluto
-            pre-commit
-            # Python with required packages
-            (python3.withPackages (ps: with ps; [
-              jinja2
-              pyyaml
-              ruamel-yaml
-            ]))
-            rclone
-            skopeo
-            tflint
-            velero
-            yamlfix
-            yq-go
-          ];
-        };
-      });
+      devShells = forEachSupportedSystem ({ pkgs }:
+        let
+          # Install recyclarr as .recyclarr to avoid name conflict with wrapper
+          recyclarr-bin = pkgs.runCommand "recyclarr-bin" {} ''
+            mkdir -p $out/bin
+            ln -s ${pkgs.recyclarr}/bin/recyclarr $out/bin/.recyclarr
+          '';
+          # Install managarr as .managarr to avoid name conflict with wrapper
+          managarr-bin = pkgs.runCommand "managarr-bin" {} ''
+            mkdir -p $out/bin
+            ln -s ${pkgs.managarr}/bin/managarr $out/bin/.managarr
+          '';
+        in
+        {
+          default = pkgs.mkShell {
+            # Pinned packages available in the environment
+            packages = with pkgs; [
+              act
+              ansible
+              ansible-lint
+              awscli2
+              curl
+              jq
+              kopia
+              kubeconform
+              kubecolor
+              kubectl
+              kustomize
+              managarr-bin
+              mosquitto
+              nodejs_24
+              opentofu
+              pluto
+              pre-commit
+              recyclarr-bin
+              # Python with required packages
+              (python3.withPackages (ps: with ps; [
+                jinja2
+                pyyaml
+                ruamel-yaml
+              ]))
+              rclone
+              skopeo
+              tflint
+              velero
+              yamlfix
+              yq-go
+            ];
+          };
+        });
     };
 }

--- a/tools/managarr/config.yml
+++ b/tools/managarr/config.yml
@@ -1,0 +1,12 @@
+---
+theme: default
+
+radarr:
+  - name: radarr
+    uri: https://radarr.k.oneill.net
+    api_token: !env ${RADARR_API_KEY}
+
+sonarr:
+  - name: sonarr
+    uri: https://sonarr.k.oneill.net
+    api_token: !env ${SONARR_API_KEY}

--- a/tools/managarr/managarr
+++ b/tools/managarr/managarr
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+export MANAGARR_CONFIG_FILE="$PWD/config.yml"
+exec .managarr "$@"

--- a/tools/recyclarr/data/recyclarr.yml
+++ b/tools/recyclarr/data/recyclarr.yml
@@ -1,0 +1,1 @@
+../recyclarr.yml

--- a/tools/recyclarr/recyclarr
+++ b/tools/recyclarr/recyclarr
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+export RECYCLARR_APP_DATA="$PWD/data"
+exec .recyclarr "$@"

--- a/tools/recyclarr/recyclarr.yml
+++ b/tools/recyclarr/recyclarr.yml
@@ -1,0 +1,108 @@
+###################################################################################################
+# Recyclarr Configuration                                                                        #
+# Radarr: HD/UHD Bluray + WEB                                                                    #
+# Sonarr: WEB-1080p and WEB-2160p                                                                #
+# Based on templates: https://github.com/recyclarr/config-templates                              #
+###################################################################################################
+
+# Radarr Instance - HD/UHD Bluray + WEB
+radarr:
+  radarr:
+    base_url: https://radarr.k.oneill.net
+    api_key: !env_var RADARR_API_KEY
+
+    media_naming:
+      folder: default
+      movie:
+        rename: true
+        standard: standard
+
+    include:
+      # Comment out any of the following includes to disable them
+      - template: radarr-quality-definition-movie
+      - template: radarr-quality-profile-hd-bluray-web
+      - template: radarr-custom-formats-hd-bluray-web
+      - template: radarr-quality-profile-uhd-bluray-web
+      - template: radarr-custom-formats-uhd-bluray-web
+
+
+    custom_formats:
+      # Movie Versions
+      - trash_ids:
+      # Uncomment any of the following lines to prefer these movie versions
+          # - 570bc9ebecd92723d2d21500f4be314c # Remaster
+          # - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
+          # - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
+          # - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
+          # - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
+          # - 957d0f44b592285f26449575e8b1167e # Special Edition
+          # - eecf3a857724171f968a66cb5719e152 # IMAX
+          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+        assign_scores_to:
+          - name: HD Bluray + WEB
+
+      # Optional
+      - trash_ids:
+          # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
+          # - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
+          # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
+          # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
+          # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
+          # - f537cf427b64c38e8e36298f657e4828 # Scene
+        assign_scores_to:
+          - name: HD Bluray + WEB
+
+      - trash_ids:
+          # Uncomment the next six lines to allow x265 HD releases with HDR/DV
+          # - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
+        # assign_scores_to:
+          # - name: HD Bluray + WEB
+            # score: 0
+      # - trash_ids:
+          # - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+        assign_scores_to:
+          - name: HD Bluray + WEB
+
+# Sonarr Instance - WEB-1080p
+sonarr:
+  sonarr:
+    base_url: https://sonarr.k.oneill.net
+    api_key: !env_var SONARR_API_KEY
+
+    media_naming:
+      series: plex-imdb
+      season: default
+      episodes:
+        rename: true
+        standard: default
+        daily: default
+        anime: default
+
+    include:
+      - template: sonarr-quality-definition-series
+      - template: sonarr-v4-quality-profile-web-1080p-alternative
+      - template: sonarr-v4-custom-formats-web-1080p
+      - template: sonarr-v4-quality-profile-web-2160p-alternative
+      - template: sonarr-v4-custom-formats-web-2160p
+
+    custom_formats:
+      # Optional
+      - trash_ids:
+          # - 32b367365729d530ca1c124a0b180c64 # Bad Dual Groups
+          # - 82d40da2bc6923f41e14394075dd4b03 # No-RlsGroup
+          # - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
+          # - 06d66ab109d4d2eddb2794d21526d140 # Retags
+          # - 1b3994c551cbb92a2c781af061f4ab44 # Scene
+        assign_scores_to:
+          - name: WEB-1080p
+
+      - trash_ids:
+          # Uncomment the next six lines to allow x265 HD releases with HDR/DV
+          # - 47435ece6b99a0b477caf360e79ba0bb # x265 (HD)
+        # assign_scores_to:
+          # - name: WEB-1080p
+            # score: 0
+      # - trash_ids:
+          # - 9b64dff695c2115facf1b6ea59c9bd07 # x265 (no HDR/DV)
+        assign_scores_to:
+          - name: WEB-1080p


### PR DESCRIPTION
Sets up two new tools in the tools/ directory:

Recyclarr:
- Syncs TRaSH Guide quality profiles, custom formats, and naming to Radarr/Sonarr
- Configured for HD/UHD Bluray + WEB (Radarr) and WEB-1080p/2160p (Sonarr)
- Config at tools/recyclarr/recyclarr.yml with generated files in data/
- Uses alternative quality profiles for Sonarr and plex-imdb series naming

Managarr:
- TUI and CLI for managing Radarr/Sonarr (browse library, downloads, etc.)
- Config at tools/managarr/config.yml

Both tools:
- Installed via flake.nix as dot-prefixed binaries (.recyclarr, .managarr)
- Use wrapper scripts in PATH that set up config locations
- Read API keys from 1Password via .envrc environment variables
