### PR TITLE
Enable Tailscale DNS with exit nodes via consolidated configuration

### DIFF
--- a/opentofu/.terraform.lock.hcl
+++ b/opentofu/.terraform.lock.hcl
@@ -103,6 +103,25 @@ provider "registry.opentofu.org/hashicorp/aws" {
   ]
 }
 
+provider "registry.opentofu.org/hashicorp/dns" {
+  version     = "3.4.3"
+  constraints = "~> 3.4"
+  hashes = [
+    "h1:5rNTdN+8ASjCwmAWsKrB1sBMJ0oMAOU6AcUS0+Zsp34=",
+    "h1:mxw8X448NmQbdaINTQqIlociGQnPruNM3iuekNHgFQI=",
+    "zh:1e2b7a78c1ca570860ec1dbe81834cc3015b6ceee98e8a231111704ea0ca44ad",
+    "zh:1eaa3eb2a08ce40880edeba23ff8f5b09c5df403724e8f32e886ee99e6a72b7b",
+    "zh:33157dc9e4146fa459598d63cf0ed1120d9568272449b5097268d01de6be3884",
+    "zh:3e1d98aa57fab96fd12ba44b077826a8d0722beb9c12306219d9d7ce87ba547a",
+    "zh:71a3722011be02e28dbd10b5831cdbb79deb85484fc937d66fe2f64899b021a6",
+    "zh:8fa38bac4590544fda877dddf699e1d80d52fef81655c4a18c97ab34799922b7",
+    "zh:961f973ff1baab5950d4315aec03d0fc3c54cf64ef58cf58590fb3cb29aa742e",
+    "zh:b01e570c054f58f73a01aa937a1c36443d4036a12edf5ca444356552f0cf137e",
+    "zh:e2ecc873327978ab3b704ccb7a9746835d62e78aa51152565047b5e3d705e7d5",
+    "zh:edb22e5a20db138c5f862e29ec0e84722f35e04deba93df3c8639cf6abae48a5",
+  ]
+}
+
 provider "registry.opentofu.org/hashicorp/random" {
   version     = "3.7.2"
   constraints = "~> 3.6"

--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -1,0 +1,44 @@
+# Local values shared across multiple resources
+#
+# infrastructure_hosts defines all infrastructure machines with static IPs.
+# This data structure is consumed by both:
+# - unifi_user resources (DHCP reservations)
+# - aws_route53_record resources (DNS A records)
+#
+# This ensures UniFi DHCP and Route53 DNS stay automatically in sync.
+# To add a new host, simply add an entry here and run `opentofu apply`.
+
+locals {
+  infrastructure_hosts = {
+    k1 = {
+      mac      = "52:54:00:7a:16:72"
+      ip       = "172.19.74.134"
+      hostname = "k1.oneill.net"
+      note     = "Kubernetes control-plane node (VM)"
+    }
+    k2 = {
+      mac      = "b4:96:91:4b:34:58"
+      ip       = "172.19.74.112"
+      hostname = "k2.oneill.net"
+      note     = "Kubernetes worker node"
+    }
+    k4 = {
+      mac      = "b4:96:91:a0:83:54"
+      ip       = "172.19.74.75"
+      hostname = "k4.oneill.net"
+      note     = "Kubernetes worker node"
+    }
+    k5 = {
+      mac      = "b4:96:91:39:e0:94"
+      ip       = "172.19.74.76"
+      hostname = "k5.oneill.net"
+      note     = "Kubernetes worker node"
+    }
+    fs2 = {
+      mac      = "b4:96:91:4e:1b:ac"
+      ip       = "172.19.74.139"
+      hostname = "fs2.oneill.net"
+      note     = "Synology NAS"
+    }
+  }
+}

--- a/opentofu/main.tf
+++ b/opentofu/main.tf
@@ -42,6 +42,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
+    dns = {
+      source  = "hashicorp/dns"
+      version = "~> 3.4"
+    }
   }
 
   backend "s3" {
@@ -95,7 +99,8 @@ provider "unifi" {
 }
 
 module "dns" {
-  source = "./modules/dns"
+  source               = "./modules/dns"
+  infrastructure_hosts = local.infrastructure_hosts
 }
 
 # Authentik provider configuration via 1Password (see locals in secrets.tf)

--- a/opentofu/modules/dns/oneill.tf
+++ b/opentofu/modules/dns/oneill.tf
@@ -117,14 +117,6 @@ resource "aws_route53_record" "clayton" {
   records = ["claytono.github.io."]
 }
 
-resource "aws_route53_record" "frank" {
-  zone_id = aws_route53_zone.oneill_net.zone_id
-  name    = "frank.oneill.net"
-  type    = "A"
-  ttl     = 300
-  records = ["20.241.73.44"]
-}
-
 resource "aws_route53_record" "k_subdomain_ns" {
   zone_id = aws_route53_zone.oneill_net.zone_id
   name    = "k.oneill.net"
@@ -147,6 +139,20 @@ resource "aws_route53_record" "router" {
   type    = "A"
   ttl     = 3600
   records = ["172.19.74.1"]
+}
+
+# Infrastructure hosts - automatically synced with UniFi DHCP reservations
+# Host definitions are in ../../locals.tf (infrastructure_hosts) and shared
+# with unifi_user resources to ensure DNS and DHCP stay automatically in sync.
+
+resource "aws_route53_record" "infrastructure_hosts" {
+  for_each = var.infrastructure_hosts
+
+  zone_id = aws_route53_zone.oneill_net.zone_id
+  name    = each.value.hostname
+  type    = "A"
+  ttl     = 300
+  records = [each.value.ip]
 }
 
 # Nameserver records for delegation set

--- a/opentofu/modules/dns/outputs.tf
+++ b/opentofu/modules/dns/outputs.tf
@@ -1,0 +1,5 @@
+# Export k.oneill.net nameservers for use in Tailscale split DNS configuration
+output "k_oneill_net_nameservers" {
+  description = "AWS Route53 nameservers for k.oneill.net zone"
+  value       = aws_route53_zone.k_oneill_net.name_servers
+}

--- a/opentofu/modules/dns/variables.tf
+++ b/opentofu/modules/dns/variables.tf
@@ -1,0 +1,11 @@
+# Variables for DNS module
+
+variable "infrastructure_hosts" {
+  description = "Map of infrastructure hosts with their network configuration"
+  type = map(object({
+    mac      = string
+    ip       = string
+    hostname = string
+    note     = string
+  }))
+}

--- a/opentofu/unifi.tf
+++ b/opentofu/unifi.tf
@@ -3,48 +3,16 @@
 # These resources manage static DHCP reservations on the UDMP for hosts that
 # need consistent IP addresses. The actual IP configuration on the hosts is
 # managed via Ansible (see ansible/host_vars/*.yaml).
+#
+# Host definitions are in locals.tf (infrastructure_hosts) and shared with
+# Route53 DNS records to ensure UniFi DHCP and DNS stay automatically in sync.
 
-# k1 - Kubernetes control-plane (VM)
-resource "unifi_user" "k1" {
-  mac              = "52:54:00:7a:16:72"
-  name             = "k1"
-  note             = "Kubernetes control-plane node (VM)"
-  fixed_ip         = "172.19.74.134"
-  local_dns_record = "k1.oneill.net"
-}
+resource "unifi_user" "infrastructure_hosts" {
+  for_each = local.infrastructure_hosts
 
-# k2 - Kubernetes node
-resource "unifi_user" "k2" {
-  mac              = "b4:96:91:4b:34:58"
-  name             = "k2"
-  note             = "Kubernetes worker node"
-  fixed_ip         = "172.19.74.112"
-  local_dns_record = "k2.oneill.net"
-}
-
-# k4 - Kubernetes node
-resource "unifi_user" "k4" {
-  mac              = "b4:96:91:a0:83:54"
-  name             = "k4"
-  note             = "Kubernetes worker node"
-  fixed_ip         = "172.19.74.75"
-  local_dns_record = "k4.oneill.net"
-}
-
-# k5 - Kubernetes node
-resource "unifi_user" "k5" {
-  mac              = "b4:96:91:39:e0:94"
-  name             = "k5"
-  note             = "Kubernetes worker node"
-  fixed_ip         = "172.19.74.76"
-  local_dns_record = "k5.oneill.net"
-}
-
-# fs2 - Synology NAS
-resource "unifi_user" "fs2" {
-  mac              = "b4:96:91:4e:1b:ac"
-  name             = "fs2"
-  note             = "Synology NAS"
-  fixed_ip         = "172.19.74.139"
-  local_dns_record = "fs2.oneill.net"
+  mac              = each.value.mac
+  name             = each.key
+  note             = each.value.note
+  fixed_ip         = each.value.ip
+  local_dns_record = each.value.hostname
 }


### PR DESCRIPTION
Migrated to tailscale_dns_configuration resource with use_with_exit_node
support, ensuring DNS resolution works when using exit nodes like flux.

Changes:
- Add hashicorp/dns provider for nameserver hostname resolution
- Create locals.tf with infrastructure_hosts shared data structure
- Migrate UniFi resources to for_each pattern using infrastructure_hosts
- Add Route53 A records for infrastructure hosts (k1, k2, k4, k5, fs2)
- Add dns module outputs to expose k.oneill.net nameservers
- Replace tailscale_dns_split_nameservers with tailscale_dns_configuration
- Configure split DNS with use_with_exit_node=true:
  - k.oneill.net → AWS Route53 nameservers
  - oneill.net → Local DNS (172.19.74.1)
- Remove frank.oneill.net DNS record

The infrastructure_hosts data structure ensures UniFi DHCP reservations
and Route53 DNS records stay automatically synchronized.
