### PR TITLE
Fix PXE boot for clients with built-in iPXE

### DIFF
--- a/ansible/host_vars/infrapi.yaml
+++ b/ansible/host_vars/infrapi.yaml
@@ -2,6 +2,17 @@
 # UPS server host - monitors all UPS devices but does NOT shut down
 # Clients will shut themselves down when they see LOWBATT
 
+# Configure ethernet-only networking (disable wifi)
+manage_network: true
+interfaces_ether_interfaces:
+  - device: eth0
+    bootproto: static
+    address: "172.19.74.224"
+    netmask: "255.255.255.0"
+    gateway: 172.19.74.1
+    dnsnameservers: 172.19.74.1
+    dnssearch: oneill.net
+
 # Override shutdown command to prevent upspi from shutting down
 # This allows upsmon to run and send notifications, but won't trigger shutdown
 nut_upsmon_extra: |

--- a/ansible/roles/pxe/files/dnsmasq.conf
+++ b/ansible/roles/pxe/files/dnsmasq.conf
@@ -4,10 +4,17 @@ enable-tftp
 tftp-root=/tftpboot
 dhcp-range=172.19.74.0,proxy,255.255.255.0
 
+# Bind only to eth0 to avoid dual-interface issues
+interface=eth0
+bind-interfaces
+
 # For legacy PXE clients: serve iPXE bootloader via TFTP, which then chainloads to HTTP
 # For iPXE clients: serve boot script directly via HTTP
 dhcp-match=set:ipxe,175
-dhcp-boot=tag:!ipxe,undionly.kpxe
-dhcp-boot=tag:ipxe,http://infrapi.oneill.net:8081/boot.ipxe
+
+# Use pxe-service for proxy mode (required for built-in iPXE clients)
+# x86 PC BIOS (type 0) - iPXE clients get HTTP boot URL, others get TFTP chainloader
+pxe-service=tag:ipxe,x86PC,"Network Boot",http://infrapi.oneill.net:8081/boot.ipxe
+pxe-service=tag:!ipxe,x86PC,"Network Boot",undionly.kpxe
 
 log-dhcp

--- a/ansible/site.yaml
+++ b/ansible/site.yaml
@@ -91,6 +91,15 @@
 
 - name: Network and security roles
   hosts: all
+  pre_tasks:
+    - name: Remove NetworkManager when managing network via interfaces
+      ansible.builtin.apt:
+        name: network-manager
+        state: absent
+        purge: true
+      become: true
+      tags: network
+      when: "manage_network | default(false) | bool"
   roles:
     - role: layereight.wifi
       when: "wifi_ssid is defined"


### PR DESCRIPTION
- Use pxe-service directives instead of dhcp-boot for proxy DHCP mode
  (required for clients like Proxmox VMs with built-in iPXE ROM)
- Configure infrapi for ethernet-only networking via interfaces role
- Remove NetworkManager on hosts using manage_network to prevent wifi
  from interfering with PXE server responses
- Bind dnsmasq to eth0 only to avoid dual-interface issues
