### PR TITLE
Switch ESPHome to uvx and improve bootstrap-secrets

### DIFF
--- a/.github/workflows/esphome.yaml
+++ b/.github/workflows/esphome.yaml
@@ -35,6 +35,9 @@ jobs:
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
+    - name: Install Nix
+      uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72  # v30
+
     - name: Create CI secrets.yaml (ephemeral)
       run: |
         mkdir -p esphome
@@ -56,8 +59,8 @@ jobs:
     - name: Run esphome-all compile (shard ${{ matrix.shard_index }}/${{ matrix.shard_total
         }})
       working-directory: esphome
-      run: ./scripts/esphome-all compile -j 1 --shard ${{ matrix.shard_index }}/${{
-        matrix.shard_total }}
+      run: nix develop ..#default --command ./scripts/esphome-all compile -j 1 --shard
+        ${{ matrix.shard_index }}/${{ matrix.shard_total }}
 
     - name: Collect failed logs
       if: always()

--- a/esphome/scripts/esphome
+++ b/esphome/scripts/esphome
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 
-# ESPHome Docker wrapper script
-# Uses the official ESPHome Docker image to run ESPHome commands
+# ESPHome wrapper script using uvx
+# Runs ESPHome via uv's tool execution for native serial port access
 
-# Fail fast
 set -Eeuo pipefail
 
 # ESPHome version
-ESPHOME_VERSION="2025.10.4"
+ESPHOME_VERSION="2025.10.5"
 
 # Get the directory where this script is located
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Set the ESPHome config directory (parent of scripts directory)
 ESPHOME_DIR="${ESPHOME_DIR:-$(dirname "$SCRIPT_DIR")}"
@@ -18,58 +17,5 @@ ESPHOME_DIR="${ESPHOME_DIR:-$(dirname "$SCRIPT_DIR")}"
 # Ensure we're in the ESPHome directory
 cd "$ESPHOME_DIR" || exit 1
 
-# Docker image
-DOCKER_IMAGE="ghcr.io/esphome/esphome:${ESPHOME_VERSION}"
-
-# Ensure docker is available
-if ! command -v docker >/dev/null 2>&1; then
-  echo "Error: docker not found in PATH" >&2
-  exit 127
-fi
-
-# Version-specific volume name for platformio
-PLATFORMIO_VOLUME="esphome-platformio-${ESPHOME_VERSION}"
-
-# Clean up platformio volumes from other ESPHome versions
-cleanup_old_volumes() {
-  # Get all esphome volumes
-  mapfile -t volumes < <(docker volume ls --format "{{.Name}}" | grep "^esphome-" || true)
-
-  for volume in "${volumes[@]}"; do
-    # Skip current version volume
-    if [[ "$volume" == "$PLATFORMIO_VOLUME" ]]; then
-      continue
-    fi
-
-    # Remove old version volumes
-    if [[ "$volume" =~ ^esphome-platformio- ]]; then
-      echo "Removing old ESPHome volume: $volume" >&2
-      docker volume rm "$volume" 2>/dev/null || true
-    fi
-  done
-}
-
-# Clean up old volumes on first run of a new version
-cleanup_old_volumes
-
-# Build Docker command array
-DOCKER_CMD=(docker run --rm)
-
-# Add interactive flags if running in a terminal
-if [ -t 0 ] && [ -t 1 ]; then
-  DOCKER_CMD+=(-it)
-fi
-
-# Add volume mounts and other options
-DOCKER_CMD+=(
-  -v "${ESPHOME_DIR}:/config"
-  -v "${PLATFORMIO_VOLUME}:/root/.platformio"
-  -v "/tmp/esphome:/config/.esphome"
-  -v /etc/localtime:/etc/localtime:ro
-  --network host
-  --privileged
-  "$DOCKER_IMAGE"
-)
-
-# Run ESPHome in Docker
-"${DOCKER_CMD[@]}" "$@"
+# Run ESPHome via uv with pip included (required by PlatformIO)
+exec uv run --with pip --with "esphome==${ESPHOME_VERSION}" esphome "$@"

