### PR TITLE
Install qemu-guest-agent on virtual machines

### DIFF
--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -21,6 +21,12 @@
     state: present
   when: ansible_distribution == 'Debian'
 
+- name: "Install qemu-guest-agent on VMs"
+  ansible.builtin.apt:
+    name: qemu-guest-agent
+    state: present
+  when: ansible_virtualization_role == 'guest'
+
 - name: "Install smartmontools on non-VM amd64 hosts"
   ansible.builtin.apt:
     name: smartmontools


### PR DESCRIPTION
This enables libvirt to query VM IP addresses and status via virsh domifaddr
and other guest agent commands, improving VM management capabilities.
