### PR TITLE
Add PXE boot server role for automated Debian installs

### DIFF
--- a/ansible/roles/pxe/files/boot.ipxe
+++ b/ansible/roles/pxe/files/boot.ipxe
@@ -1,0 +1,52 @@
+#!ipxe
+
+set menu-timeout 30000
+set pxe-server http://infrapi.oneill.net:8081
+
+menu PXE Boot Menu
+item --gap -- -------- Default --------
+item localdisk         Boot from local disk
+item --gap -- -------- Debian Trixie --------
+item trixie-preseed    Debian Trixie - Preseed
+item trixie-expert     Debian Trixie - Expert
+item --gap -- -------- Debian Bookworm --------
+item bookworm-preseed  Debian Bookworm - Preseed
+item bookworm-expert   Debian Bookworm - Expert
+item --gap -- -------- Tools --------
+item memtest           Memtest86+
+item shell             iPXE Shell
+choose --timeout ${menu-timeout} --default localdisk target && goto ${target}
+
+:localdisk
+exit
+
+:trixie-preseed
+set base http://deb.debian.org/debian/dists/trixie/main/installer-amd64/current/images/netboot/debian-installer/amd64
+kernel ${base}/linux auto=true priority=critical preseed/url=${pxe-server}/preseed.trixie.cfg interface=auto
+initrd ${base}/initrd.gz
+boot
+
+:trixie-expert
+set base http://deb.debian.org/debian/dists/trixie/main/installer-amd64/current/images/netboot/debian-installer/amd64
+kernel ${base}/linux priority=low
+initrd ${base}/initrd.gz
+boot
+
+:bookworm-preseed
+set base http://deb.debian.org/debian/dists/bookworm/main/installer-amd64/current/images/netboot/debian-installer/amd64
+kernel ${base}/linux auto=true priority=critical preseed/url=${pxe-server}/preseed.bookworm.cfg interface=auto
+initrd ${base}/initrd.gz
+boot
+
+:bookworm-expert
+set base http://deb.debian.org/debian/dists/bookworm/main/installer-amd64/current/images/netboot/debian-installer/amd64
+kernel ${base}/linux priority=low
+initrd ${base}/initrd.gz
+boot
+
+:memtest
+kernel ${pxe-server}/memtest64.bin
+boot
+
+:shell
+shell

--- a/ansible/roles/pxe/files/dnsmasq.conf
+++ b/ansible/roles/pxe/files/dnsmasq.conf
@@ -1,0 +1,13 @@
+# PXE boot server - DHCP proxy mode
+port=0
+enable-tftp
+tftp-root=/tftpboot
+dhcp-range=172.19.74.0,proxy,255.255.255.0
+
+# For legacy PXE clients: serve iPXE bootloader via TFTP, which then chainloads to HTTP
+# For iPXE clients: serve boot script directly via HTTP
+dhcp-match=set:ipxe,175
+dhcp-boot=tag:!ipxe,undionly.kpxe
+dhcp-boot=tag:ipxe,http://infrapi.oneill.net:8081/boot.ipxe
+
+log-dhcp

--- a/ansible/roles/pxe/files/docker-compose.yaml
+++ b/ansible/roles/pxe/files/docker-compose.yaml
@@ -1,0 +1,19 @@
+---
+services:
+  dnsmasq:
+    image: dockurr/dnsmasq:2.91
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+    network_mode: host
+    volumes:
+      - /etc/pxe/dnsmasq.conf:/etc/dnsmasq.conf:ro
+      - /etc/pxe/assets:/tftpboot:ro
+
+  nginx:
+    image: nginx:1.27-alpine
+    restart: unless-stopped
+    ports:
+      - "8081:80"
+    volumes:
+      - /etc/pxe/assets:/usr/share/nginx/html:ro

--- a/ansible/roles/pxe/files/preseed.bookworm.cfg
+++ b/ansible/roles/pxe/files/preseed.bookworm.cfg
@@ -1,0 +1,1 @@
+preseed.trixie.cfg

