### PR TITLE
Increase refrigerator freezer alert threshold to 15°F

### DIFF
--- a/kubernetes/hass/config/configuration.yaml
+++ b/kubernetes/hass/config/configuration.yaml
@@ -551,7 +551,7 @@ binary_sensor:
       delay_on: 00:20:00
       value_template: >
         {{ states("sensor.refrigerator_freezer_temperature") | float(999.0) == 999.0
-           or states("sensor.refrigerator_freezer_temperature") | float > 0 }}
+           or states("sensor.refrigerator_freezer_temperature") | float > 15 }}
     freezer_door_open_delayed:
       friendly_name: Freezer Door Open Too Long
       delay_on: 00:05:00


### PR DESCRIPTION
Change the temperature alert threshold from 0°F to 15°F to provide
earlier warning when the freezer temperature rises above safe levels.
