### PR TITLE
Add Velero monitoring with Prometheus and Healthchecks.io

### DIFF
--- a/kubernetes/velero/healthcheck-cronjob.yaml
+++ b/kubernetes/velero/healthcheck-cronjob.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: velero-healthcheck
+  namespace: velero
+
+spec:
+  # Run daily at 8:00 AM UTC (2 hours after backup at 6:00 AM)
+  schedule: 0 8 * * *
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: velero-server
+          restartPolicy: OnFailure
+          containers:
+          - name: healthcheck
+            image: alpine:3.22
+            env:
+            - name: HEALTHCHECK_PING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: velero-healthcheck
+                  key: HEALTHCHECK_PING_KEY
+            command:
+            - /bin/sh
+            - /scripts/healthcheck.sh
+            volumeMounts:
+            - name: healthcheck-script
+              mountPath: /scripts
+          volumes:
+          - name: healthcheck-script
+            configMap:
+              name: velero-healthcheck-script
+              defaultMode: 0755

--- a/kubernetes/velero/healthcheck-externalsecret.yaml
+++ b/kubernetes/velero/healthcheck-externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+  name: velero-healthcheck
+  namespace: velero
+
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  target:
+    name: velero-healthcheck
+    creationPolicy: Owner
+  data:
+  - secretKey: HEALTHCHECK_PING_KEY
+    remoteRef:
+      key: velero-healthchecks
+      property: HEALTHCHECK_PING_KEY

--- a/kubernetes/velero/healthcheck.sh
+++ b/kubernetes/velero/healthcheck.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+set -eu
+
+echo "Installing kubectl, wget, coreutils, and jq..."
+apk add --no-cache curl wget coreutils jq
+curl -sLO "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+chmod +x kubectl
+mv kubectl /usr/local/bin/
+
+echo "Checking Velero backup status..."
+
+# Calculate 48 hours ago in epoch seconds
+NOW_EPOCH=$(date +%s)
+CUTOFF_EPOCH=$(( NOW_EPOCH - (48 * 3600) ))
+
+# Get all backups sorted by creation time
+BACKUPS_JSON=$(kubectl get backups.velero.io -n velero \
+  --sort-by=.metadata.creationTimestamp \
+  --request-timeout=30s \
+  -o json)
+
+# Find the most recent completed backup within the past 48 hours
+FOUND_BACKUP=""
+BACKUP_COUNT=$(echo "$BACKUPS_JSON" | jq -r '.items | length')
+
+if [ "$BACKUP_COUNT" -eq 0 ]; then
+  echo "ERROR: No backups found"
+  wget -q -O- "https://hc-ping.com/${HEALTHCHECK_PING_KEY}/fail" \
+    --post-data "No backups found"
+  exit 1
+fi
+
+echo "Checking $BACKUP_COUNT backups for completed backup within past 48 hours..."
+
+# Iterate through backups from newest to oldest
+for i in $(seq $((BACKUP_COUNT - 1)) -1 0); do
+  BACKUP_NAME=$(echo "$BACKUPS_JSON" | jq -r ".items[$i].metadata.name")
+  BACKUP_STATUS=$(echo "$BACKUPS_JSON" | jq -r ".items[$i].status.phase")
+  BACKUP_CREATED=$(echo "$BACKUPS_JSON" | jq -r ".items[$i].metadata.creationTimestamp")
+
+  # Convert creation time to epoch
+  BACKUP_EPOCH=$(date -u -d "$BACKUP_CREATED" +%s)
+  AGE_HOURS=$(( (NOW_EPOCH - BACKUP_EPOCH) / 3600 ))
+
+  echo "  $BACKUP_NAME: status=$BACKUP_STATUS, age=${AGE_HOURS}h"
+
+  # If backup is older than 48 hours, stop checking
+  if [ "$BACKUP_EPOCH" -lt "$CUTOFF_EPOCH" ]; then
+    echo "  (stopping - older than 48h)"
+    break
+  fi
+
+  # If backup is completed and within 48 hours, we found it!
+  if [ "$BACKUP_STATUS" = "Completed" ]; then
+    FOUND_BACKUP="$BACKUP_NAME"
+    FOUND_AGE="$AGE_HOURS"
+    echo "  ✓ Found completed backup!"
+    break
+  fi
+done
+
+# Check if we found a successful backup
+if [ -z "$FOUND_BACKUP" ]; then
+  echo "ERROR: No completed backup found in past 48 hours"
+  wget -q -O- "https://hc-ping.com/${HEALTHCHECK_PING_KEY}/fail" \
+    --post-data "No completed backup found in past 48 hours"
+  exit 1
+fi
+
+# Success!
+echo "SUCCESS: Backup $FOUND_BACKUP completed successfully (${FOUND_AGE}h ago)"
+wget -q -O- "https://hc-ping.com/${HEALTHCHECK_PING_KEY}" \
+  --post-data "Backup: $FOUND_BACKUP completed successfully (${FOUND_AGE}h ago)"