--- a/esphome/secrets.tmpl
+++ b/esphome/secrets.tmpl
@@ -2,8 +2,8 @@
 # Vault: infra (adjust item names/fields as needed)
 
 encryption_key: "{{op://infra/esphome/encryption_key}}"
-wifi_ssid: "{{op://infra/esphome/wifi_ssid}}"
-wifi_password: "{{op://infra/esphome/wifi_password}}"
+wifi_ssid: "{{op://infra/esphome/wifi_ssid_iot}}"
+wifi_password: "{{op://infra/esphome/wifi_password_iot}}"
 ota: "{{op://infra/esphome/ota_password}}"
 
 mqtt_host: "{{op://infra/esphome/mqtt_host}}"

--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,7 @@
               rclone
               skopeo
               tflint
+              uv
               velero
               yamlfix
               yq-go

--- a/scripts/bootstrap-secrets
+++ b/scripts/bootstrap-secrets
@@ -8,15 +8,56 @@ VAULT="infra"
 
 cd "$REPO_ROOT"
 
-# Retrieve and validate all required secrets from 1Password
-get_secrets() {
-  local secrets_list=(
-    "ANSIBLE_VAULT_PASS:item get ansible-vault-password --fields password"
-    "OP_CREDENTIALS:document get 1password-credentials.json"
-    "EXTERNAL_SECRETS_TOKEN:document get external-secrets-token"
-  )
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS] [TARGETS...]
 
