### PR TITLE
Fix Prometheus scraping of Home Assistant

### DIFF
--- a/kubernetes/prometheus/config/prometheus.yml
+++ b/kubernetes/prometheus/config/prometheus.yml
@@ -63,7 +63,7 @@ scrape_configs:
   metrics_path: /api/prometheus
   static_configs:
   - targets:
-    - hass.default:8123
+    - hass-home-assistant.hass:8080
 
 - job_name: vera
   scrape_interval: 15s


### PR DESCRIPTION
Update the Prometheus hass job target from `hass.default:8123` to
`hass-home-assistant.hass:8080` to reflect the namespace and port
changes from the November 8th Helm chart migration.

When Home Assistant was migrated to use a Helm chart, it moved from
the default namespace to a dedicated hass namespace, and the service
port changed from 8123 to 8080. The Prometheus configuration wasn't
updated at that time, causing scraping to fail.