--- a/kubernetes/velero/helm/service.yaml
+++ b/kubernetes/velero/helm/service.yaml
@@ -5,6 +5,9 @@ kind: Service
 metadata:
   name: velero
   namespace: velero
+  annotations:
+    prometheus.io/port: "8085"
+    prometheus.io/scrape: "true"
   labels:
     app.kubernetes.io/name: velero
     app.kubernetes.io/instance: velero

--- a/kubernetes/velero/kustomization.yaml
+++ b/kubernetes/velero/kustomization.yaml
@@ -38,6 +38,8 @@ resources:
 - rclone-externalsecret.yaml
 - schedule-daily.yaml
 - volume-policy-configmap.yaml
+- healthcheck-externalsecret.yaml
+- healthcheck-cronjob.yaml
 
 configMapGenerator:
 - name: velero-encrypt-startup
@@ -45,6 +47,11 @@ configMapGenerator:
     disableNameSuffixHash: true
   files:
   - start.sh
+- name: velero-healthcheck-script
+  options:
+    disableNameSuffixHash: true
+  files:
+  - healthcheck.sh
 
 patches:
 

--- a/kubernetes/velero/run-kopia
+++ b/kubernetes/velero/run-kopia
@@ -56,5 +56,11 @@ if [ ! -f "$KOPIA_CONFIG" ]; then
 fi
 
 # Run kopia command
-echo "Running kopia command..."
-exec kopia --config-file="$KOPIA_CONFIG" "$@"
+# Default to "snapshot list -d --storage-stats" if no arguments provided
+if [ $# -eq 0 ]; then
+    echo "Running kopia snapshot list -d --storage-stats..."
+    exec kopia --config-file="$KOPIA_CONFIG" snapshot list -d --storage-stats
+else
+    echo "Running kopia command..."
+    exec kopia --config-file="$KOPIA_CONFIG" "$@"
+fi

--- a/kubernetes/velero/values.yaml
+++ b/kubernetes/velero/values.yaml
@@ -31,6 +31,13 @@ uploaderType: kopia
 credentials:
   existingSecret: velero-b2-credentials
 
+metrics:
+  enabled: true
+  service:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '8085'
+
 initContainers:
 - name: velero-plugin-for-aws
   # renovate: datasource=docker depName=velero/velero-plugin-for-aws


### PR DESCRIPTION
Implements two-tier monitoring for Velero backups:

Prometheus metrics:
- Added service annotations for auto-discovery by Prometheus
- Exposes metrics on port 8085 for detailed backup statistics
- Enables future alerting capabilities

Healthchecks.io integration:
- Daily CronJob checks for successful backup within past 48 hours
- Uses Alpine container with kubectl, wget, coreutils, and jq
- Searches all recent backups for 'Completed' status
- Pings healthchecks.io on success or failure
- Runs at 8:00 AM UTC (2 hours after backup window)
- ExternalSecret syncs ping key from 1Password

Also:
- Updated run-kopia script to default to 'snapshot list -d --storage-stats'
