### PR TITLE
Enable fact caching for single playbook runs

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -6,6 +6,7 @@ roles_path = galaxy/roles
 collections_path=galaxy/collections
 nocows = 1
 interpreter_python=auto_silent
+gathering = smart
 
 [privilege_escalation]
 become=True


### PR DESCRIPTION
Cache facts with zero timeout so they're gathered once per playbook
and reused across plays, but fresh on each invocation.
