### PR TITLE
Disable become for ARA Reporting play

### DIFF
--- a/ansible/site.yaml
+++ b/ansible/site.yaml
@@ -206,6 +206,7 @@
 - name: ARA Reporting
   hosts: all
   gather_facts: false
+  become: false
   tags: [always]
   tasks:
     - name: Get current playbook ID from ARA


### PR DESCRIPTION
The global become=True in ansible.cfg was causing the ARA Reporting
tasks to attempt sudo on localhost when using delegate_to, resulting
in "sudo: a password is required" errors.
