### PR TITLE
Configure NUT server for multi-UPS monitoring with Synology support

### DIFF
--- a/ansible/group_vars/nut.yaml
+++ b/ansible/group_vars/nut.yaml
@@ -6,22 +6,22 @@ nut_packages:
   - nut-server
 
 nut_ups:
-  - name: "ups1"
+  - name: "ups"
     driver: "usbhid-ups"
     device: auto
-    description: "UPS 1"
+    description: "UPS for Synology"
     extra: |
-      serial = "CXXPV7000092"
+      serial = "CXXPV7000091"
   - name: "ups2"
     driver: "usbhid-ups"
     device: auto
-    description: "UPS 2"
+    description: "UPS for luser, k2, k4, k5"
     extra: |
-      serial = "CXXPV7000091"
+      serial = "CXXPV7000092"
   - name: "ups3"
     driver: "usbhid-ups"
     device: auto
-    description: "UPS 3"
+    description: "UPS for network gear"
     extra: |
       serial = "CXXPX7007632"
 
@@ -62,8 +62,12 @@ nut_users:
       66613138623232623838633063393238373662303864356664643663653365346265643164303666
       3838663262303561326139663665363065663362643739343863
     extra: |
-      upsmon user
+      upsmon primary
       actions = MONITOR
+  - name: "monuser"
+    password: "secret"
+    extra: |
+      upsmon secondary
 
 nut_peanut_enabled: true
 nut_peanut_nut_host: "{{ inventory_hostname }}"
@@ -75,3 +79,4 @@ nut_enabled: true
 
 nut_services:
   - nut-server
+  - nut-monitor

--- a/ansible/host_vars/upspi.yaml
+++ b/ansible/host_vars/upspi.yaml
@@ -1,0 +1,21 @@
+---
+# UPS server host - monitors all UPS devices but does NOT shut down
+# Clients will shut themselves down when they see LOWBATT
+
+# Override shutdown command to prevent upspi from shutting down
+# This allows upsmon to run and send notifications, but won't trigger shutdown
+nut_upsmon_extra: |
+  SHUTDOWNCMD "/bin/true"
+  HOSTSYNC 60
+  FINALDELAY 120
+  RUN_AS_USER root
+  NOTIFYCMD /usr/sbin/upssched
+  NOTIFYFLAG ONBATT WALL+EXEC
+  NOTIFYFLAG ONLINE WALL+EXEC
+  NOTIFYFLAG LOWBATT WALL+EXEC
+  NOTIFYFLAG FSD WALL+EXEC
+  NOTIFYFLAG COMMBAD WALL+EXEC
+  NOTIFYFLAG COMMOK WALL+EXEC
+  NOTIFYFLAG REPLBATT WALL+EXEC
+  NOTIFYFLAG NOCOMM WALL+EXEC
+  NOTIFYFLAG SHUTDOWN WALL+EXEC

--- a/ansible/inventory/default
+++ b/ansible/inventory/default
@@ -28,6 +28,11 @@ k5
 [nut]
 upspi
 
+[nut_client]
+luser
+k2
+k4
+k5
 
 [pi]
 #voron2-pizero


### PR DESCRIPTION
- Rename UPS devices for clarity and Synology compatibility:
  - ups1 → ups (for Synology - required naming)
  - ups2 → ups2 (for luser, k2, k4, k5)
  - Swapped serial numbers to match physical connections
- Add monuser with password 'secret' for Synology/client connections
- Configure upspi to monitor UPS but not shut down (SHUTDOWNCMD=/bin/true)
- Enable nut-monitor service for email notifications
- Add nut_client inventory group for future client configuration
