### PR TITLE
Configure ARA to display timestamps in America/New_York timezone

### DIFF
--- a/kubernetes/ara/helm/deployment.yaml
+++ b/kubernetes/ara/helm/deployment.yaml
@@ -46,6 +46,8 @@ spec:
             value: "INFO"
           - name: ARA_READ_LOGIN_REQUIRED
             value: "false"
+          - name: ARA_TIME_ZONE
+            value: "America/New_York"
           - name: ARA_WRITE_LOGIN_REQUIRED
             value: "false"
         volumeMounts:

--- a/kubernetes/ara/values.yaml
+++ b/kubernetes/ara/values.yaml
@@ -31,6 +31,9 @@ env:
   # Logging
   ARA_LOG_LEVEL: INFO
 
+  # Timezone - display timestamps in local time instead of UTC
+  ARA_TIME_ZONE: America/New_York
+
 # Database password will be set via environment variable from secret
 # Note: ara-postgres-app secret contains 'password' key, we need ARA_DATABASE_PASSWORD
 


### PR DESCRIPTION
Add ARA_TIME_ZONE environment variable to display playbook timestamps
in local time (America/New_York) instead of UTC. This makes the web
interface timestamps more intuitive for users in the local timezone.

The timezone setting uses Django's TIME_ZONE configuration under the
hood, which is supported in ARA 1.2.0+ with consistent timestamp
handling between the API and callback plugin.

Tested: Deployed to cluster and verified environment variable is set.