-  echo "Retrieving all secrets from 1Password..."
+Bootstrap secrets from 1Password for local development and cluster setup.
+
+OPTIONS:
+  --apply     Apply changes (default is diff/dry-run mode)
+  -h, --help  Show this help message
+
+TARGETS (run all if none specified):
+  ansible     Ansible vault password
+  esphome     ESPHome secrets.yaml
+  kubernetes  Kubernetes namespaces and secrets (1password, external-secrets)
+
+EXAMPLES:
+  $(basename "$0")                    # Diff all targets
+  $(basename "$0") --apply            # Apply all targets
+  $(basename "$0") esphome            # Diff ESPHome only
+  $(basename "$0") --apply esphome    # Apply ESPHome only
+  $(basename "$0") ansible esphome    # Diff ansible and esphome
+EOF
+}
+
+# Retrieve and validate required secrets from 1Password
+# Only retrieves secrets needed for the specified targets
+get_secrets() {
+  local targets=("$@")
+  local secrets_list=()
+
+  # Build list of secrets needed based on targets
+  for target in "${targets[@]}"; do
+    case "$target" in
+      ansible)
+        secrets_list+=("ANSIBLE_VAULT_PASS:item get ansible-vault-password --fields password")
+        ;;
+      kubernetes)
+        secrets_list+=("OP_CREDENTIALS:document get 1password-credentials.json")
+        secrets_list+=("EXTERNAL_SECRETS_TOKEN:document get external-secrets-token")
+        ;;
+    esac
+  done
+
+  # ESPHome uses op inject directly, no secrets to fetch here
+
+  if [[ ${#secrets_list[@]} -eq 0 ]]; then
+    return 0
+  fi
+
+  echo "Retrieving secrets from 1Password..."
 
   for secret_def in "${secrets_list[@]}"; do
     local var_name="${secret_def%%:*}"
@@ -38,79 +79,77 @@ get_secrets() {
     export "$var_name=$secret_value"
   done
 
-  echo "✅ All secrets retrieved successfully"
+  echo "✅ Secrets retrieved successfully"
 }
 
-# Parse arguments
-APPLY_MODE=false
-if [[ "${1:-}" == "--apply" ]]; then
-  APPLY_MODE=true
-  ACTION_VERB="Updating"
-  echo "🚀 Deploying bootstrap secrets..."
-else
-  ACTION_VERB="Checking"
-  echo "🔍 Diff mode: showing what would change..."
-fi
+bootstrap_ansible() {
+  local apply_mode="$1"
+  local action_verb="$2"
 
-# Retrieve all secrets upfront
-get_secrets
-
-# 1. Update Ansible vault password
-echo ""
-echo "${ACTION_VERB} Ansible vault password..."
-if [[ "$APPLY_MODE" == "true" ]]; then
-  echo "$ANSIBLE_VAULT_PASS" > ansible/ansible-vault-password
-  echo "✅ Updated ansible/ansible-vault-password"
-else
-  CURRENT_VAULT_PASS=""
-  if [[ -f "ansible/ansible-vault-password" ]]; then
-    CURRENT_VAULT_PASS=$(cat ansible/ansible-vault-password)
-  fi
-  if [[ "$CURRENT_VAULT_PASS" != "$ANSIBLE_VAULT_PASS" ]]; then
-    echo "📝 Would update ansible/ansible-vault-password"
+  echo ""
+  echo "${action_verb} Ansible vault password..."
+  if [[ "$apply_mode" == "true" ]]; then
+    echo "$ANSIBLE_VAULT_PASS" > ansible/ansible-vault-password
+    echo "✅ Updated ansible/ansible-vault-password"
   else
-    echo "✅ ansible/ansible-vault-password is up to date"
-  fi
-fi
-
-# 2. Update ESPHome secrets
-echo ""
-echo "${ACTION_VERB} ESPHome secrets..."
-if [[ -f "esphome/secrets.tmpl" ]]; then
-  if [[ "$APPLY_MODE" == "true" ]]; then
-    op inject -i esphome/secrets.tmpl -o esphome/secrets.yaml
-    echo "✅ Updated esphome/secrets.yaml"
-  else
-    # Generate what the new file would look like and compare
-    TEMP_SECRETS=$(mktemp)
-    rm -f "$TEMP_SECRETS"  # Remove it so op inject doesn't prompt to overwrite
-    op inject -i esphome/secrets.tmpl -o "$TEMP_SECRETS" >/dev/null
-
-    if [[ -f "esphome/secrets.yaml" ]]; then
-      if diff -q esphome/secrets.yaml "$TEMP_SECRETS" >/dev/null 2>&1; then
-        echo "✅ esphome/secrets.yaml is up to date"
-      else
-        echo "📝 Would update esphome/secrets.yaml:"
-        diff -u esphome/secrets.yaml "$TEMP_SECRETS" || true
-      fi
-    else
-      echo "📝 Would create esphome/secrets.yaml:"
-      echo "--- /dev/null"
-      echo "+++ esphome/secrets.yaml"
-      sed 's/^/+/' "$TEMP_SECRETS"
+    CURRENT_VAULT_PASS=""
+    if [[ -f "ansible/ansible-vault-password" ]]; then
+      CURRENT_VAULT_PASS=$(cat ansible/ansible-vault-password)
     fi
-
-    rm -f "$TEMP_SECRETS"
+    if [[ "$CURRENT_VAULT_PASS" != "$ANSIBLE_VAULT_PASS" ]]; then
+      echo "📝 Would update ansible/ansible-vault-password"
+    else
+      echo "✅ ansible/ansible-vault-password is up to date"
+    fi
   fi
-else
-  echo "⚠️  esphome/secrets.tmpl not found, skipping ESPHome secrets"
-fi
+}
 
-# 3. Create namespaces
-echo ""
-echo "${ACTION_VERB} namespaces..."
-if [[ "$APPLY_MODE" == "true" ]]; then
-  cat <<EOF | kubectl apply -f -
+bootstrap_esphome() {
+  local apply_mode="$1"
+  local action_verb="$2"
+
+  echo ""
+  echo "${action_verb} ESPHome secrets..."
+  if [[ -f "esphome/secrets.tmpl" ]]; then
+    if [[ "$apply_mode" == "true" ]]; then
+      op inject -f -i esphome/secrets.tmpl -o esphome/secrets.yaml
+      echo "✅ Updated esphome/secrets.yaml"
+    else
+      # Generate what the new file would look like and compare
+      TEMP_SECRETS=$(mktemp)
+      rm -f "$TEMP_SECRETS"  # Remove it so op inject doesn't prompt to overwrite
+      op inject -i esphome/secrets.tmpl -o "$TEMP_SECRETS" >/dev/null
+
+      if [[ -f "esphome/secrets.yaml" ]]; then
+        if diff -q esphome/secrets.yaml "$TEMP_SECRETS" >/dev/null 2>&1; then
+          echo "✅ esphome/secrets.yaml is up to date"
+        else
+          echo "📝 Would update esphome/secrets.yaml:"
+          diff -u esphome/secrets.yaml "$TEMP_SECRETS" || true
+        fi
+      else
+        echo "📝 Would create esphome/secrets.yaml:"
+        echo "--- /dev/null"
+        echo "+++ esphome/secrets.yaml"
+        sed 's/^/+/' "$TEMP_SECRETS"
+      fi
+
+      rm -f "$TEMP_SECRETS"
+    fi
+  else
+    echo "⚠️  esphome/secrets.tmpl not found, skipping ESPHome secrets"
+  fi
+}
+
+bootstrap_kubernetes() {
+  local apply_mode="$1"
+  local action_verb="$2"
+
+  # Create namespaces
+  echo ""
+  echo "${action_verb} namespaces..."
+  if [[ "$apply_mode" == "true" ]]; then
+    cat <<EOF | kubectl apply -f -
 ---
 apiVersion: v1
 kind: Namespace
@@ -122,8 +161,8 @@ kind: Namespace
 metadata:
   name: external-secrets
 EOF
-else
-  DIFF_OUTPUT=$(cat <<EOF | kubectl diff -f - 2>/dev/null || true
+  else
+    DIFF_OUTPUT=$(cat <<EOF | kubectl diff -f - 2>/dev/null || true
 ---
 apiVersion: v1
 kind: Namespace
@@ -136,67 +175,114 @@ metadata:
   name: external-secrets
 EOF
 )
-  if [[ -z "$DIFF_OUTPUT" ]]; then
-    echo "✅ namespaces are up to date"
-  else
-    echo "📝 Would update namespaces:"
-    echo "$DIFF_OUTPUT"
+    if [[ -z "$DIFF_OUTPUT" ]]; then
+      echo "✅ namespaces are up to date"
+    else
+      echo "📝 Would update namespaces:"
+      echo "$DIFF_OUTPUT"
+    fi
   fi
+
+  # Generate and apply Kubernetes secrets
+  echo ""
+  OP_CREDENTIALS_B64=$(echo "$OP_CREDENTIALS" | base64)
+
+  if [[ "$apply_mode" == "true" ]]; then
+    echo "Creating 1password-connect credentials..."
+    echo "$OP_CREDENTIALS_B64" | \
+      kubectl create secret generic op-credentials \
+      --namespace=1password \
+      --from-file=1password-credentials.json=/dev/stdin \
+      --dry-run=client -o yaml | \
+      kubectl apply -f -
+
+    echo "Creating external-secrets token..."
+    kubectl create secret generic secrets \
+      --namespace=external-secrets \
+      --from-literal=token="$EXTERNAL_SECRETS_TOKEN" \
+      --dry-run=client -o yaml | \
+      kubectl apply -f -
+  else
+    echo "Checking 1password-connect credentials..."
+    echo "$OP_CREDENTIALS_B64" | \
+      kubectl create secret generic op-credentials \
+      --namespace=1password \
+      --from-file=1password-credentials.json=/dev/stdin \
+      --dry-run=client -o yaml | \
+      kubectl diff -f - || true
+
+    echo "Checking external-secrets token..."
+    kubectl create secret generic secrets \
+      --namespace=external-secrets \
+      --from-literal=token="$EXTERNAL_SECRETS_TOKEN" \
+      --dry-run=client -o yaml | \
+      kubectl diff -f - || true
+  fi
+}
+
+# Parse arguments
+APPLY_MODE=false
+TARGETS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply)
+      APPLY_MODE=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    ansible|esphome|kubernetes)
+      TARGETS+=("$1")
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Default to all targets if none specified
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+  TARGETS=(ansible esphome kubernetes)
 fi
 
-echo ""
-
-# 4. Generate and apply Kubernetes secrets
-echo ""
-OP_CREDENTIALS_B64=$(echo "$OP_CREDENTIALS" | base64)
-
 if [[ "$APPLY_MODE" == "true" ]]; then
-  echo "Creating 1password-connect credentials..."
-  echo "$OP_CREDENTIALS_B64" | \
-    kubectl create secret generic op-credentials \
-    --namespace=1password \
-    --from-file=1password-credentials.json=/dev/stdin \
-    --dry-run=client -o yaml | \
-    kubectl apply -f -
-
-  echo "Creating external-secrets token..."
-  kubectl create secret generic secrets \
-    --namespace=external-secrets \
-    --from-literal=token="$EXTERNAL_SECRETS_TOKEN" \
-    --dry-run=client -o yaml | \
-    kubectl apply -f -
+  ACTION_VERB="Updating"
+  echo "🚀 Deploying bootstrap secrets: ${TARGETS[*]}"
 else
-  echo "Checking 1password-connect credentials..."
-  echo "$OP_CREDENTIALS_B64" | \
-    kubectl create secret generic op-credentials \
-    --namespace=1password \
-    --from-file=1password-credentials.json=/dev/stdin \
-    --dry-run=client -o yaml | \
-    kubectl diff -f - || true
-
-  echo "Checking external-secrets token..."
-  kubectl create secret generic secrets \
-    --namespace=external-secrets \
-    --from-literal=token="$EXTERNAL_SECRETS_TOKEN" \
-    --dry-run=client -o yaml | \
-    kubectl diff -f - || true
+  ACTION_VERB="Checking"
+  echo "🔍 Diff mode: showing what would change for: ${TARGETS[*]}"
 fi
 
+# Retrieve only the secrets we need
+get_secrets "${TARGETS[@]}"
+
+# Run selected targets
+for target in "${TARGETS[@]}"; do
+  case "$target" in
+    ansible)
+      bootstrap_ansible "$APPLY_MODE" "$ACTION_VERB"
+      ;;
+    esphome)
+      bootstrap_esphome "$APPLY_MODE" "$ACTION_VERB"
+      ;;
+    kubernetes)
+      bootstrap_kubernetes "$APPLY_MODE" "$ACTION_VERB"
+      ;;
+  esac
+done
+
+echo ""
 if [[ "$APPLY_MODE" == "true" ]]; then
-  echo "✅ Bootstrap secrets deployed successfully!"
-  echo ""
-  echo "📋 Summary:"
-  echo "  - Ansible: ansible/ansible-vault-password"
-  echo "  - ESPHome: esphome/secrets.yaml"
-  echo "  - Namespace: 1password"
-  echo "    - Secret: op-credentials"
-  echo "  - Namespace: external-secrets"
-  echo "    - Secret: secrets"
-  echo ""
-  echo "🎯 Services can now be deployed via ArgoCD"
+  echo "✅ Bootstrap complete!"
 else
   echo "✅ Diff complete!"
   echo ""
   echo "📋 To apply changes, run:"
-  echo "  ./scripts/bootstrap-secrets --apply"
+  echo "  ./scripts/bootstrap-secrets --apply ${TARGETS[*]}"
 fi


### PR DESCRIPTION
- Replace Docker-based ESPHome wrapper with uvx for native serial port
  access on macOS
- Add uv to flake.nix dev shell
- Update ESPHome secrets template to use IoT network credentials
- Add --help and individual target support to bootstrap-secrets script
  (ansible, esphome, kubernetes can now be run separately)