--- a/ansible/roles/pxe/files/preseed.trixie.cfg
+++ b/ansible/roles/pxe/files/preseed.trixie.cfg
@@ -1,0 +1,93 @@
+#### Preseed for Debian Trixie
+### Localization
+d-i debian-installer/locale string en_US
+d-i keyboard-configuration/xkb-keymap select us
+
+### Network configuration
+d-i netcfg/choose_interface select auto
+d-i netcfg/get_domain string unassigned-domain
+
+### Mirror settings
+d-i mirror/country string manual
+d-i mirror/http/hostname string http.us.debian.org
+d-i mirror/http/directory string /debian
+d-i mirror/http/proxy string
+
+### Account setup
+d-i passwd/root-login boolean true
+d-i passwd/root-password-crypted password $6$rounds=1000000$cokzO6b5JXHIg14R$WxBbuuOlpy.Tx9AygtMYXy8hfJ21NjpYsBqJ/GMn0e7SrdPDcCGh2hA1JiymFzO4sy2k4nLPCL6kXBA9lgkQS1
+d-i passwd/user-fullname string Ansible User
+d-i passwd/username string ansible
+d-i passwd/user-password-crypted password $6$rounds=1000000$RpVgooiQ$n9mSw3FrvtdsdQ0mYlfX1RFPSfAX0EkRqbUJ6wEZ6rXtKcaeiLM4tPlzZe.Orc8MOw3w6fTXrd3i/xEYf2ZTI1
+d-i passwd/user-uid string 9000
+
+### Clock and time zone setup
+d-i clock-setup/utc boolean true
+d-i time/zone string US/Eastern
+d-i clock-setup/ntp boolean true
+
+### Partitioning
+d-i partman-auto/method string lvm
+d-i partman-auto-lvm/new_vg_name string rootvg
+d-i partman-auto-lvm/guided_size string max
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-md/device_remove_md boolean true
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+
+d-i partman-basicfilesystems/no_swap boolean false
+d-i partman-auto/expert_recipe string                         \
+      big-root ::                                             \
+              256 512 512 ext4                                \
+                      $primary{ } $bootable{ }                \
+                      method{ format } format{ }              \
+                      use_filesystem{ } filesystem{ ext4 }    \
+                      mountpoint{ /boot }                     \
+              .                                               \
+              500 10000 -1 ext4                               \
+                      $lvmok{_}                               \
+                      method{ format } format{ }              \
+                      use_filesystem{ } filesystem{ ext4 }    \
+                      mountpoint{ / }                         \
+              .
+
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman-md/confirm boolean true
+
+### Base system installation
+d-i base-installer/install-recommends boolean false
+
+### Apt setup
+d-i apt-setup/non-free boolean true
+d-i apt-setup/contrib boolean true
+
+### Package selection
+tasksel tasksel/first multiselect ssh-server
+d-i pkgsel/upgrade select full-upgrade
+d-i pkgsel/include string openssh-server python3 ifenslave cloud-init qemu-guest-agent
+
+### Boot loader installation
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i grub-installer/bootdev string default
+
+### Finishing up the installation
+d-i finish-install/reboot_in_progress note
+
+### Late command - set up SSH keys and sudoers
+d-i preseed/late_command string \
+  in-target mkdir /root/.ssh ; \
+  in-target chmod 0700 /root/.ssh ; \
+  echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB3URIT9ojo8mqsEjxmFu1C+Bxa3jdcKkUzM++IfDVmu coneill@xtal.oneill.net" > /target/root/.ssh/authorized_keys ; \
+  in-target chmod 0600 /root/.ssh/authorized_keys ; \
+  in-target mkdir /home/ansible/.ssh ; \
+  in-target chmod 0700 /home/ansible/.ssh ; \
+  echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB3URIT9ojo8mqsEjxmFu1C+Bxa3jdcKkUzM++IfDVmu coneill@xtal.oneill.net" > /target/home/ansible/.ssh/authorized_keys ; \
+  in-target chmod 0600 /home/ansible/.ssh/authorized_keys ; \
+  in-target chown -R ansible.ansible /home/ansible/.ssh ; \
+  echo 'ansible ALL=(ALL) NOPASSWD: ALL' > /target/etc/sudoers.d/ansible ; \
+  in-target chmod 440 /etc/sudoers.d/ansible ; \
+  in-target passwd -l ansible ;

--- a/ansible/roles/pxe/handlers/main.yml
+++ b/ansible/roles/pxe/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart PXE services
+  community.docker.docker_compose_v2:
+    project_src: /etc/pxe
+    state: restarted

