### PR TITLE
Upgrade Kubernetes cluster to v1.33.5

### DIFF
--- a/ansible/group_vars/kubernetes.yaml
+++ b/ansible/group_vars/kubernetes.yaml
@@ -4,18 +4,18 @@ kernel_parameters: "nofb vga=normal"
 node_exporter_enabled: true
 
 # Our goal is to stay one version behind
-kubernetes_short_version: "1.32"
-kubernetes_version: "1.32.8"
-kubeadm_version: "1.32.8-1.1"
-kubelet_version: "1.32.8-1.1"
-kubectl_version: "1.32.8-1.1"
-cri_tools_version: "1.32.0-1.1"
+kubernetes_short_version: "1.33"
+kubernetes_version: "1.33.5"
+kubeadm_version: "1.33.5-1.1"
+kubelet_version: "1.33.5-1.1"
+kubectl_version: "1.33.5-1.1"
+cri_tools_version: "1.33.0-1.1"
 kubernetes_cni_version: "1.6.0-1.1"
 
 # Kubernetes repository versions to maintain (current + previous for rollback)
 kubernetes_repo_versions:
-  - "1.32" # Current
-  - "1.31" # Previous
+  - "1.33"
+  - "1.32"
 
 kubernetes_master: "k1.oneill.net"
 

--- a/kubernetes/ara/ara-postgres-cluster.yaml
+++ b/kubernetes/ara/ara-postgres-cluster.yaml
@@ -9,6 +9,8 @@ spec:
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:17.6-standard-bookworm@sha256:de94ee3c8b01defe1d641a37a70d421740c7f90681604352f1b7c4039e94d313
 
+  enablePDB: false
+
   storage:
     size: 10Gi
 


### PR DESCRIPTION
Update all cluster nodes to Kubernetes v1.33.5 across the cluster.

Package versions:
- kubernetes: 1.33.5
- kubeadm: 1.33.5-1.1
- kubelet: 1.33.5-1.1
- kubectl: 1.33.5-1.1
- cri-tools: 1.33.0-1.1
- kubernetes-cni: 1.6.0-1.1

Disabled PDB for ara-postgres CNPG cluster (single instance, PDB blocks node
drains during maintenance windows).

All nodes upgraded successfully:
- k1 (control plane): v1.33.5
- k2, k4, k5 (workers): v1.33.5

Post-upgrade validation completed:
- All nodes Ready
- All pods Running/Completed
- All ArgoCD applications Synced & Healthy (except ara OutOfSync)
- All ingress resources have addresses
- All PV/PVCs Bound
- Cluster connectivity verified
- Certificates renewed (364d remaining)
