### PR TITLE
Fix nginx ingress snippet annotations blocking Authentik auth requests

### DIFF
--- a/kubernetes/cwa/ingress.yaml
+++ b/kubernetes/cwa/ingress.yaml
@@ -14,12 +14,7 @@ metadata:
     gethomepage.dev/description: Ebook Library
     gethomepage.dev/group: Media
     gethomepage.dev/icon: calibre-web.png
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($uri ~* ^/opds) {
-        if ($request_method = HEAD) {
-          return 204;
-        }
-      }
+
 spec:
   tls:
   - hosts:
@@ -37,6 +32,7 @@ spec:
             port:
               number: 8083
   ingressClassName: nginx
+
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -45,6 +41,7 @@ metadata:
   name: cwa-opds
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+
 #    nginx.ingress.kubernetes.io/configuration-snippet: |
 #      if ($uri ~* ^/opds) {
 #        if ($request_method = HEAD) {

--- a/kubernetes/ingress-nginx/helm/controller-configmap.yaml
+++ b/kubernetes/ingress-nginx/helm/controller-configmap.yaml
@@ -14,6 +14,6 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 data:
-  allowSnippetAnnotations: "true"
+  allow-snippet-annotations: "true"
   annotations-risk-level: "Critical"
   proxy-body-size: "100m"

--- a/kubernetes/ingress-nginx/values.yaml
+++ b/kubernetes/ingress-nginx/values.yaml
@@ -1,11 +1,11 @@
 ---
 controller:
   replicaCount: 2
+  allowSnippetAnnotations: true
   extraArgs:
     enable-ssl-passthrough: ''
   config:
     proxy-body-size: 100m
-    allowSnippetAnnotations: true
     annotations-risk-level: Critical
   admissionWebhooks:
     enabled: false


### PR DESCRIPTION
API requests to services behind Authentik (Sonarr, Radarr) were returning 500 errors because auth-snippet annotations weren't being processed.

Root cause: The allowSnippetAnnotations helm value was incorrectly placed under controller.config instead of directly under controller, causing it to generate a camelCase configmap key that nginx doesn't recognize.

Changes:
- Move allowSnippetAnnotations from controller.config to controller level in values.yaml
- This generates the correct allow-snippet-annotations (kebab-case) configmap key
- Remove invalid nested if directive from CWA ingress that was blocking nginx config reloads

Verification: Sonarr and Radarr API requests now return 200 OK instead of 500 errors.