--- a/ansible/roles/pxe/tasks/main.yml
+++ b/ansible/roles/pxe/tasks/main.yml
@@ -1,0 +1,70 @@
+---
+- name: Create PXE directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - /etc/pxe
+    - /etc/pxe/assets
+
+- name: Download iPXE bootloader
+  ansible.builtin.get_url:
+    url: https://boot.ipxe.org/undionly.kpxe
+    dest: /etc/pxe/assets/undionly.kpxe
+    mode: "0644"
+
+- name: Check if memtest exists
+  ansible.builtin.stat:
+    path: /etc/pxe/assets/memtest64.bin
+  register: pxe_memtest_stat
+
+- name: Download memtest86+
+  ansible.builtin.get_url:
+    url: https://memtest.org/download/v7.00/mt86plus_7.00.binaries.zip
+    dest: /tmp/memtest.zip
+    mode: "0644"
+  when: not pxe_memtest_stat.stat.exists
+
+- name: Extract memtest86+ binary
+  ansible.builtin.unarchive:
+    src: /tmp/memtest.zip
+    dest: /etc/pxe/assets/
+    remote_src: true
+    include:
+      - memtest64.bin
+  when: not pxe_memtest_stat.stat.exists
+
+- name: Deploy boot.ipxe script
+  ansible.builtin.copy:
+    src: boot.ipxe
+    dest: /etc/pxe/assets/boot.ipxe
+    mode: "0644"
+
+- name: Deploy preseed files
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: /etc/pxe/assets/
+    mode: "0644"
+  loop:
+    - preseed.trixie.cfg
+    - preseed.bookworm.cfg
+
+- name: Deploy dnsmasq configuration
+  ansible.builtin.copy:
+    src: dnsmasq.conf
+    dest: /etc/pxe/dnsmasq.conf
+    mode: "0644"
+  notify: Restart PXE services
+
+- name: Deploy docker-compose file
+  ansible.builtin.copy:
+    src: docker-compose.yaml
+    dest: /etc/pxe/docker-compose.yaml
+    mode: "0644"
+  notify: Restart PXE services
+
+- name: Start PXE services
+  community.docker.docker_compose_v2:
+    project_src: /etc/pxe
+    state: present

--- a/ansible/site.yaml
+++ b/ansible/site.yaml
@@ -123,6 +123,12 @@
     - role: nut
       tags: nut
 
+- name: PXE boot server
+  hosts: infrapi
+  roles:
+    - role: pxe
+      tags: pxe
+
 - name: Tailscale sysctl config
   hosts: all,!tailscale_disabled
   pre_tasks:

--- a/kubernetes/homepage/services.yaml
+++ b/kubernetes/homepage/services.yaml
@@ -1,7 +1,7 @@
 ---
 - Miscellaneous:
   - NUT WebGUI:
-      href: https://upspi.oneill.net
+      href: https://nut.oneill.net
       description: UPS Monitoring
       icon: mdi-battery-charging
   - Z-Wave JS:

--- a/opentofu/modules/dns/oneill.tf
+++ b/opentofu/modules/dns/oneill.tf
@@ -155,10 +155,18 @@ resource "aws_route53_record" "infrastructure_hosts" {
   records = [each.value.ip]
 }
 
-# Service CNAME for NUT web interface
+# Service CNAMEs for infrapi services
 resource "aws_route53_record" "nut" {
   zone_id = aws_route53_zone.oneill_net.zone_id
   name    = "nut.oneill.net"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["infrapi.oneill.net"]
+}
+
+resource "aws_route53_record" "pxe" {
+  zone_id = aws_route53_zone.oneill_net.zone_id
+  name    = "pxe.oneill.net"
   type    = "CNAME"
   ttl     = 300
   records = ["infrapi.oneill.net"]


### PR DESCRIPTION
- iPXE-based network boot with HTTP boot script
- Preseed configs for Debian Trixie and Bookworm
- dnsmasq in DHCP proxy mode for PXE discovery
- nginx serves boot files on port 8081
- Menu defaults to local disk boot after 30s timeout
- Includes memtest86+ option
- Add pxe.oneill.net DNS CNAME
