### PR TITLE
Configure Renovate to manage Caddy and route53 plugin together

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -90,6 +90,16 @@
         "VERSION=\"(?<currentValue>[^\"]+)\"\\s*\\nGIT_URL=\"https://github.com/(?<depName>[^/]+/[^/]+)\\.git\""
       ],
       "datasourceTemplate": "github-tags"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "ansible/roles/nut/files/Dockerfile"
+      ],
+      "matchStrings": [
+        "--with github\\.com/(?<depName>[^@]+)@(?<currentValue>v[0-9.]+)"
+      ],
+      "datasourceTemplate": "github-releases"
     }
   ],
   "packageRules": [
@@ -225,6 +235,17 @@
       ],
       "pinDigests": false,
       "description": "Disable digest pinning for ESPHome Docker images managed by custom regex"
+    },
+    {
+      "matchFileNames": [
+        "ansible/roles/nut/files/Dockerfile"
+      ],
+      "matchPackagePatterns": [
+        "^caddy$",
+        "^caddy-dns/"
+      ],
+      "groupName": "Caddy and plugins",
+      "description": "Group Caddy Docker images with caddy-dns plugins"
     }
   ],
   "gitIgnoredAuthors": [


### PR DESCRIPTION
## Summary
Configure Renovate to automatically manage both Caddy Docker images and the caddy-dns/route53 plugin version together in a single PR.

## Changes
- Add custom regex manager to detect route53 plugin versions in the NUT Dockerfile
- Add grouping rule to combine Caddy and plugin updates into one PR
- Ensures version compatibility (Caddy 2.10+ requires route53 v1.6+)

## Context
Previously, Renovate would update the Caddy Docker images but leave the route53 plugin at an incompatible version, causing build failures. This configuration ensures both are updated together.

Related: #363, #571