### PR TITLE
Increase refrigerator temperature alert threshold to 50°F

### DIFF
--- a/kubernetes/hass/config/configuration.yaml
+++ b/kubernetes/hass/config/configuration.yaml
@@ -544,7 +544,7 @@ binary_sensor:
       delay_on: 00:20:00
       value_template: >
         {{ states("sensor.refrigerator_temperature") | float(999.0) == 999.0
-           or states("sensor.refrigerator_temperature") | float > 47 }}
+           or states("sensor.refrigerator_temperature") | float > 50 }}
     refrigerator_freezer_too_warm:
       friendly_name: Refrigerator Freezer Too Warm
       device_class: problem


### PR DESCRIPTION
The refrigerator temperature alert was triggering too frequently at 47°F.
Raising the threshold to 50°F to reduce false positives while still
catching actual temperature issues.
