### PR TITLE
Restrict flux exit node to SSH-only access via Tailscale ACL

### DIFF
--- a/ansible/host_vars/flux.yaml
+++ b/ansible/host_vars/flux.yaml
@@ -2,6 +2,7 @@
 # Vultr VPS running Debian 11 (bullseye)
 # vc2-1c-1gb instance
 tailscale_args: --advertise-exit-node # --accept-dns=false
+tailscale_tags: ['flux']
 ip_forwarding_enabled: true
 restic_prometheus_config: {}
 restic_host_config:

--- a/opentofu/tailscale.tf
+++ b/opentofu/tailscale.tf
@@ -14,6 +14,7 @@ resource "tailscale_acl" "main" {
             "tag:k8s": ["tag:k8s-operator"],
             "tag:github-actions": [],
             "tag:argocd": ["tag:k8s-operator"],
+            "tag:flux": ["autogroup:admin"],
         },
 
         // Define access control lists for users, groups, autogroups, tags,
@@ -24,6 +25,14 @@ resource "tailscale_acl" "main" {
                 "action": "accept",
                 "src":    ["autogroup:member"],
                 "dst":    ["*:*"],
+            },
+
+            // Allow flux to reach other hosts via SSH only
+            {
+                "action": "accept",
+                "src":    ["tag:flux"],
+                "proto":  "tcp",
+                "dst":    ["*:22"],
             },
 
             // Allow GitHub Actions to reach ArgoCD only


### PR DESCRIPTION
Add tag:flux to Tailscale ACL policy and configure flux to advertise
this tag. The ACL restricts tag:flux to only TCP port 22, preventing
the exit node from reaching other tailnet hosts on any other ports.
