### PR TITLE
Configure smartd for disk health monitoring with email alerts

### DIFF
--- a/ansible/roles/common/handlers/main.yaml
+++ b/ansible/roles/common/handlers/main.yaml
@@ -1,0 +1,5 @@
+---
+- name: Restart smartd
+  ansible.builtin.service:
+    name: smartd
+    state: restarted

--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -21,6 +21,35 @@
     state: present
   when: ansible_distribution == 'Debian'
 
+- name: "Install smartmontools on non-VM amd64 hosts"
+  ansible.builtin.apt:
+    name: smartmontools
+    state: present
+  when:
+    - ansible_architecture == 'x86_64'
+    - ansible_virtualization_role != 'guest'
+
+- name: "Configure smartd for disk monitoring"
+  ansible.builtin.template:
+    src: smartd.conf.j2
+    dest: /etc/smartd.conf
+    mode: "0644"
+    owner: root
+    group: root
+  when:
+    - ansible_architecture == 'x86_64'
+    - ansible_virtualization_role != 'guest'
+  notify: Restart smartd
+
+- name: "Ensure smartd service is enabled and started"
+  ansible.builtin.service:
+    name: smartd
+    state: started
+    enabled: true
+  when:
+    - ansible_architecture == 'x86_64'
+    - ansible_virtualization_role != 'guest'
+
 - name: "Turn on passwordless sudo for sudo group"
   ansible.builtin.lineinfile:
     dest: /etc/sudoers
@@ -40,3 +69,13 @@
     owner: root
     group: root
   when: manage_resolv_conf | default(false) | bool
+
+- name: "Configure NMI watchdog sysctl"
+  ansible.posix.sysctl:
+    name: kernel.nmi_watchdog
+    value: "1"
+    state: present
+    reload: true
+  when:
+    - ansible_architecture in ['x86_64', 'i386']
+    - ansible_virtualization_role != 'guest'

--- a/ansible/roles/common/templates/smartd.conf.j2
+++ b/ansible/roles/common/templates/smartd.conf.j2
@@ -1,0 +1,24 @@
+# {{ ansible_managed }}
+# smartd configuration for disk health monitoring
+# See smartd.conf(5) man page for details
+
+# Scan SATA/ATA devices only (excludes iSCSI and other SCSI devices):
+#
+# -d sat: Only monitor SATA/ATA devices (physical SSDs/HDDs)
+# -a: Monitor all SMART attributes
+# -o on: Enable automatic offline tests
+# -S on: Enable attribute autosave
+# -s (S/../.././02|L/../../6/03): Schedule tests
+#     S = Short test daily at 2:00-3:00 AM
+#     L = Long test every Saturday at 3:00-4:00 AM
+# -m root: Send alerts to root (forwarded to {{ relaymail_overwrite_to_target | default('root') }} via Postfix)
+# -M exec: Use smartd-runner for email delivery (Debian/Ubuntu default)
+#
+# Email notifications are sent for:
+# - SMART health status failures
+# - Increases in error counts
+# - Self-test failures
+# - Temperature excursions (if supported)
+# - Changes in SMART attributes beyond thresholds
+
+DEVICESCAN -d sat -a -o on -S on -s (S/../.././02|L/../../6/03) -m root -M exec /usr/share/smartmontools/smartd-runner


### PR DESCRIPTION
Add smartmontools monitoring for physical SATA/ATA drives on non-VM
amd64 hosts with automated email notifications via existing Postfix relay.

Changes:
- Install smartmontools package on physical x86_64 hosts
- Deploy smartd.conf configuration to monitor only SATA/ATA devices
  (excludes iSCSI and other SCSI devices)
- Schedule automated SMART tests: short tests daily at 2am, long tests
  weekly on Saturdays at 3am
- Enable comprehensive monitoring: all SMART attributes, error logs,
  self-test results, temperature
- Configure email alerts to root (forwarded to clayton.oneill@gmail.com
  via Postfix relay managed by yannik.relaymail role)
- Add NMI watchdog sysctl configuration for improved system stability

Tested on k2, k4, k5, and luser - verified smartd service running and
monitoring only physical SSDs.
