### PR TITLE
Allow unauthenticated access to Prometheus API endpoints

### DIFF
--- a/kubernetes/prometheus/ingress.yaml
+++ b/kubernetes/prometheus/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   name: prometheus
   annotations:
     ak-type: simple
+    ak-path-exclude: /api/.*
     cert-manager.io/cluster-issuer: letsencrypt
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Prometheus

--- a/opentofu/modules/authentik/generated-prometheus.tf
+++ b/opentofu/modules/authentik/generated-prometheus.tf
@@ -13,6 +13,9 @@ resource "authentik_provider_proxy" "prometheus" {
   access_token_validity = "hours=1"
 
 
+  skip_path_regex = <<-EOT
+^https://prometheus.k.oneill.net/api/.*
+  EOT
 }
 
 resource "authentik_application" "prometheus" {


### PR DESCRIPTION
Configure Authentik to bypass authentication for Prometheus /api/*
endpoints while keeping the UI protected. This enables external
scraping, federation, and API access without authentication.

Changes:
- Add ak-path-exclude annotation to Prometheus ingress for /api/.*
- Add skip_path_regex to Authentik Prometheus proxy provider config

The generated Authentik config may need to be updated if using ak-tool
to manage Authentik resources.
