### PR TITLE
Strip helm.sh/chart labels from rendered helm manifests

### DIFF
--- a/kubernetes/1password-connect/helm/connect/templates/connect-credentials.yaml
+++ b/kubernetes/1password-connect/helm/connect/templates/connect-credentials.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: 1password
   labels:
     app.kubernetes.io/component: connect
-    helm.sh/chart: connect-2.0.5
     app.kubernetes.io/name: connect
     app.kubernetes.io/instance: connect
     app.kubernetes.io/version: "1.8.1"

--- a/kubernetes/1password-connect/helm/connect/templates/connect-deployment.yaml
+++ b/kubernetes/1password-connect/helm/connect/templates/connect-deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: 1password
   labels:
     app.kubernetes.io/component: connect
-    helm.sh/chart: connect-2.0.5
     app.kubernetes.io/name: connect
     app.kubernetes.io/instance: connect
     app.kubernetes.io/version: "1.8.1"

--- a/kubernetes/1password-connect/helm/connect/templates/service.yaml
+++ b/kubernetes/1password-connect/helm/connect/templates/service.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: 1password
   labels:
     app.kubernetes.io/component: connect
-    helm.sh/chart: connect-2.0.5
     app.kubernetes.io/name: connect
     app.kubernetes.io/instance: connect
     app.kubernetes.io/version: "1.8.1"

--- a/kubernetes/alloy/helm/templates/configmap.yaml
+++ b/kubernetes/alloy/helm/templates/configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   name: alloy
   namespace: loki
   labels:
-    helm.sh/chart: alloy-1.2.1
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: alloy
     app.kubernetes.io/version: "v1.10.1"

--- a/kubernetes/alloy/helm/templates/controllers/daemonset.yaml
+++ b/kubernetes/alloy/helm/templates/controllers/daemonset.yaml
@@ -6,7 +6,6 @@ metadata:
   name: alloy
   namespace: loki
   labels:
-    helm.sh/chart: alloy-1.2.1
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: alloy
     app.kubernetes.io/version: "v1.10.1"

--- a/kubernetes/alloy/helm/templates/rbac.yaml
+++ b/kubernetes/alloy/helm/templates/rbac.yaml
@@ -5,7 +5,6 @@ kind: ClusterRole
 metadata:
   name: alloy
   labels:
-    helm.sh/chart: alloy-1.2.1
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: alloy
     app.kubernetes.io/version: "v1.10.1"
@@ -105,7 +104,6 @@ kind: ClusterRoleBinding
 metadata:
   name: alloy
   labels:
-    helm.sh/chart: alloy-1.2.1
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: alloy
     app.kubernetes.io/version: "v1.10.1"

--- a/kubernetes/alloy/helm/templates/service.yaml
+++ b/kubernetes/alloy/helm/templates/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: alloy
   namespace: loki
   labels:
-    helm.sh/chart: alloy-1.2.1
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: alloy
     app.kubernetes.io/version: "v1.10.1"

--- a/kubernetes/alloy/helm/templates/serviceaccount.yaml
+++ b/kubernetes/alloy/helm/templates/serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   name: alloy
   namespace: loki
   labels:
-    helm.sh/chart: alloy-1.2.1
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: alloy
     app.kubernetes.io/version: "v1.10.1"

--- a/kubernetes/argocd/helm/templates/argocd-application-controller/clusterrole.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-application-controller/clusterrole.yaml
@@ -5,7 +5,6 @@ kind: ClusterRole
 metadata:
   name: argocd-application-controller
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: application-controller

--- a/kubernetes/argocd/helm/templates/argocd-application-controller/clusterrolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-application-controller/clusterrolebinding.yaml
@@ -5,7 +5,6 @@ kind: ClusterRoleBinding
 metadata:
   name: argocd-application-controller
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: application-controller

--- a/kubernetes/argocd/helm/templates/argocd-application-controller/role.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-application-controller/role.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-application-controller
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: application-controller

--- a/kubernetes/argocd/helm/templates/argocd-application-controller/rolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-application-controller/rolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-application-controller
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: application-controller

--- a/kubernetes/argocd/helm/templates/argocd-application-controller/serviceaccount.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-application-controller/serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   name: argocd-application-controller
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: application-controller

--- a/kubernetes/argocd/helm/templates/argocd-application-controller/statefulset.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-application-controller/statefulset.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-application-controller
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: application-controller
@@ -25,7 +24,6 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: argo-cd-9.1.0
         app.kubernetes.io/name: argocd-application-controller
         app.kubernetes.io/instance: argocd
         app.kubernetes.io/component: application-controller

--- a/kubernetes/argocd/helm/templates/argocd-applicationset/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-applicationset/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-applicationset-controller
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: applicationset-controller
@@ -24,7 +23,6 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: argo-cd-9.1.0
         app.kubernetes.io/name: argocd-applicationset-controller
         app.kubernetes.io/instance: argocd
         app.kubernetes.io/component: applicationset-controller

--- a/kubernetes/argocd/helm/templates/argocd-applicationset/role.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-applicationset/role.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-applicationset-controller
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: applicationset-controller

--- a/kubernetes/argocd/helm/templates/argocd-applicationset/rolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-applicationset/rolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-applicationset-controller
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: applicationset-controller

--- a/kubernetes/argocd/helm/templates/argocd-applicationset/service.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-applicationset/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-applicationset-controller
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: applicationset-controller

--- a/kubernetes/argocd/helm/templates/argocd-applicationset/serviceaccount.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-applicationset/serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   name: argocd-applicationset-controller
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: applicationset-controller

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-cm.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-cm
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: server

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-cmd-params-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-cmd-params-cm.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-cmd-params-cm
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-cmd-params-cm
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: server

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-gpg-keys-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-gpg-keys-cm.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-gpg-keys-cm
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-gpg-keys-cm
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/managed-by: Helm

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-notifications-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-notifications-cm.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-notifications-cm
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: notifications-controller

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-notifications-secret.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-notifications-secret.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-notifications-secret
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: notifications-controller

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-rbac-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-rbac-cm.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-rbac-cm
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-rbac-cm
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: server

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-secret.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-secret.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-secret
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-secret
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: server

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-ssh-known-hosts-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-ssh-known-hosts-cm.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-ssh-known-hosts-cm
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-ssh-known-hosts-cm
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/managed-by: Helm

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-tls-certs-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-tls-certs-cm.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-tls-certs-cm
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-tls-certs-cm
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/managed-by: Helm

--- a/kubernetes/argocd/helm/templates/argocd-notifications/clusterrole.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-notifications/clusterrole.yaml
@@ -5,7 +5,6 @@ kind: ClusterRole
 metadata:
   name: argocd-notifications-controller
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: notifications-controller

--- a/kubernetes/argocd/helm/templates/argocd-notifications/clusterrolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-notifications/clusterrolebinding.yaml
@@ -5,7 +5,6 @@ kind: ClusterRoleBinding
 metadata:
   name: argocd-notifications-controller
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: notifications-controller

--- a/kubernetes/argocd/helm/templates/argocd-notifications/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-notifications/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-notifications-controller
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: notifications-controller
@@ -26,7 +25,6 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: argo-cd-9.1.0
         app.kubernetes.io/name: argocd-notifications-controller
         app.kubernetes.io/instance: argocd
         app.kubernetes.io/component: notifications-controller

--- a/kubernetes/argocd/helm/templates/argocd-notifications/role.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-notifications/role.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-notifications-controller
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: notifications-controller

--- a/kubernetes/argocd/helm/templates/argocd-notifications/rolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-notifications/rolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-notifications-controller
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: notifications-controller

--- a/kubernetes/argocd/helm/templates/argocd-notifications/serviceaccount.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-notifications/serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   name: argocd-notifications-controller
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: notifications-controller

--- a/kubernetes/argocd/helm/templates/argocd-repo-server/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-repo-server/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-repo-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: repo-server
@@ -24,7 +23,6 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: argo-cd-9.1.0
         app.kubernetes.io/name: argocd-repo-server
         app.kubernetes.io/instance: argocd
         app.kubernetes.io/component: repo-server

--- a/kubernetes/argocd/helm/templates/argocd-repo-server/role.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-repo-server/role.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-repo-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: repo-server

--- a/kubernetes/argocd/helm/templates/argocd-repo-server/rolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-repo-server/rolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-repo-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: repo-server

--- a/kubernetes/argocd/helm/templates/argocd-repo-server/service.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-repo-server/service.yaml
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: repo-server

--- a/kubernetes/argocd/helm/templates/argocd-repo-server/serviceaccount.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-repo-server/serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   name: argocd-repo-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: repo-server

--- a/kubernetes/argocd/helm/templates/argocd-server/certificate.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/certificate.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: server

--- a/kubernetes/argocd/helm/templates/argocd-server/clusterrole.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/clusterrole.yaml
@@ -5,7 +5,6 @@ kind: ClusterRole
 metadata:
   name: argocd-server
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: server

--- a/kubernetes/argocd/helm/templates/argocd-server/clusterrolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/clusterrolebinding.yaml
@@ -5,7 +5,6 @@ kind: ClusterRoleBinding
 metadata:
   name: argocd-server
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: server

--- a/kubernetes/argocd/helm/templates/argocd-server/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: server
@@ -24,7 +23,6 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: argo-cd-9.1.0
         app.kubernetes.io/name: argocd-server
         app.kubernetes.io/instance: argocd
         app.kubernetes.io/component: server

--- a/kubernetes/argocd/helm/templates/argocd-server/ingress.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: server

--- a/kubernetes/argocd/helm/templates/argocd-server/role.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/role.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: server

--- a/kubernetes/argocd/helm/templates/argocd-server/rolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/rolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: server

--- a/kubernetes/argocd/helm/templates/argocd-server/service.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: server

--- a/kubernetes/argocd/helm/templates/argocd-server/serviceaccount.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   name: argocd-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: server

--- a/kubernetes/argocd/helm/templates/dex/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/dex/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-dex-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: dex-server
@@ -24,7 +23,6 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: argo-cd-9.1.0
         app.kubernetes.io/name: argocd-dex-server
         app.kubernetes.io/instance: argocd
         app.kubernetes.io/component: dex-server

--- a/kubernetes/argocd/helm/templates/dex/role.yaml
+++ b/kubernetes/argocd/helm/templates/dex/role.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-dex-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: dex-server

--- a/kubernetes/argocd/helm/templates/dex/rolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/dex/rolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-dex-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: dex-server

--- a/kubernetes/argocd/helm/templates/dex/service.yaml
+++ b/kubernetes/argocd/helm/templates/dex/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-dex-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: dex-server

--- a/kubernetes/argocd/helm/templates/dex/serviceaccount.yaml
+++ b/kubernetes/argocd/helm/templates/dex/serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   name: argocd-dex-server
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: dex-server

--- a/kubernetes/argocd/helm/templates/redis-secret-init/job.yaml
+++ b/kubernetes/argocd/helm/templates/redis-secret-init/job.yaml
@@ -9,7 +9,6 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-redis-secret-init
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: redis-secret-init
@@ -21,7 +20,6 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: argo-cd-9.1.0
         app.kubernetes.io/name: argocd-redis-secret-init
         app.kubernetes.io/instance: argocd
         app.kubernetes.io/component: redis-secret-init

--- a/kubernetes/argocd/helm/templates/redis-secret-init/role.yaml
+++ b/kubernetes/argocd/helm/templates/redis-secret-init/role.yaml
@@ -7,7 +7,6 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-redis-secret-init
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: redis-secret-init

--- a/kubernetes/argocd/helm/templates/redis-secret-init/rolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/redis-secret-init/rolebinding.yaml
@@ -7,7 +7,6 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-redis-secret-init
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: redis-secret-init

--- a/kubernetes/argocd/helm/templates/redis-secret-init/serviceaccount.yaml
+++ b/kubernetes/argocd/helm/templates/redis-secret-init/serviceaccount.yaml
@@ -10,7 +10,6 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-redis-secret-init
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: redis-secret-init

--- a/kubernetes/argocd/helm/templates/redis/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/redis/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-redis
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: redis
@@ -22,7 +21,6 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: argo-cd-9.1.0
         app.kubernetes.io/name: argocd-redis
         app.kubernetes.io/instance: argocd
         app.kubernetes.io/component: redis

--- a/kubernetes/argocd/helm/templates/redis/health-configmap.yaml
+++ b/kubernetes/argocd/helm/templates/redis/health-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-redis-health-configmap
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: redis

--- a/kubernetes/argocd/helm/templates/redis/service.yaml
+++ b/kubernetes/argocd/helm/templates/redis/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: argocd-redis
   namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.1.0
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/component: redis

--- a/kubernetes/authentik/helm/authentik/secret.yaml
+++ b/kubernetes/authentik/helm/authentik/secret.yaml
@@ -6,7 +6,6 @@ metadata:
   name: authentik
   namespace: "authentik"
   labels:
-    helm.sh/chart: "authentik-2025.8.4"
     app.kubernetes.io/name: "authentik"
     app.kubernetes.io/instance: "authentik"
     app.kubernetes.io/managed-by: "Helm"

--- a/kubernetes/authentik/helm/authentik/server/deployment.yaml
+++ b/kubernetes/authentik/helm/authentik/server/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: authentik-server
   namespace: "authentik"
   labels:
-    helm.sh/chart: "authentik-2025.8.4"
     app.kubernetes.io/name: "authentik"
     app.kubernetes.io/instance: "authentik"
     app.kubernetes.io/component: "server"
@@ -24,7 +23,6 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: "authentik-2025.8.4"
         app.kubernetes.io/name: "authentik"
         app.kubernetes.io/instance: "authentik"
         app.kubernetes.io/component: "server"

--- a/kubernetes/authentik/helm/authentik/server/ingress.yaml
+++ b/kubernetes/authentik/helm/authentik/server/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   name: authentik-server
   namespace: "authentik"
   labels:
-    helm.sh/chart: "authentik-2025.8.4"
     app.kubernetes.io/name: "authentik"
     app.kubernetes.io/instance: "authentik"
     app.kubernetes.io/component: "server"

--- a/kubernetes/authentik/helm/authentik/server/service.yaml
+++ b/kubernetes/authentik/helm/authentik/server/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: authentik-server
   namespace: "authentik"
   labels:
-    helm.sh/chart: "authentik-2025.8.4"
     app.kubernetes.io/name: "authentik"
     app.kubernetes.io/instance: "authentik"
     app.kubernetes.io/component: "server"

--- a/kubernetes/authentik/helm/authentik/serviceAccount/templates/clusterrole.yaml
+++ b/kubernetes/authentik/helm/authentik/serviceAccount/templates/clusterrole.yaml
@@ -5,7 +5,6 @@ kind: ClusterRole
 metadata:
   name: "authentik-authentik"
   labels:
-    helm.sh/chart: "serviceAccount-2.1.0"
     app.kubernetes.io/name: "serviceAccount"
     app.kubernetes.io/instance: "authentik"
     app.kubernetes.io/managed-by: "Helm"

--- a/kubernetes/authentik/helm/authentik/serviceAccount/templates/clusterrolebinding.yaml
+++ b/kubernetes/authentik/helm/authentik/serviceAccount/templates/clusterrolebinding.yaml
@@ -5,7 +5,6 @@ kind: ClusterRoleBinding
 metadata:
   name: "authentik-authentik"
   labels:
-    helm.sh/chart: "serviceAccount-2.1.0"
     app.kubernetes.io/name: "serviceAccount"
     app.kubernetes.io/instance: "authentik"
     app.kubernetes.io/managed-by: "Helm"

--- a/kubernetes/authentik/helm/authentik/serviceAccount/templates/role.yaml
+++ b/kubernetes/authentik/helm/authentik/serviceAccount/templates/role.yaml
@@ -6,7 +6,6 @@ metadata:
   name: authentik
   namespace: "authentik"
   labels:
-    helm.sh/chart: "serviceAccount-2.1.0"
     app.kubernetes.io/name: "serviceAccount"
     app.kubernetes.io/instance: "authentik"
     app.kubernetes.io/managed-by: "Helm"

--- a/kubernetes/authentik/helm/authentik/serviceAccount/templates/rolebinding.yaml
+++ b/kubernetes/authentik/helm/authentik/serviceAccount/templates/rolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
   name: authentik
   namespace: "authentik"
   labels:
-    helm.sh/chart: "serviceAccount-2.1.0"
     app.kubernetes.io/name: "serviceAccount"
     app.kubernetes.io/instance: "authentik"
     app.kubernetes.io/managed-by: "Helm"

--- a/kubernetes/authentik/helm/authentik/serviceAccount/templates/serviceaccount.yaml
+++ b/kubernetes/authentik/helm/authentik/serviceAccount/templates/serviceaccount.yaml
@@ -6,7 +6,6 @@ metadata:
   name: authentik
   namespace: "authentik"
   labels:
-    helm.sh/chart: "serviceAccount-2.1.0"
     app.kubernetes.io/name: "serviceAccount"
     app.kubernetes.io/instance: "authentik"
     app.kubernetes.io/managed-by: "Helm"

--- a/kubernetes/authentik/helm/authentik/worker/deployment.yaml
+++ b/kubernetes/authentik/helm/authentik/worker/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: authentik-worker
   namespace: "authentik"
   labels:
-    helm.sh/chart: "authentik-2025.8.4"
     app.kubernetes.io/name: "authentik"
     app.kubernetes.io/instance: "authentik"
     app.kubernetes.io/component: "worker"
@@ -24,7 +23,6 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: "authentik-2025.8.4"
         app.kubernetes.io/name: "authentik"
         app.kubernetes.io/instance: "authentik"
         app.kubernetes.io/component: "worker"

--- a/kubernetes/authentik/helm/valkey/pvc.yaml
+++ b/kubernetes/authentik/helm/valkey/pvc.yaml
@@ -5,7 +5,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: valkey-2.1.6
     app.kubernetes.io/name: valkey
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/version: "8.1.4"

--- a/kubernetes/authentik/helm/valkey/scripts.yaml
+++ b/kubernetes/authentik/helm/valkey/scripts.yaml
@@ -5,7 +5,6 @@ kind: ConfigMap
 metadata:
   name: valkey-scripts
   labels:
-    helm.sh/chart: valkey-2.1.6
     app.kubernetes.io/name: valkey
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/version: "8.1.4"

--- a/kubernetes/authentik/helm/valkey/service-internal.yaml
+++ b/kubernetes/authentik/helm/valkey/service-internal.yaml
@@ -5,7 +5,6 @@ kind: Service
 metadata:
   name: valkey-headless
   labels:
-    helm.sh/chart: valkey-2.1.6
     app.kubernetes.io/name: valkey
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/version: "8.1.4"

--- a/kubernetes/authentik/helm/valkey/services.yaml
+++ b/kubernetes/authentik/helm/valkey/services.yaml
@@ -5,7 +5,6 @@ kind: Service
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: valkey-2.1.6
     app.kubernetes.io/name: valkey
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/version: "8.1.4"

--- a/kubernetes/authentik/helm/valkey/statefulset.yaml
+++ b/kubernetes/authentik/helm/valkey/statefulset.yaml
@@ -5,7 +5,6 @@ kind: Deployment
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: valkey-2.1.6
     app.kubernetes.io/name: valkey
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/version: "8.1.4"

--- a/kubernetes/cert-manager/helm/templates/cainjector-deployment.yaml
+++ b/kubernetes/cert-manager/helm/templates/cainjector-deployment.yaml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/component: "cainjector"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 spec:
   replicas: 1
   selector:
@@ -29,7 +28,6 @@ spec:
         app.kubernetes.io/component: "cainjector"
         app.kubernetes.io/version: "v1.19.1"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.19.1
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'

--- a/kubernetes/cert-manager/helm/templates/cainjector-rbac.yaml
+++ b/kubernetes/cert-manager/helm/templates/cainjector-rbac.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/component: "cainjector"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -44,7 +43,6 @@ metadata:
     app.kubernetes.io/component: "cainjector"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -68,7 +66,6 @@ metadata:
     app.kubernetes.io/component: "cainjector"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -98,7 +95,6 @@ metadata:
     app.kubernetes.io/component: "cainjector"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/kubernetes/cert-manager/helm/templates/cainjector-service.yaml
+++ b/kubernetes/cert-manager/helm/templates/cainjector-service.yaml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/component: "cainjector"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 spec:
   type: ClusterIP
   ports:

--- a/kubernetes/cert-manager/helm/templates/cainjector-serviceaccount.yaml
+++ b/kubernetes/cert-manager/helm/templates/cainjector-serviceaccount.yaml
@@ -13,4 +13,3 @@ metadata:
     app.kubernetes.io/component: "cainjector"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1

--- a/kubernetes/cert-manager/helm/templates/crd-acme.cert-manager.io_challenges.yaml
+++ b/kubernetes/cert-manager/helm/templates/crd-acme.cert-manager.io_challenges.yaml
@@ -13,7 +13,6 @@ metadata:
     app.kubernetes.io/component: "crds"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 spec:
   group: acme.cert-manager.io
   names:

--- a/kubernetes/cert-manager/helm/templates/crd-acme.cert-manager.io_orders.yaml
+++ b/kubernetes/cert-manager/helm/templates/crd-acme.cert-manager.io_orders.yaml
@@ -13,7 +13,6 @@ metadata:
     app.kubernetes.io/component: "crds"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 spec:
   group: acme.cert-manager.io
   names:

--- a/kubernetes/cert-manager/helm/templates/crd-cert-manager.io_certificaterequests.yaml
+++ b/kubernetes/cert-manager/helm/templates/crd-cert-manager.io_certificaterequests.yaml
@@ -13,7 +13,6 @@ metadata:
     app.kubernetes.io/component: "crds"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 spec:
   group: cert-manager.io
   names:

--- a/kubernetes/cert-manager/helm/templates/crd-cert-manager.io_certificates.yaml
+++ b/kubernetes/cert-manager/helm/templates/crd-cert-manager.io_certificates.yaml
@@ -13,7 +13,6 @@ metadata:
     app.kubernetes.io/component: "crds"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 spec:
   group: cert-manager.io
   names:

--- a/kubernetes/cert-manager/helm/templates/crd-cert-manager.io_clusterissuers.yaml
+++ b/kubernetes/cert-manager/helm/templates/crd-cert-manager.io_clusterissuers.yaml
@@ -13,7 +13,6 @@ metadata:
     app.kubernetes.io/component: "crds"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 spec:
   group: cert-manager.io
   names:

--- a/kubernetes/cert-manager/helm/templates/crd-cert-manager.io_issuers.yaml
+++ b/kubernetes/cert-manager/helm/templates/crd-cert-manager.io_issuers.yaml
@@ -13,7 +13,6 @@ metadata:
     app.kubernetes.io/component: "crds"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 spec:
   group: cert-manager.io
   names:

--- a/kubernetes/cert-manager/helm/templates/deployment.yaml
+++ b/kubernetes/cert-manager/helm/templates/deployment.yaml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 spec:
   replicas: 1
   selector:
@@ -29,7 +28,6 @@ spec:
         app.kubernetes.io/component: "controller"
         app.kubernetes.io/version: "v1.19.1"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.19.1
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'

--- a/kubernetes/cert-manager/helm/templates/rbac.yaml
+++ b/kubernetes/cert-manager/helm/templates/rbac.yaml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -40,7 +39,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -68,7 +66,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -105,7 +102,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -145,7 +141,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -207,7 +202,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -246,7 +240,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
   - apiGroups: ["cert-manager.io"]
@@ -265,7 +258,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -290,7 +282,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -317,7 +308,6 @@ metadata:
     app.kubernetes.io/component: "cert-manager"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -341,7 +331,6 @@ metadata:
     app.kubernetes.io/component: "cert-manager"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -369,7 +358,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -391,7 +379,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -413,7 +400,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -435,7 +421,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -457,7 +442,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -479,7 +463,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -501,7 +484,6 @@ metadata:
     app.kubernetes.io/component: "cert-manager"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -523,7 +505,6 @@ metadata:
     app.kubernetes.io/component: "cert-manager"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -546,7 +527,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -569,7 +549,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 rules:
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
@@ -591,7 +570,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -615,7 +593,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/kubernetes/cert-manager/helm/templates/service.yaml
+++ b/kubernetes/cert-manager/helm/templates/service.yaml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 spec:
   type: ClusterIP
   ports:

--- a/kubernetes/cert-manager/helm/templates/serviceaccount.yaml
+++ b/kubernetes/cert-manager/helm/templates/serviceaccount.yaml
@@ -13,4 +13,3 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1

--- a/kubernetes/cert-manager/helm/templates/startupapicheck-rbac.yaml
+++ b/kubernetes/cert-manager/helm/templates/startupapicheck-rbac.yaml
@@ -13,7 +13,6 @@ metadata:
     app.kubernetes.io/component: "startupapicheck"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -36,7 +35,6 @@ metadata:
     app.kubernetes.io/component: "startupapicheck"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded

--- a/kubernetes/cert-manager/helm/templates/startupapicheck-serviceaccount.yaml
+++ b/kubernetes/cert-manager/helm/templates/startupapicheck-serviceaccount.yaml
@@ -17,4 +17,3 @@ metadata:
     app.kubernetes.io/component: "startupapicheck"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1

--- a/kubernetes/cert-manager/helm/templates/webhook-deployment.yaml
+++ b/kubernetes/cert-manager/helm/templates/webhook-deployment.yaml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/component: "webhook"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 spec:
   replicas: 1
   selector:
@@ -29,7 +28,6 @@ spec:
         app.kubernetes.io/component: "webhook"
         app.kubernetes.io/version: "v1.19.1"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.19.1
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'

--- a/kubernetes/cert-manager/helm/templates/webhook-mutating-webhook.yaml
+++ b/kubernetes/cert-manager/helm/templates/webhook-mutating-webhook.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/component: "webhook"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
   annotations:
     cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
 webhooks:

--- a/kubernetes/cert-manager/helm/templates/webhook-rbac.yaml
+++ b/kubernetes/cert-manager/helm/templates/webhook-rbac.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/component: "webhook"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -29,7 +28,6 @@ metadata:
     app.kubernetes.io/component: "webhook"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -52,7 +50,6 @@ metadata:
     app.kubernetes.io/component: "webhook"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -77,7 +74,6 @@ metadata:
     app.kubernetes.io/component: "webhook"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/kubernetes/cert-manager/helm/templates/webhook-service.yaml
+++ b/kubernetes/cert-manager/helm/templates/webhook-service.yaml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/component: "webhook"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
 spec:
   type: ClusterIP
   ports:

--- a/kubernetes/cert-manager/helm/templates/webhook-serviceaccount.yaml
+++ b/kubernetes/cert-manager/helm/templates/webhook-serviceaccount.yaml
@@ -13,4 +13,3 @@ metadata:
     app.kubernetes.io/component: "webhook"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1

--- a/kubernetes/cert-manager/helm/templates/webhook-validating-webhook.yaml
+++ b/kubernetes/cert-manager/helm/templates/webhook-validating-webhook.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/component: "webhook"
     app.kubernetes.io/version: "v1.19.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.1
   annotations:
     cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
 webhooks:

--- a/kubernetes/cloudnative-pg/helm/templates/config.yaml
+++ b/kubernetes/cloudnative-pg/helm/templates/config.yaml
@@ -24,7 +24,6 @@ metadata:
   name: cnpg-controller-manager-config
   namespace: cnpg-system
   labels:
-    helm.sh/chart: cloudnative-pg-0.26.1
     app.kubernetes.io/name: cloudnative-pg
     app.kubernetes.io/instance: cloudnative-pg
     app.kubernetes.io/version: "1.27.1"

--- a/kubernetes/cloudnative-pg/helm/templates/deployment.yaml
+++ b/kubernetes/cloudnative-pg/helm/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: cloudnative-pg
   namespace: cnpg-system
   labels:
-    helm.sh/chart: cloudnative-pg-0.26.1
     app.kubernetes.io/name: cloudnative-pg
     app.kubernetes.io/instance: cloudnative-pg
     app.kubernetes.io/version: "1.27.1"

--- a/kubernetes/cloudnative-pg/helm/templates/monitoring-configmap.yaml
+++ b/kubernetes/cloudnative-pg/helm/templates/monitoring-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   name: cnpg-default-monitoring
   namespace: cnpg-system
   labels:
-    helm.sh/chart: cloudnative-pg-0.26.1
     app.kubernetes.io/name: cloudnative-pg
     app.kubernetes.io/instance: cloudnative-pg
     app.kubernetes.io/version: "1.27.1"

--- a/kubernetes/cloudnative-pg/helm/templates/mutatingwebhookconfiguration.yaml
+++ b/kubernetes/cloudnative-pg/helm/templates/mutatingwebhookconfiguration.yaml
@@ -25,7 +25,6 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: cnpg-mutating-webhook-configuration
   labels:
-    helm.sh/chart: cloudnative-pg-0.26.1
     app.kubernetes.io/name: cloudnative-pg
     app.kubernetes.io/instance: cloudnative-pg
     app.kubernetes.io/version: "1.27.1"

--- a/kubernetes/cloudnative-pg/helm/templates/rbac.yaml
+++ b/kubernetes/cloudnative-pg/helm/templates/rbac.yaml
@@ -6,7 +6,6 @@ metadata:
   name: cloudnative-pg
   namespace: cnpg-system
   labels:
-    helm.sh/chart: cloudnative-pg-0.26.1
     app.kubernetes.io/name: cloudnative-pg
     app.kubernetes.io/instance: cloudnative-pg
     app.kubernetes.io/version: "1.27.1"
@@ -18,7 +17,6 @@ kind: ClusterRole
 metadata:
   name: cloudnative-pg
   labels:
-    helm.sh/chart: cloudnative-pg-0.26.1
     app.kubernetes.io/name: cloudnative-pg
     app.kubernetes.io/instance: cloudnative-pg
     app.kubernetes.io/version: "1.27.1"
@@ -258,7 +256,6 @@ kind: ClusterRole
 metadata:
   name: cloudnative-pg-view
   labels:
-    helm.sh/chart: cloudnative-pg-0.26.1
     app.kubernetes.io/name: cloudnative-pg
     app.kubernetes.io/instance: cloudnative-pg
     app.kubernetes.io/version: "1.27.1"
@@ -289,7 +286,6 @@ kind: ClusterRole
 metadata:
   name: cloudnative-pg-edit
   labels:
-    helm.sh/chart: cloudnative-pg-0.26.1
     app.kubernetes.io/name: cloudnative-pg
     app.kubernetes.io/instance: cloudnative-pg
     app.kubernetes.io/version: "1.27.1"
@@ -322,7 +318,6 @@ kind: ClusterRoleBinding
 metadata:
   name: cloudnative-pg
   labels:
-    helm.sh/chart: cloudnative-pg-0.26.1
     app.kubernetes.io/name: cloudnative-pg
     app.kubernetes.io/instance: cloudnative-pg
     app.kubernetes.io/version: "1.27.1"

--- a/kubernetes/cloudnative-pg/helm/templates/service.yaml
+++ b/kubernetes/cloudnative-pg/helm/templates/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: cnpg-webhook-service
   namespace: cnpg-system
   labels:
-    helm.sh/chart: cloudnative-pg-0.26.1
     app.kubernetes.io/name: cloudnative-pg
     app.kubernetes.io/instance: cloudnative-pg
     app.kubernetes.io/version: "1.27.1"

--- a/kubernetes/cloudnative-pg/helm/templates/validatingwebhookconfiguration.yaml
+++ b/kubernetes/cloudnative-pg/helm/templates/validatingwebhookconfiguration.yaml
@@ -25,7 +25,6 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: cnpg-validating-webhook-configuration
   labels:
-    helm.sh/chart: cloudnative-pg-0.26.1
     app.kubernetes.io/name: cloudnative-pg
     app.kubernetes.io/instance: cloudnative-pg
     app.kubernetes.io/version: "1.27.1"

--- a/kubernetes/dawarich/helm/valkey/pvc.yaml
+++ b/kubernetes/dawarich/helm/valkey/pvc.yaml
@@ -5,7 +5,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: valkey-2.1.6
     app.kubernetes.io/name: valkey
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/version: "8.1.4"

--- a/kubernetes/dawarich/helm/valkey/scripts.yaml
+++ b/kubernetes/dawarich/helm/valkey/scripts.yaml
@@ -5,7 +5,6 @@ kind: ConfigMap
 metadata:
   name: valkey-scripts
   labels:
-    helm.sh/chart: valkey-2.1.6
     app.kubernetes.io/name: valkey
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/version: "8.1.4"

--- a/kubernetes/dawarich/helm/valkey/service-internal.yaml
+++ b/kubernetes/dawarich/helm/valkey/service-internal.yaml
@@ -5,7 +5,6 @@ kind: Service
 metadata:
   name: valkey-headless
   labels:
-    helm.sh/chart: valkey-2.1.6
     app.kubernetes.io/name: valkey
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/version: "8.1.4"

--- a/kubernetes/dawarich/helm/valkey/services.yaml
+++ b/kubernetes/dawarich/helm/valkey/services.yaml
@@ -5,7 +5,6 @@ kind: Service
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: valkey-2.1.6
     app.kubernetes.io/name: valkey
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/version: "8.1.4"

--- a/kubernetes/dawarich/helm/valkey/statefulset.yaml
+++ b/kubernetes/dawarich/helm/valkey/statefulset.yaml
@@ -5,7 +5,6 @@ kind: Deployment
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: valkey-2.1.6
     app.kubernetes.io/name: valkey
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/version: "8.1.4"

--- a/kubernetes/democratic-csi/helm/templates/configmap.yaml
+++ b/kubernetes/democratic-csi/helm/templates/configmap.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: democratic-csi
   labels:
     app.kubernetes.io/name: democratic-csi
-    helm.sh/chart: democratic-csi-0.15.0
     app.kubernetes.io/instance: democratic-csi
     app.kubernetes.io/managed-by: Helm
 data:

--- a/kubernetes/democratic-csi/helm/templates/controller-rbac.yaml
+++ b/kubernetes/democratic-csi/helm/templates/controller-rbac.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: democratic-csi
   labels:
     app.kubernetes.io/name: democratic-csi
-    helm.sh/chart: democratic-csi-0.15.0
     app.kubernetes.io/instance: democratic-csi
     app.kubernetes.io/managed-by: Helm
 ---
@@ -18,7 +17,6 @@ metadata:
   name: democratic-csi-controller-cr
   labels:
     app.kubernetes.io/name: democratic-csi
-    helm.sh/chart: democratic-csi-0.15.0
     app.kubernetes.io/instance: democratic-csi
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -101,7 +99,6 @@ metadata:
   name: democratic-csi-controller-rb
   labels:
     app.kubernetes.io/name: democratic-csi
-    helm.sh/chart: democratic-csi-0.15.0
     app.kubernetes.io/instance: democratic-csi
     app.kubernetes.io/managed-by: Helm
 roleRef:

--- a/kubernetes/democratic-csi/helm/templates/controller.yaml
+++ b/kubernetes/democratic-csi/helm/templates/controller.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: democratic-csi
   labels:
     app.kubernetes.io/name: democratic-csi
-    helm.sh/chart: democratic-csi-0.15.0
     app.kubernetes.io/instance: democratic-csi
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/csi-role: "controller"

--- a/kubernetes/democratic-csi/helm/templates/driver.yaml
+++ b/kubernetes/democratic-csi/helm/templates/driver.yaml
@@ -6,7 +6,6 @@ metadata:
   name: org.democratic-csi.synology-iscsi
   labels:
     app.kubernetes.io/name: democratic-csi
-    helm.sh/chart: democratic-csi-0.15.0
     app.kubernetes.io/instance: democratic-csi
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/kubernetes/democratic-csi/helm/templates/node-rbac.yaml
+++ b/kubernetes/democratic-csi/helm/templates/node-rbac.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: democratic-csi
   labels:
     app.kubernetes.io/name: democratic-csi
-    helm.sh/chart: democratic-csi-0.15.0
     app.kubernetes.io/instance: democratic-csi
     app.kubernetes.io/managed-by: Helm
 ---
@@ -18,7 +17,6 @@ metadata:
   name: democratic-csi-node-cr
   labels:
     app.kubernetes.io/name: democratic-csi
-    helm.sh/chart: democratic-csi-0.15.0
     app.kubernetes.io/instance: democratic-csi
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -43,7 +41,6 @@ metadata:
   name: democratic-csi-node-rb
   labels:
     app.kubernetes.io/name: democratic-csi
-    helm.sh/chart: democratic-csi-0.15.0
     app.kubernetes.io/instance: democratic-csi
     app.kubernetes.io/managed-by: Helm
 roleRef:

--- a/kubernetes/democratic-csi/helm/templates/node.yaml
+++ b/kubernetes/democratic-csi/helm/templates/node.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: democratic-csi
   labels:
     app.kubernetes.io/name: democratic-csi
-    helm.sh/chart: democratic-csi-0.15.0
     app.kubernetes.io/instance: democratic-csi
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/csi-role: "node"

--- a/kubernetes/democratic-csi/helm/templates/snapshot-classes.yaml
+++ b/kubernetes/democratic-csi/helm/templates/snapshot-classes.yaml
@@ -7,7 +7,6 @@ metadata:
   annotations:
   labels:
     app.kubernetes.io/name: democratic-csi
-    helm.sh/chart: democratic-csi-0.15.0
     app.kubernetes.io/instance: democratic-csi
     app.kubernetes.io/managed-by: Helm
 driver: org.democratic-csi.synology-iscsi

--- a/kubernetes/democratic-csi/helm/templates/storage-classes.yaml
+++ b/kubernetes/democratic-csi/helm/templates/storage-classes.yaml
@@ -6,7 +6,6 @@ metadata:
   name: synology-iscsi
   labels:
     app.kubernetes.io/name: democratic-csi
-    helm.sh/chart: democratic-csi-0.15.0
     app.kubernetes.io/instance: democratic-csi
     app.kubernetes.io/managed-by: Helm
 provisioner: org.democratic-csi.synology-iscsi

--- a/kubernetes/descheduler/helm/templates/clusterrole.yaml
+++ b/kubernetes/descheduler/helm/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
   name: descheduler
   labels:
     app.kubernetes.io/name: descheduler
-    helm.sh/chart: descheduler-0.34.0
     app.kubernetes.io/instance: descheduler
     app.kubernetes.io/version: "0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/kubernetes/descheduler/helm/templates/clusterrolebinding.yaml
+++ b/kubernetes/descheduler/helm/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
   name: descheduler
   labels:
     app.kubernetes.io/name: descheduler
-    helm.sh/chart: descheduler-0.34.0
     app.kubernetes.io/instance: descheduler
     app.kubernetes.io/version: "0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/kubernetes/descheduler/helm/templates/configmap.yaml
+++ b/kubernetes/descheduler/helm/templates/configmap.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: descheduler
-    helm.sh/chart: descheduler-0.34.0
     app.kubernetes.io/instance: descheduler
     app.kubernetes.io/version: "0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/kubernetes/descheduler/helm/templates/cronjob.yaml
+++ b/kubernetes/descheduler/helm/templates/cronjob.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: descheduler
-    helm.sh/chart: descheduler-0.34.0
     app.kubernetes.io/instance: descheduler
     app.kubernetes.io/version: "0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/kubernetes/descheduler/helm/templates/serviceaccount.yaml
+++ b/kubernetes/descheduler/helm/templates/serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: descheduler
-    helm.sh/chart: descheduler-0.34.0
     app.kubernetes.io/instance: descheduler
     app.kubernetes.io/version: "0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/kubernetes/external-dns/helm/templates/clusterrole.yaml
+++ b/kubernetes/external-dns/helm/templates/clusterrole.yaml
@@ -5,7 +5,6 @@ kind: ClusterRole
 metadata:
   name: external-dns
   labels:
-    helm.sh/chart: external-dns-1.19.0
     app.kubernetes.io/name: external-dns
     app.kubernetes.io/instance: external-dns
     app.kubernetes.io/version: "0.19.0"

--- a/kubernetes/external-dns/helm/templates/clusterrolebinding.yaml
+++ b/kubernetes/external-dns/helm/templates/clusterrolebinding.yaml
@@ -5,7 +5,6 @@ kind: ClusterRoleBinding
 metadata:
   name: external-dns-viewer
   labels:
-    helm.sh/chart: external-dns-1.19.0
     app.kubernetes.io/name: external-dns
     app.kubernetes.io/instance: external-dns
     app.kubernetes.io/version: "0.19.0"

--- a/kubernetes/external-dns/helm/templates/deployment.yaml
+++ b/kubernetes/external-dns/helm/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: external-dns
   namespace: default
   labels:
-    helm.sh/chart: external-dns-1.19.0
     app.kubernetes.io/name: external-dns
     app.kubernetes.io/instance: external-dns
     app.kubernetes.io/version: "0.19.0"

--- a/kubernetes/external-dns/helm/templates/service.yaml
+++ b/kubernetes/external-dns/helm/templates/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: external-dns
   namespace: default
   labels:
-    helm.sh/chart: external-dns-1.19.0
     app.kubernetes.io/name: external-dns
     app.kubernetes.io/instance: external-dns
     app.kubernetes.io/version: "0.19.0"

--- a/kubernetes/external-dns/helm/templates/serviceaccount.yaml
+++ b/kubernetes/external-dns/helm/templates/serviceaccount.yaml
@@ -6,7 +6,6 @@ metadata:
   name: external-dns
   namespace: default
   labels:
-    helm.sh/chart: external-dns-1.19.0
     app.kubernetes.io/name: external-dns
     app.kubernetes.io/instance: external-dns
     app.kubernetes.io/version: "0.19.0"

--- a/kubernetes/external-secrets/helm/templates/deployment.yaml
+++ b/kubernetes/external-secrets/helm/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: external-secrets
   namespace: external-secrets
   labels:
-    helm.sh/chart: external-secrets-1.0.0
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v1.0.0"
@@ -21,7 +20,6 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: external-secrets-1.0.0
         app.kubernetes.io/name: external-secrets
         app.kubernetes.io/instance: external-secrets
         app.kubernetes.io/version: "v1.0.0"

--- a/kubernetes/external-secrets/helm/templates/rbac.yaml
+++ b/kubernetes/external-secrets/helm/templates/rbac.yaml
@@ -5,7 +5,6 @@ kind: ClusterRole
 metadata:
   name: external-secrets-controller
   labels:
-    helm.sh/chart: external-secrets-1.0.0
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v1.0.0"
@@ -157,7 +156,6 @@ kind: ClusterRole
 metadata:
   name: external-secrets-view
   labels:
-    helm.sh/chart: external-secrets-1.0.0
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v1.0.0"
@@ -208,7 +206,6 @@ kind: ClusterRole
 metadata:
   name: external-secrets-edit
   labels:
-    helm.sh/chart: external-secrets-1.0.0
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v1.0.0"
@@ -263,7 +260,6 @@ metadata:
   name: external-secrets-servicebindings
   labels:
     servicebinding.io/controller: "true"
-    helm.sh/chart: external-secrets-1.0.0
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v1.0.0"
@@ -285,7 +281,6 @@ kind: ClusterRoleBinding
 metadata:
   name: external-secrets-controller
   labels:
-    helm.sh/chart: external-secrets-1.0.0
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v1.0.0"
@@ -306,7 +301,6 @@ metadata:
   name: external-secrets-leaderelection
   namespace: external-secrets
   labels:
-    helm.sh/chart: external-secrets-1.0.0
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v1.0.0"
@@ -345,7 +339,6 @@ metadata:
   name: external-secrets-leaderelection
   namespace: external-secrets
   labels:
-    helm.sh/chart: external-secrets-1.0.0
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v1.0.0"

--- a/kubernetes/external-secrets/helm/templates/serviceaccount.yaml
+++ b/kubernetes/external-secrets/helm/templates/serviceaccount.yaml
@@ -6,7 +6,6 @@ metadata:
   name: external-secrets
   namespace: external-secrets
   labels:
-    helm.sh/chart: external-secrets-1.0.0
     app.kubernetes.io/name: external-secrets
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v1.0.0"

--- a/kubernetes/external-secrets/helm/templates/validatingwebhook.yaml
+++ b/kubernetes/external-secrets/helm/templates/validatingwebhook.yaml
@@ -6,7 +6,6 @@ metadata:
   name: secretstore-validate
   labels:
     
-    helm.sh/chart: external-secrets-1.0.0
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v1.0.0"
@@ -54,7 +53,6 @@ metadata:
   name: externalsecret-validate
   labels:
     
-    helm.sh/chart: external-secrets-1.0.0
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v1.0.0"

--- a/kubernetes/external-secrets/helm/templates/webhook-certificate.yaml
+++ b/kubernetes/external-secrets/helm/templates/webhook-certificate.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: external-secrets
   labels:
     
-    helm.sh/chart: external-secrets-1.0.0
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v1.0.0"

--- a/kubernetes/external-secrets/helm/templates/webhook-deployment.yaml
+++ b/kubernetes/external-secrets/helm/templates/webhook-deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: external-secrets
   labels:
     
-    helm.sh/chart: external-secrets-1.0.0
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v1.0.0"
@@ -23,7 +22,6 @@ spec:
     metadata:
       labels:
         
-        helm.sh/chart: external-secrets-1.0.0
         app.kubernetes.io/name: external-secrets-webhook
         app.kubernetes.io/instance: external-secrets
         app.kubernetes.io/version: "v1.0.0"

--- a/kubernetes/external-secrets/helm/templates/webhook-service.yaml
+++ b/kubernetes/external-secrets/helm/templates/webhook-service.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: external-secrets
   labels:
     
-    helm.sh/chart: external-secrets-1.0.0
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v1.0.0"

--- a/kubernetes/external-secrets/helm/templates/webhook-serviceaccount.yaml
+++ b/kubernetes/external-secrets/helm/templates/webhook-serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: external-secrets
   labels:
     
-    helm.sh/chart: external-secrets-1.0.0
     app.kubernetes.io/name: external-secrets-webhook
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v1.0.0"

--- a/kubernetes/goldilocks/helm/templates/controller-clusterrole.yaml
+++ b/kubernetes/goldilocks/helm/templates/controller-clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
   name: goldilocks-controller
   labels:
     app.kubernetes.io/name: goldilocks
-    helm.sh/chart: goldilocks-10.1.0
     app.kubernetes.io/instance: goldilocks
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/kubernetes/goldilocks/helm/templates/controller-clusterrolebinding.yaml
+++ b/kubernetes/goldilocks/helm/templates/controller-clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
   name: goldilocks-controller
   labels:
     app.kubernetes.io/name: goldilocks
-    helm.sh/chart: goldilocks-10.1.0
     app.kubernetes.io/instance: goldilocks
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/kubernetes/goldilocks/helm/templates/controller-deployment.yaml
+++ b/kubernetes/goldilocks/helm/templates/controller-deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: goldilocks
-    helm.sh/chart: goldilocks-10.1.0
     app.kubernetes.io/instance: goldilocks
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/kubernetes/goldilocks/helm/templates/controller-serviceaccount.yaml
+++ b/kubernetes/goldilocks/helm/templates/controller-serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: goldilocks
-    helm.sh/chart: goldilocks-10.1.0
     app.kubernetes.io/instance: goldilocks
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/kubernetes/goldilocks/helm/templates/dashboard-clusterrole.yaml
+++ b/kubernetes/goldilocks/helm/templates/dashboard-clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
   name: goldilocks-dashboard
   labels:
     app.kubernetes.io/name: goldilocks
-    helm.sh/chart: goldilocks-10.1.0
     app.kubernetes.io/instance: goldilocks
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: dashboard

--- a/kubernetes/goldilocks/helm/templates/dashboard-clusterrolebinding.yaml
+++ b/kubernetes/goldilocks/helm/templates/dashboard-clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
   name: goldilocks-dashboard
   labels:
     app.kubernetes.io/name: goldilocks
-    helm.sh/chart: goldilocks-10.1.0
     app.kubernetes.io/instance: goldilocks
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: dashboard

--- a/kubernetes/goldilocks/helm/templates/dashboard-deployment.yaml
+++ b/kubernetes/goldilocks/helm/templates/dashboard-deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: goldilocks
-    helm.sh/chart: goldilocks-10.1.0
     app.kubernetes.io/instance: goldilocks
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: dashboard

--- a/kubernetes/goldilocks/helm/templates/dashboard-ingress.yaml
+++ b/kubernetes/goldilocks/helm/templates/dashboard-ingress.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: goldilocks
-    helm.sh/chart: goldilocks-10.1.0
     app.kubernetes.io/instance: goldilocks
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: dashboard

--- a/kubernetes/goldilocks/helm/templates/dashboard-service.yaml
+++ b/kubernetes/goldilocks/helm/templates/dashboard-service.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: goldilocks
-    helm.sh/chart: goldilocks-10.1.0
     app.kubernetes.io/instance: goldilocks
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: dashboard

--- a/kubernetes/goldilocks/helm/templates/dashboard-serviceaccount.yaml
+++ b/kubernetes/goldilocks/helm/templates/dashboard-serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: goldilocks
-    helm.sh/chart: goldilocks-10.1.0
     app.kubernetes.io/instance: goldilocks
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: dashboard

--- a/kubernetes/grafana/helm/grafana/clusterrole.yaml
+++ b/kubernetes/grafana/helm/grafana/clusterrole.yaml
@@ -4,7 +4,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-8.15.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
     app.kubernetes.io/version: "11.6.1"

--- a/kubernetes/grafana/helm/grafana/clusterrolebinding.yaml
+++ b/kubernetes/grafana/helm/grafana/clusterrolebinding.yaml
@@ -5,7 +5,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-8.15.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
     app.kubernetes.io/version: "11.6.1"

--- a/kubernetes/grafana/helm/grafana/configmap.yaml
+++ b/kubernetes/grafana/helm/grafana/configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   name: grafana
   namespace: o11y
   labels:
-    helm.sh/chart: grafana-8.15.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
     app.kubernetes.io/version: "11.6.1"

--- a/kubernetes/grafana/helm/grafana/deployment.yaml
+++ b/kubernetes/grafana/helm/grafana/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: grafana
   namespace: o11y
   labels:
-    helm.sh/chart: grafana-8.15.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
     app.kubernetes.io/version: "11.6.1"
@@ -22,7 +21,6 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: grafana-8.15.0
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: grafana
         app.kubernetes.io/version: "11.6.1"

--- a/kubernetes/grafana/helm/grafana/ingress.yaml
+++ b/kubernetes/grafana/helm/grafana/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   name: grafana
   namespace: o11y
   labels:
-    helm.sh/chart: grafana-8.15.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
     app.kubernetes.io/version: "11.6.1"

--- a/kubernetes/grafana/helm/grafana/pvc.yaml
+++ b/kubernetes/grafana/helm/grafana/pvc.yaml
@@ -6,7 +6,6 @@ metadata:
   name: grafana
   namespace: o11y
   labels:
-    helm.sh/chart: grafana-8.15.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
     app.kubernetes.io/version: "11.6.1"

--- a/kubernetes/grafana/helm/grafana/role.yaml
+++ b/kubernetes/grafana/helm/grafana/role.yaml
@@ -6,7 +6,6 @@ metadata:
   name: grafana
   namespace: o11y
   labels:
-    helm.sh/chart: grafana-8.15.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
     app.kubernetes.io/version: "11.6.1"

--- a/kubernetes/grafana/helm/grafana/rolebinding.yaml
+++ b/kubernetes/grafana/helm/grafana/rolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
   name: grafana
   namespace: o11y
   labels:
-    helm.sh/chart: grafana-8.15.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
     app.kubernetes.io/version: "11.6.1"

--- a/kubernetes/grafana/helm/grafana/service.yaml
+++ b/kubernetes/grafana/helm/grafana/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: grafana
   namespace: o11y
   labels:
-    helm.sh/chart: grafana-8.15.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
     app.kubernetes.io/version: "11.6.1"

--- a/kubernetes/grafana/helm/grafana/serviceaccount.yaml
+++ b/kubernetes/grafana/helm/grafana/serviceaccount.yaml
@@ -5,7 +5,6 @@ kind: ServiceAccount
 automountServiceAccountToken: false
 metadata:
   labels:
-    helm.sh/chart: grafana-8.15.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
     app.kubernetes.io/version: "11.6.1"

--- a/kubernetes/hass/helm/ingress.yaml
+++ b/kubernetes/hass/helm/ingress.yaml
@@ -5,7 +5,6 @@ kind: Ingress
 metadata:
   name: hass-home-assistant
   labels:
-    helm.sh/chart: home-assistant-0.3.30
     app.kubernetes.io/name: home-assistant
     app.kubernetes.io/instance: hass
     app.kubernetes.io/version: "2025.11.1"

--- a/kubernetes/hass/helm/service.yaml
+++ b/kubernetes/hass/helm/service.yaml
@@ -5,7 +5,6 @@ kind: Service
 metadata:
   name: hass-home-assistant
   labels:
-    helm.sh/chart: home-assistant-0.3.30
     app.kubernetes.io/name: home-assistant
     app.kubernetes.io/instance: hass
     app.kubernetes.io/version: "2025.11.1"

--- a/kubernetes/hass/helm/serviceaccount.yaml
+++ b/kubernetes/hass/helm/serviceaccount.yaml
@@ -5,7 +5,6 @@ kind: ServiceAccount
 metadata:
   name: hass-home-assistant
   labels:
-    helm.sh/chart: home-assistant-0.3.30
     app.kubernetes.io/name: home-assistant
     app.kubernetes.io/instance: hass
     app.kubernetes.io/version: "2025.11.1"

--- a/kubernetes/hass/helm/statefulset.yaml
+++ b/kubernetes/hass/helm/statefulset.yaml
@@ -5,7 +5,6 @@ kind: StatefulSet
 metadata:
   name: hass-home-assistant
   labels:
-    helm.sh/chart: home-assistant-0.3.30
     app.kubernetes.io/name: home-assistant
     app.kubernetes.io/instance: hass
     app.kubernetes.io/version: "2025.11.1"

--- a/kubernetes/homebox/helm/homebox/deployment.yaml
+++ b/kubernetes/homebox/helm/homebox/deployment.yaml
@@ -5,7 +5,6 @@ kind: Deployment
 metadata:
   name: homebox
   labels:
-    helm.sh/chart: homebox-0.2.0
     app.kubernetes.io/name: homebox
     app.kubernetes.io/instance: homebox
     app.kubernetes.io/version: "0.21.0"
@@ -22,7 +21,6 @@ spec:
         checksum/secret: 0ec8b33b18b21dd857c89bfa93092da22e9875cdf3382ad71d5b2b50293308fe
         reloader.stakater.com/auto: "true"
       labels:
-        helm.sh/chart: homebox-0.2.0
         app.kubernetes.io/name: homebox
         app.kubernetes.io/instance: homebox
         app.kubernetes.io/version: "0.21.0"

--- a/kubernetes/homebox/helm/homebox/ingress.yaml
+++ b/kubernetes/homebox/helm/homebox/ingress.yaml
@@ -5,7 +5,6 @@ kind: Ingress
 metadata:
   name: homebox
   labels:
-    helm.sh/chart: homebox-0.2.0
     app.kubernetes.io/name: homebox
     app.kubernetes.io/instance: homebox
     app.kubernetes.io/version: "0.21.0"

--- a/kubernetes/homebox/helm/homebox/pvc.yaml
+++ b/kubernetes/homebox/helm/homebox/pvc.yaml
@@ -5,7 +5,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: homebox-data
   labels:
-    helm.sh/chart: homebox-0.2.0
     app.kubernetes.io/name: homebox
     app.kubernetes.io/instance: homebox
     app.kubernetes.io/version: "0.21.0"

--- a/kubernetes/homebox/helm/homebox/secrets.yaml
+++ b/kubernetes/homebox/helm/homebox/secrets.yaml
@@ -5,7 +5,6 @@ kind: Secret
 metadata:
   name: homebox
   labels:
-    helm.sh/chart: homebox-0.2.0
     app.kubernetes.io/name: homebox
     app.kubernetes.io/instance: homebox
     app.kubernetes.io/version: "0.21.0"

--- a/kubernetes/homebox/helm/homebox/service.yaml
+++ b/kubernetes/homebox/helm/homebox/service.yaml
@@ -5,7 +5,6 @@ kind: Service
 metadata:
   name: homebox
   labels:
-    helm.sh/chart: homebox-0.2.0
     app.kubernetes.io/name: homebox
     app.kubernetes.io/instance: homebox
     app.kubernetes.io/version: "0.21.0"

--- a/kubernetes/homebox/helm/homebox/serviceaccount.yaml
+++ b/kubernetes/homebox/helm/homebox/serviceaccount.yaml
@@ -5,7 +5,6 @@ kind: ServiceAccount
 metadata:
   name: homebox
   labels:
-    helm.sh/chart: homebox-0.2.0
     app.kubernetes.io/name: homebox
     app.kubernetes.io/instance: homebox
     app.kubernetes.io/version: "0.21.0"

--- a/kubernetes/homepage/helm/templates/common.yaml
+++ b/kubernetes/homepage/helm/templates/common.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: homepage
     app.kubernetes.io/version: v1.2.0
-    helm.sh/chart: homepage-2.1.0
 secrets:
   - name: homepage-sa-token
 ---
@@ -24,7 +23,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: homepage
     app.kubernetes.io/version: v1.2.0
-    helm.sh/chart: homepage-2.1.0
   annotations:
     kubernetes.io/service-account.name: homepage
 ---
@@ -38,7 +36,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: homepage
     app.kubernetes.io/version: v1.2.0
-    helm.sh/chart: homepage-2.1.0
 rules:
   - apiGroups:
       - ""
@@ -98,7 +95,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: homepage
     app.kubernetes.io/version: v1.2.0
-    helm.sh/chart: homepage-2.1.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -119,7 +115,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: homepage
     app.kubernetes.io/version: v1.2.0
-    helm.sh/chart: homepage-2.1.0
   annotations:
 spec:
   type: ClusterIP
@@ -142,7 +137,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: homepage
     app.kubernetes.io/version: v1.2.0
-    helm.sh/chart: homepage-2.1.0
   annotations:
     values-checksum: 65a9a18b832c342d95effc7458a57defa0132e5b9a2142a387daa34de3d59c5a
 spec:
@@ -241,7 +235,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: homepage
     app.kubernetes.io/version: v1.2.0
-    helm.sh/chart: homepage-2.1.0
   annotations:
     ak-type: simple
     cert-manager.io/cluster-issuer: letsencrypt

--- a/kubernetes/ingress-nginx/helm/clusterrole.yaml
+++ b/kubernetes/ingress-nginx/helm/clusterrole.yaml
@@ -4,7 +4,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/version: "1.14.0"

--- a/kubernetes/ingress-nginx/helm/clusterrolebinding.yaml
+++ b/kubernetes/ingress-nginx/helm/clusterrolebinding.yaml
@@ -4,7 +4,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/version: "1.14.0"

--- a/kubernetes/ingress-nginx/helm/controller-configmap.yaml
+++ b/kubernetes/ingress-nginx/helm/controller-configmap.yaml
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/version: "1.14.0"

--- a/kubernetes/ingress-nginx/helm/controller-deployment.yaml
+++ b/kubernetes/ingress-nginx/helm/controller-deployment.yaml
@@ -4,7 +4,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/version: "1.14.0"
@@ -30,7 +29,6 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ingress-nginx-4.14.0
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/version: "1.14.0"

--- a/kubernetes/ingress-nginx/helm/controller-ingressclass.yaml
+++ b/kubernetes/ingress-nginx/helm/controller-ingressclass.yaml
@@ -4,7 +4,6 @@ apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/version: "1.14.0"

--- a/kubernetes/ingress-nginx/helm/controller-poddisruptionbudget.yaml
+++ b/kubernetes/ingress-nginx/helm/controller-poddisruptionbudget.yaml
@@ -6,7 +6,6 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/version: "1.14.0"

--- a/kubernetes/ingress-nginx/helm/controller-role.yaml
+++ b/kubernetes/ingress-nginx/helm/controller-role.yaml
@@ -4,7 +4,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/version: "1.14.0"

--- a/kubernetes/ingress-nginx/helm/controller-rolebinding.yaml
+++ b/kubernetes/ingress-nginx/helm/controller-rolebinding.yaml
@@ -4,7 +4,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/version: "1.14.0"

--- a/kubernetes/ingress-nginx/helm/controller-service-metrics.yaml
+++ b/kubernetes/ingress-nginx/helm/controller-service-metrics.yaml
@@ -7,7 +7,6 @@ metadata:
     prometheus.io/port: "10254"
     prometheus.io/scrape: "true"
   labels:
-    helm.sh/chart: ingress-nginx-4.14.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/version: "1.14.0"

--- a/kubernetes/ingress-nginx/helm/controller-service.yaml
+++ b/kubernetes/ingress-nginx/helm/controller-service.yaml
@@ -5,7 +5,6 @@ kind: Service
 metadata:
   annotations:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/version: "1.14.0"

--- a/kubernetes/ingress-nginx/helm/controller-serviceaccount.yaml
+++ b/kubernetes/ingress-nginx/helm/controller-serviceaccount.yaml
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/version: "1.14.0"

--- a/kubernetes/karakeep/helm/karakeep/common.yaml
+++ b/kubernetes/karakeep/helm/karakeep/common.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: karakeep
     app.kubernetes.io/version: 0.27.0
-    helm.sh/chart: karakeep-0.27.0
   namespace: karakeep
 stringData:
   MEILI_MASTER_KEY: 'bogus'
@@ -24,7 +23,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: karakeep
     app.kubernetes.io/version: 0.27.0
-    helm.sh/chart: karakeep-0.27.0
   namespace: karakeep
 spec:
   accessModes:
@@ -44,7 +42,6 @@ metadata:
     app.kubernetes.io/name: karakeep
     app.kubernetes.io/service: karakeep-chrome
     app.kubernetes.io/version: 0.27.0
-    helm.sh/chart: karakeep-0.27.0
   namespace: karakeep
 spec:
   type: ClusterIP
@@ -69,7 +66,6 @@ metadata:
     app.kubernetes.io/name: karakeep
     app.kubernetes.io/service: karakeep
     app.kubernetes.io/version: 0.27.0
-    helm.sh/chart: karakeep-0.27.0
   namespace: karakeep
 spec:
   type: ClusterIP
@@ -94,7 +90,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: karakeep
     app.kubernetes.io/version: 0.27.0
-    helm.sh/chart: karakeep-0.27.0
   namespace: karakeep
 spec:
   revisionHistoryLimit: 3
@@ -185,7 +180,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: karakeep
     app.kubernetes.io/version: 0.27.0
-    helm.sh/chart: karakeep-0.27.0
   namespace: karakeep
 spec:
   revisionHistoryLimit: 3
@@ -299,7 +293,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: karakeep
     app.kubernetes.io/version: 0.27.0
-    helm.sh/chart: karakeep-0.27.0
   annotations:
     ak-oidc-callback: /api/auth/callback/custom
     ak-type: oidc

--- a/kubernetes/karakeep/helm/meilisearch/configmap.yaml
+++ b/kubernetes/karakeep/helm/meilisearch/configmap.yaml
@@ -5,7 +5,6 @@ kind: ConfigMap
 metadata:
   name: karakeep-meilisearch-environment
   labels:
-    helm.sh/chart: meilisearch-0.12.0
     app.kubernetes.io/name: meilisearch
     app.kubernetes.io/instance: karakeep
     app.kubernetes.io/version: "v1.13.0"

--- a/kubernetes/karakeep/helm/meilisearch/pvc.yaml
+++ b/kubernetes/karakeep/helm/meilisearch/pvc.yaml
@@ -5,7 +5,6 @@ apiVersion: v1
 metadata:
   name: karakeep-meilisearch
   labels:
-    helm.sh/chart: meilisearch-0.12.0
     app.kubernetes.io/name: meilisearch
     app.kubernetes.io/instance: karakeep
     app.kubernetes.io/version: "v1.13.0"

--- a/kubernetes/karakeep/helm/meilisearch/service.yaml
+++ b/kubernetes/karakeep/helm/meilisearch/service.yaml
@@ -5,7 +5,6 @@ kind: Service
 metadata:
   name: karakeep-meilisearch
   labels:
-    helm.sh/chart: meilisearch-0.12.0
     app.kubernetes.io/name: meilisearch
     app.kubernetes.io/instance: karakeep
     app.kubernetes.io/version: "v1.13.0"

--- a/kubernetes/karakeep/helm/meilisearch/serviceaccount.yaml
+++ b/kubernetes/karakeep/helm/meilisearch/serviceaccount.yaml
@@ -5,7 +5,6 @@ kind: ServiceAccount
 metadata:
   name: karakeep-meilisearch
   labels:
-    helm.sh/chart: meilisearch-0.12.0
     app.kubernetes.io/name: meilisearch
     app.kubernetes.io/instance: karakeep
     app.kubernetes.io/version: "v1.13.0"

--- a/kubernetes/karakeep/helm/meilisearch/statefulset.yaml
+++ b/kubernetes/karakeep/helm/meilisearch/statefulset.yaml
@@ -5,7 +5,6 @@ kind: StatefulSet
 metadata:
   name: karakeep-meilisearch
   labels:
-    helm.sh/chart: meilisearch-0.12.0
     app.kubernetes.io/name: meilisearch
     app.kubernetes.io/instance: karakeep
     app.kubernetes.io/version: "v1.13.0"
@@ -22,7 +21,6 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: meilisearch-0.12.0
         app.kubernetes.io/name: meilisearch
         app.kubernetes.io/instance: karakeep
         app.kubernetes.io/version: "v1.13.0"

--- a/kubernetes/kube-state-metrics/helm/templates/clusterrolebinding.yaml
+++ b/kubernetes/kube-state-metrics/helm/templates/clusterrolebinding.yaml
@@ -4,7 +4,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-6.4.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics

--- a/kubernetes/kube-state-metrics/helm/templates/deployment.yaml
+++ b/kubernetes/kube-state-metrics/helm/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: kube-state-metrics
   namespace: default
   labels:    
-    helm.sh/chart: kube-state-metrics-6.4.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
@@ -25,7 +24,6 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-6.4.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics

--- a/kubernetes/kube-state-metrics/helm/templates/role.yaml
+++ b/kubernetes/kube-state-metrics/helm/templates/role.yaml
@@ -4,7 +4,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-6.4.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics

--- a/kubernetes/kube-state-metrics/helm/templates/service.yaml
+++ b/kubernetes/kube-state-metrics/helm/templates/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: kube-state-metrics
   namespace: default
   labels:    
-    helm.sh/chart: kube-state-metrics-6.4.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics

--- a/kubernetes/kube-state-metrics/helm/templates/serviceaccount.yaml
+++ b/kubernetes/kube-state-metrics/helm/templates/serviceaccount.yaml
@@ -5,7 +5,6 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-6.4.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics

--- a/kubernetes/loki/helm/templates/backend/clusterrole.yaml
+++ b/kubernetes/loki/helm/templates/backend/clusterrole.yaml
@@ -4,7 +4,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: loki-6.42.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
     app.kubernetes.io/version: "3.5.5"

--- a/kubernetes/loki/helm/templates/backend/clusterrolebinding.yaml
+++ b/kubernetes/loki/helm/templates/backend/clusterrolebinding.yaml
@@ -5,7 +5,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: loki-clusterrolebinding
   labels:
-    helm.sh/chart: loki-6.42.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
     app.kubernetes.io/version: "3.5.5"

--- a/kubernetes/loki/helm/templates/config.yaml
+++ b/kubernetes/loki/helm/templates/config.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loki
   namespace: loki
   labels:
-    helm.sh/chart: loki-6.42.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
     app.kubernetes.io/version: "3.5.5"

--- a/kubernetes/loki/helm/templates/gateway/configmap-gateway.yaml
+++ b/kubernetes/loki/helm/templates/gateway/configmap-gateway.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loki-gateway
   namespace: loki
   labels:
-    helm.sh/chart: loki-6.42.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
     app.kubernetes.io/version: "3.5.5"

--- a/kubernetes/loki/helm/templates/gateway/deployment-gateway-nginx.yaml
+++ b/kubernetes/loki/helm/templates/gateway/deployment-gateway-nginx.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loki-gateway
   namespace: loki
   labels:
-    helm.sh/chart: loki-6.42.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
     app.kubernetes.io/version: "3.5.5"

--- a/kubernetes/loki/helm/templates/gateway/service-gateway.yaml
+++ b/kubernetes/loki/helm/templates/gateway/service-gateway.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loki-gateway
   namespace: loki
   labels:
-    helm.sh/chart: loki-6.42.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
     app.kubernetes.io/version: "3.5.5"

--- a/kubernetes/loki/helm/templates/loki-canary/daemonset.yaml
+++ b/kubernetes/loki/helm/templates/loki-canary/daemonset.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loki-canary
   namespace: loki
   labels:
-    helm.sh/chart: loki-6.42.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
     app.kubernetes.io/version: "3.5.5"

--- a/kubernetes/loki/helm/templates/loki-canary/service.yaml
+++ b/kubernetes/loki/helm/templates/loki-canary/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loki-canary
   namespace: loki
   labels:
-    helm.sh/chart: loki-6.42.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
     app.kubernetes.io/version: "3.5.5"

--- a/kubernetes/loki/helm/templates/loki-canary/serviceaccount.yaml
+++ b/kubernetes/loki/helm/templates/loki-canary/serviceaccount.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loki-canary
   namespace: loki
   labels:
-    helm.sh/chart: loki-6.42.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
     app.kubernetes.io/version: "3.5.5"

--- a/kubernetes/loki/helm/templates/runtime-configmap.yaml
+++ b/kubernetes/loki/helm/templates/runtime-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loki-runtime
   namespace: loki
   labels:
-    helm.sh/chart: loki-6.42.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
     app.kubernetes.io/version: "3.5.5"

--- a/kubernetes/loki/helm/templates/service-memberlist.yaml
+++ b/kubernetes/loki/helm/templates/service-memberlist.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loki-memberlist
   namespace: loki
   labels:
-    helm.sh/chart: loki-6.42.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
     app.kubernetes.io/version: "3.5.5"

--- a/kubernetes/loki/helm/templates/serviceaccount.yaml
+++ b/kubernetes/loki/helm/templates/serviceaccount.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loki
   namespace: loki
   labels:
-    helm.sh/chart: loki-6.42.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
     app.kubernetes.io/version: "3.5.5"

--- a/kubernetes/loki/helm/templates/single-binary/service-headless.yaml
+++ b/kubernetes/loki/helm/templates/single-binary/service-headless.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loki-headless
   namespace: loki
   labels:
-    helm.sh/chart: loki-6.42.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
     app.kubernetes.io/version: "3.5.5"

--- a/kubernetes/loki/helm/templates/single-binary/service.yaml
+++ b/kubernetes/loki/helm/templates/single-binary/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loki
   namespace: loki
   labels:
-    helm.sh/chart: loki-6.42.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
     app.kubernetes.io/version: "3.5.5"

--- a/kubernetes/loki/helm/templates/single-binary/statefulset.yaml
+++ b/kubernetes/loki/helm/templates/single-binary/statefulset.yaml
@@ -6,7 +6,6 @@ metadata:
   name: loki
   namespace: loki
   labels:
-    helm.sh/chart: loki-6.42.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: loki
     app.kubernetes.io/version: "3.5.5"

--- a/kubernetes/metallb/helm/templates/controller.yaml
+++ b/kubernetes/metallb/helm/templates/controller.yaml
@@ -6,7 +6,6 @@ metadata:
   name: metallb-controller
   namespace: "metallb-system"
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"

--- a/kubernetes/metallb/helm/templates/exclude-l2-config.yaml
+++ b/kubernetes/metallb/helm/templates/exclude-l2-config.yaml
@@ -6,7 +6,6 @@ metadata:
   name: metallb-excludel2
   namespace: "metallb-system"
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"

--- a/kubernetes/metallb/helm/templates/rbac.yaml
+++ b/kubernetes/metallb/helm/templates/rbac.yaml
@@ -5,7 +5,6 @@ kind: ClusterRole
 metadata:
   name: metallb:controller
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"
@@ -45,7 +44,6 @@ kind: ClusterRole
 metadata:
   name: metallb:speaker
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"
@@ -70,7 +68,6 @@ kind: ClusterRoleBinding
 metadata:
   name: metallb:controller
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"
@@ -90,7 +87,6 @@ kind: ClusterRoleBinding
 metadata:
   name: metallb:speaker
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"
@@ -111,7 +107,6 @@ metadata:
   name: metallb-pod-lister
   namespace: "metallb-system"
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"
@@ -155,7 +150,6 @@ metadata:
   name: metallb-controller
   namespace: "metallb-system"
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"
@@ -204,7 +198,6 @@ metadata:
   name: metallb-pod-lister
   namespace: "metallb-system"
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"
@@ -224,7 +217,6 @@ metadata:
   name: metallb-controller
   namespace: "metallb-system"
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"

--- a/kubernetes/metallb/helm/templates/service-accounts.yaml
+++ b/kubernetes/metallb/helm/templates/service-accounts.yaml
@@ -6,7 +6,6 @@ metadata:
   name: metallb-controller
   namespace: "metallb-system"
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"
@@ -20,7 +19,6 @@ metadata:
   name: metallb-speaker
   namespace: "metallb-system"
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"

--- a/kubernetes/metallb/helm/templates/speaker.yaml
+++ b/kubernetes/metallb/helm/templates/speaker.yaml
@@ -8,7 +8,6 @@ metadata:
   name: metallb-frr-startup
   namespace: "metallb-system"
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"
@@ -114,7 +113,6 @@ metadata:
   name: metallb-speaker
   namespace: "metallb-system"
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"

--- a/kubernetes/metallb/helm/templates/webhooks.yaml
+++ b/kubernetes/metallb/helm/templates/webhooks.yaml
@@ -6,7 +6,6 @@ metadata:
   name: metallb-webhook-cert
   namespace: "metallb-system"
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"
@@ -19,7 +18,6 @@ metadata:
   name: metallb-webhook-service
   namespace: "metallb-system"
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"
@@ -39,7 +37,6 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: metallb-webhook-configuration
   labels:
-    helm.sh/chart: metallb-0.15.2
     app.kubernetes.io/name: metallb
     app.kubernetes.io/instance: metallb
     app.kubernetes.io/version: "v0.15.2"

--- a/kubernetes/metrics-server/helm/apiservice.yaml
+++ b/kubernetes/metrics-server/helm/apiservice.yaml
@@ -5,7 +5,6 @@ kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io
   labels:
-    helm.sh/chart: metrics-server-3.13.0
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/version: "0.8.0"

--- a/kubernetes/metrics-server/helm/clusterrole-aggregated-reader.yaml
+++ b/kubernetes/metrics-server/helm/clusterrole-aggregated-reader.yaml
@@ -5,7 +5,6 @@ kind: ClusterRole
 metadata:
   name: system:metrics-server-aggregated-reader
   labels:
-    helm.sh/chart: metrics-server-3.13.0
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/version: "0.8.0"

--- a/kubernetes/metrics-server/helm/clusterrole.yaml
+++ b/kubernetes/metrics-server/helm/clusterrole.yaml
@@ -5,7 +5,6 @@ kind: ClusterRole
 metadata:
   name: system:metrics-server
   labels:
-    helm.sh/chart: metrics-server-3.13.0
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/version: "0.8.0"

--- a/kubernetes/metrics-server/helm/clusterrolebinding-auth-delegator.yaml
+++ b/kubernetes/metrics-server/helm/clusterrolebinding-auth-delegator.yaml
@@ -5,7 +5,6 @@ kind: ClusterRoleBinding
 metadata:
   name: metrics-server:system:auth-delegator
   labels:
-    helm.sh/chart: metrics-server-3.13.0
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/version: "0.8.0"

--- a/kubernetes/metrics-server/helm/clusterrolebinding.yaml
+++ b/kubernetes/metrics-server/helm/clusterrolebinding.yaml
@@ -5,7 +5,6 @@ kind: ClusterRoleBinding
 metadata:
   name: system:metrics-server
   labels:
-    helm.sh/chart: metrics-server-3.13.0
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/version: "0.8.0"

--- a/kubernetes/metrics-server/helm/deployment.yaml
+++ b/kubernetes/metrics-server/helm/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: metrics-server
   namespace: default
   labels:
-    helm.sh/chart: metrics-server-3.13.0
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/version: "0.8.0"

--- a/kubernetes/metrics-server/helm/rolebinding.yaml
+++ b/kubernetes/metrics-server/helm/rolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
   name: metrics-server-auth-reader
   namespace: kube-system
   labels:
-    helm.sh/chart: metrics-server-3.13.0
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/version: "0.8.0"

--- a/kubernetes/metrics-server/helm/service.yaml
+++ b/kubernetes/metrics-server/helm/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: metrics-server
   namespace: default
   labels:
-    helm.sh/chart: metrics-server-3.13.0
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/version: "0.8.0"

--- a/kubernetes/metrics-server/helm/serviceaccount.yaml
+++ b/kubernetes/metrics-server/helm/serviceaccount.yaml
@@ -6,7 +6,6 @@ metadata:
   name: metrics-server
   namespace: default
   labels:
-    helm.sh/chart: metrics-server-3.13.0
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/instance: metrics-server
     app.kubernetes.io/version: "0.8.0"

--- a/kubernetes/n8n/helm/n8n/configmap.yaml
+++ b/kubernetes/n8n/helm/n8n/configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   name: n8n-app-config
   namespace: n8n
   labels:
-    helm.sh/chart: n8n-1.0.15
     app.kubernetes.io/name: n8n
     app.kubernetes.io/instance: n8n
     app.kubernetes.io/version: "1.112.0"

--- a/kubernetes/n8n/helm/n8n/deployment.yaml
+++ b/kubernetes/n8n/helm/n8n/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: n8n
   namespace: n8n
   labels:
-    helm.sh/chart: n8n-1.0.15
     app.kubernetes.io/name: n8n
     app.kubernetes.io/instance: n8n
     app.kubernetes.io/version: "1.112.0"

--- a/kubernetes/n8n/helm/n8n/ingress.yaml
+++ b/kubernetes/n8n/helm/n8n/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   name: n8n
   namespace: n8n
   labels:
-    helm.sh/chart: n8n-1.0.15
     app.kubernetes.io/name: n8n
     app.kubernetes.io/instance: n8n
     app.kubernetes.io/version: "1.112.0"

--- a/kubernetes/n8n/helm/n8n/pvc.yaml
+++ b/kubernetes/n8n/helm/n8n/pvc.yaml
@@ -6,7 +6,6 @@ metadata:
   name: n8n
   namespace: n8n
   labels:
-    helm.sh/chart: n8n-1.0.15
     app.kubernetes.io/name: n8n
     app.kubernetes.io/instance: n8n
     app.kubernetes.io/version: "1.112.0"

--- a/kubernetes/n8n/helm/n8n/service.yaml
+++ b/kubernetes/n8n/helm/n8n/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: n8n
   namespace: n8n
   labels:
-    helm.sh/chart: n8n-1.0.15
     app.kubernetes.io/name: n8n
     app.kubernetes.io/instance: n8n
     app.kubernetes.io/version: "1.112.0"

--- a/kubernetes/n8n/helm/n8n/serviceaccount.yaml
+++ b/kubernetes/n8n/helm/n8n/serviceaccount.yaml
@@ -6,7 +6,6 @@ metadata:
   name: n8n
   namespace: n8n
   labels:
-    helm.sh/chart: n8n-1.0.15
     app.kubernetes.io/name: n8n
     app.kubernetes.io/instance: n8n
     app.kubernetes.io/version: "1.112.0"

--- a/kubernetes/n8n/helm/valkey/pvc.yaml
+++ b/kubernetes/n8n/helm/valkey/pvc.yaml
@@ -5,7 +5,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: valkey-2.1.6
     app.kubernetes.io/name: valkey
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/version: "8.1.4"

--- a/kubernetes/n8n/helm/valkey/scripts.yaml
+++ b/kubernetes/n8n/helm/valkey/scripts.yaml
@@ -5,7 +5,6 @@ kind: ConfigMap
 metadata:
   name: valkey-scripts
   labels:
-    helm.sh/chart: valkey-2.1.6
     app.kubernetes.io/name: valkey
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/version: "8.1.4"

--- a/kubernetes/n8n/helm/valkey/service-internal.yaml
+++ b/kubernetes/n8n/helm/valkey/service-internal.yaml
@@ -5,7 +5,6 @@ kind: Service
 metadata:
   name: valkey-headless
   labels:
-    helm.sh/chart: valkey-2.1.6
     app.kubernetes.io/name: valkey
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/version: "8.1.4"

--- a/kubernetes/n8n/helm/valkey/services.yaml
+++ b/kubernetes/n8n/helm/valkey/services.yaml
@@ -5,7 +5,6 @@ kind: Service
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: valkey-2.1.6
     app.kubernetes.io/name: valkey
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/version: "8.1.4"

--- a/kubernetes/n8n/helm/valkey/statefulset.yaml
+++ b/kubernetes/n8n/helm/valkey/statefulset.yaml
@@ -5,7 +5,6 @@ kind: Deployment
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: valkey-2.1.6
     app.kubernetes.io/name: valkey
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/version: "8.1.4"

--- a/kubernetes/node-feature-discovery/helm/templates/clusterrole.yaml
+++ b/kubernetes/node-feature-discovery/helm/templates/clusterrole.yaml
@@ -5,7 +5,6 @@ kind: ClusterRole
 metadata:
   name: node-feature-discovery
   labels:
-    helm.sh/chart: node-feature-discovery-0.18.1
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: node-feature-discovery
     app.kubernetes.io/version: "v0.18.1"
@@ -67,7 +66,6 @@ kind: ClusterRole
 metadata:
   name: node-feature-discovery-gc
   labels:
-    helm.sh/chart: node-feature-discovery-0.18.1
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: node-feature-discovery
     app.kubernetes.io/version: "v0.18.1"

--- a/kubernetes/node-feature-discovery/helm/templates/clusterrolebinding.yaml
+++ b/kubernetes/node-feature-discovery/helm/templates/clusterrolebinding.yaml
@@ -5,7 +5,6 @@ kind: ClusterRoleBinding
 metadata:
   name: node-feature-discovery
   labels:
-    helm.sh/chart: node-feature-discovery-0.18.1
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: node-feature-discovery
     app.kubernetes.io/version: "v0.18.1"
@@ -25,7 +24,6 @@ kind: ClusterRoleBinding
 metadata:
   name: node-feature-discovery-gc
   labels:
-    helm.sh/chart: node-feature-discovery-0.18.1
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: node-feature-discovery
     app.kubernetes.io/version: "v0.18.1"

--- a/kubernetes/node-feature-discovery/helm/templates/master.yaml
+++ b/kubernetes/node-feature-discovery/helm/templates/master.yaml
@@ -6,7 +6,6 @@ metadata:
   name:  node-feature-discovery-master
   namespace: node-feature-discovery
   labels:
-    helm.sh/chart: node-feature-discovery-0.18.1
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: node-feature-discovery
     app.kubernetes.io/version: "v0.18.1"

--- a/kubernetes/node-feature-discovery/helm/templates/nfd-gc.yaml
+++ b/kubernetes/node-feature-discovery/helm/templates/nfd-gc.yaml
@@ -6,7 +6,6 @@ metadata:
   name: node-feature-discovery-gc
   namespace: node-feature-discovery
   labels:
-    helm.sh/chart: node-feature-discovery-0.18.1
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: node-feature-discovery
     app.kubernetes.io/version: "v0.18.1"

--- a/kubernetes/node-feature-discovery/helm/templates/nfd-master-conf.yaml
+++ b/kubernetes/node-feature-discovery/helm/templates/nfd-master-conf.yaml
@@ -6,7 +6,6 @@ metadata:
   name: node-feature-discovery-master-conf
   namespace: node-feature-discovery
   labels:
-    helm.sh/chart: node-feature-discovery-0.18.1
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: node-feature-discovery
     app.kubernetes.io/version: "v0.18.1"

--- a/kubernetes/node-feature-discovery/helm/templates/nfd-worker-conf.yaml
+++ b/kubernetes/node-feature-discovery/helm/templates/nfd-worker-conf.yaml
@@ -6,7 +6,6 @@ metadata:
   name: node-feature-discovery-worker-conf
   namespace: node-feature-discovery
   labels:
-    helm.sh/chart: node-feature-discovery-0.18.1
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: node-feature-discovery
     app.kubernetes.io/version: "v0.18.1"

--- a/kubernetes/node-feature-discovery/helm/templates/role.yaml
+++ b/kubernetes/node-feature-discovery/helm/templates/role.yaml
@@ -6,7 +6,6 @@ metadata:
   name: node-feature-discovery-worker
   namespace: node-feature-discovery
   labels:
-    helm.sh/chart: node-feature-discovery-0.18.1
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: node-feature-discovery
     app.kubernetes.io/version: "v0.18.1"

--- a/kubernetes/node-feature-discovery/helm/templates/rolebinding.yaml
+++ b/kubernetes/node-feature-discovery/helm/templates/rolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
   name: node-feature-discovery-worker
   namespace: node-feature-discovery
   labels:
-    helm.sh/chart: node-feature-discovery-0.18.1
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: node-feature-discovery
     app.kubernetes.io/version: "v0.18.1"

--- a/kubernetes/node-feature-discovery/helm/templates/serviceaccount.yaml
+++ b/kubernetes/node-feature-discovery/helm/templates/serviceaccount.yaml
@@ -6,7 +6,6 @@ metadata:
   name: node-feature-discovery
   namespace: node-feature-discovery
   labels:
-    helm.sh/chart: node-feature-discovery-0.18.1
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: node-feature-discovery
     app.kubernetes.io/version: "v0.18.1"
@@ -19,7 +18,6 @@ metadata:
   name: node-feature-discovery-gc
   namespace: node-feature-discovery
   labels:
-    helm.sh/chart: node-feature-discovery-0.18.1
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: node-feature-discovery
     app.kubernetes.io/version: "v0.18.1"
@@ -32,7 +30,6 @@ metadata:
   name: node-feature-discovery-worker
   namespace: node-feature-discovery
   labels:
-    helm.sh/chart: node-feature-discovery-0.18.1
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: node-feature-discovery
     app.kubernetes.io/version: "v0.18.1"

--- a/kubernetes/node-feature-discovery/helm/templates/worker.yaml
+++ b/kubernetes/node-feature-discovery/helm/templates/worker.yaml
@@ -6,7 +6,6 @@ metadata:
   name:  node-feature-discovery-worker
   namespace: node-feature-discovery
   labels:
-    helm.sh/chart: node-feature-discovery-0.18.1
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: node-feature-discovery
     app.kubernetes.io/version: "v0.18.1"

--- a/kubernetes/reloader/helm/templates/clusterrole.yaml
+++ b/kubernetes/reloader/helm/templates/clusterrole.yaml
@@ -12,7 +12,6 @@ metadata:
     release: "reloader"
     app.kubernetes.io/name: reloader
     app.kubernetes.io/instance: "reloader"
-    helm.sh/chart: "reloader-2.2.5"
     chart: "reloader-2.2.5"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"

--- a/kubernetes/reloader/helm/templates/clusterrolebinding.yaml
+++ b/kubernetes/reloader/helm/templates/clusterrolebinding.yaml
@@ -12,7 +12,6 @@ metadata:
     release: "reloader"
     app.kubernetes.io/name: reloader
     app.kubernetes.io/instance: "reloader"
-    helm.sh/chart: "reloader-2.2.5"
     chart: "reloader-2.2.5"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"

--- a/kubernetes/reloader/helm/templates/deployment.yaml
+++ b/kubernetes/reloader/helm/templates/deployment.yaml
@@ -11,7 +11,6 @@ metadata:
     release: "reloader"
     app.kubernetes.io/name: reloader
     app.kubernetes.io/instance: "reloader"
-    helm.sh/chart: "reloader-2.2.5"
     chart: "reloader-2.2.5"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
@@ -35,7 +34,6 @@ spec:
         release: "reloader"
         app.kubernetes.io/name: reloader
         app.kubernetes.io/instance: "reloader"
-        helm.sh/chart: "reloader-2.2.5"
         chart: "reloader-2.2.5"
         heritage: "Helm"
         app.kubernetes.io/managed-by: "Helm"

--- a/kubernetes/reloader/helm/templates/role.yaml
+++ b/kubernetes/reloader/helm/templates/role.yaml
@@ -11,7 +11,6 @@ metadata:
     release: "reloader"
     app.kubernetes.io/name: reloader
     app.kubernetes.io/instance: "reloader"
-    helm.sh/chart: "reloader-2.2.5"
     chart: "reloader-2.2.5"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"

--- a/kubernetes/reloader/helm/templates/rolebinding.yaml
+++ b/kubernetes/reloader/helm/templates/rolebinding.yaml
@@ -11,7 +11,6 @@ metadata:
     release: "reloader"
     app.kubernetes.io/name: reloader
     app.kubernetes.io/instance: "reloader"
-    helm.sh/chart: "reloader-2.2.5"
     chart: "reloader-2.2.5"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"

--- a/kubernetes/reloader/helm/templates/serviceaccount.yaml
+++ b/kubernetes/reloader/helm/templates/serviceaccount.yaml
@@ -11,7 +11,6 @@ metadata:
     release: "reloader"
     app.kubernetes.io/name: reloader
     app.kubernetes.io/instance: "reloader"
-    helm.sh/chart: "reloader-2.2.5"
     chart: "reloader-2.2.5"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"

--- a/kubernetes/scripts/chart-version
+++ b/kubernetes/scripts/chart-version
@@ -37,15 +37,41 @@ helm_chart_args() {
 }
 
 # Function to call helm template with correct chart args and any extra options
+# Automatically removes helm.sh/chart labels when --output-dir is specified
 helm_template() {
   local release="$1"
   local chart_key="$2"
   shift 2
-  local chart_args
-  # Use a more compatible approach for older shells
-  chart_args=()
+
+  # Parse args to find output directory for post-processing
+  local output_dir=""
+  local args=("$@")
+  for ((i = 0; i < ${#args[@]}; i++)); do
+    if [[ "${args[i]}" == "--output-dir" ]]; then
+      output_dir="${args[i + 1]}"
+      break
+    fi
+  done
+
+  local chart_args=()
   while IFS= read -r line; do
     chart_args+=("$line")
   done < <(helm_chart_args "$chart_key")
+
   helm template "$release" "${chart_args[@]}" "$@"
+
+  # Auto-remove helm.sh/chart labels to reduce diff noise on upgrades
+  if [[ -n "$output_dir" && -d "$output_dir" ]]; then
+    remove_helm_chart_labels "$output_dir"
+  fi
+}
+
+# Remove helm.sh/chart labels from rendered YAML files
+# Usage: remove_helm_chart_labels <directory>
+remove_helm_chart_labels() {
+  local dir="$1"
+  find "$dir" \( -name '*.yaml' -o -name '*.yml' \) -type f | while read -r file; do
+    # Use temp file approach for portability (works on both macOS and Linux)
+    sed '/^[[:space:]]*helm\.sh\/chart:/d' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+  done
 }

--- a/kubernetes/semaphore/helm/configmap.yaml
+++ b/kubernetes/semaphore/helm/configmap.yaml
@@ -7,7 +7,6 @@ metadata:
   name: semaphore-config
   namespace: semaphore
   labels:
-    helm.sh/chart: "semaphore-16.0.6"
     app.kubernetes.io/name: "semaphore"
     app.kubernetes.io/instance: "semaphore"
     app.kubernetes.io/version: "2.16.35"

--- a/kubernetes/semaphore/helm/deployment.yaml
+++ b/kubernetes/semaphore/helm/deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   name: semaphore
   namespace: semaphore
   labels:
-    helm.sh/chart: "semaphore-16.0.6"
     app.kubernetes.io/name: "semaphore"
     app.kubernetes.io/instance: "semaphore"
     app.kubernetes.io/version: "2.16.35"
@@ -28,7 +27,6 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: "semaphore-16.0.6"
         app.kubernetes.io/name: "semaphore"
         app.kubernetes.io/instance: "semaphore"
         app.kubernetes.io/version: "2.16.35"

--- a/kubernetes/semaphore/helm/ingress.yaml
+++ b/kubernetes/semaphore/helm/ingress.yaml
@@ -7,7 +7,6 @@ metadata:
   name: semaphore
   namespace: semaphore
   labels:
-    helm.sh/chart: "semaphore-16.0.6"
     app.kubernetes.io/name: "semaphore"
     app.kubernetes.io/instance: "semaphore"
     app.kubernetes.io/version: "2.16.35"

--- a/kubernetes/semaphore/helm/pvc.yaml
+++ b/kubernetes/semaphore/helm/pvc.yaml
@@ -7,7 +7,6 @@ metadata:
   name: semaphore-workdir
   namespace: semaphore
   labels:
-    helm.sh/chart: "semaphore-16.0.6"
     app.kubernetes.io/name: "semaphore"
     app.kubernetes.io/instance: "semaphore"
     app.kubernetes.io/version: "2.16.35"

--- a/kubernetes/semaphore/helm/service.yaml
+++ b/kubernetes/semaphore/helm/service.yaml
@@ -7,7 +7,6 @@ metadata:
   name: semaphore
   namespace: semaphore
   labels:
-    helm.sh/chart: "semaphore-16.0.6"
     app.kubernetes.io/name: "semaphore"
     app.kubernetes.io/instance: "semaphore"
     app.kubernetes.io/version: "2.16.35"

--- a/kubernetes/semaphore/helm/serviceaccount.yaml
+++ b/kubernetes/semaphore/helm/serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   name: semaphore
   namespace: semaphore
   labels:
-    helm.sh/chart: "semaphore-16.0.6"
     app.kubernetes.io/name: "semaphore"
     app.kubernetes.io/instance: "semaphore"
     app.kubernetes.io/version: "2.16.35"

--- a/kubernetes/spegel/helm/templates/daemonset.yaml
+++ b/kubernetes/spegel/helm/templates/daemonset.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: spegel
   labels:
     app.kubernetes.io/component: spegel
-    helm.sh/chart: spegel-0.4.0
     app.kubernetes.io/name: spegel
     app.kubernetes.io/instance: spegel
     app.kubernetes.io/version: "v0.4.0"

--- a/kubernetes/spegel/helm/templates/rbac.yaml
+++ b/kubernetes/spegel/helm/templates/rbac.yaml
@@ -6,7 +6,6 @@ metadata:
   name: spegel
   namespace: spegel
   labels:
-    helm.sh/chart: spegel-0.4.0
     app.kubernetes.io/name: spegel
     app.kubernetes.io/instance: spegel
     app.kubernetes.io/version: "v0.4.0"

--- a/kubernetes/spegel/helm/templates/service.yaml
+++ b/kubernetes/spegel/helm/templates/service.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: spegel
   labels:
     app.kubernetes.io/component: metrics
-    helm.sh/chart: spegel-0.4.0
     app.kubernetes.io/name: spegel
     app.kubernetes.io/instance: spegel
     app.kubernetes.io/version: "v0.4.0"
@@ -30,7 +29,6 @@ metadata:
   name: spegel-registry
   namespace: spegel
   labels:
-    helm.sh/chart: spegel-0.4.0
     app.kubernetes.io/name: spegel
     app.kubernetes.io/instance: spegel
     app.kubernetes.io/version: "v0.4.0"
@@ -57,7 +55,6 @@ metadata:
   name: spegel-bootstrap
   namespace: spegel
   labels:
-    helm.sh/chart: spegel-0.4.0
     app.kubernetes.io/name: spegel
     app.kubernetes.io/instance: spegel
     app.kubernetes.io/version: "v0.4.0"

--- a/kubernetes/velero/helm/backupstoragelocation.yaml
+++ b/kubernetes/velero/helm/backupstoragelocation.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/name: velero
     app.kubernetes.io/instance: velero
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-11.1.1
 spec:
   provider: aws
   accessMode: ReadWrite

--- a/kubernetes/velero/helm/clusterrolebinding.yaml
+++ b/kubernetes/velero/helm/clusterrolebinding.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/name: velero
     app.kubernetes.io/instance: velero
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-11.1.1
 subjects:
   - kind: ServiceAccount
     namespace: velero

--- a/kubernetes/velero/helm/deployment.yaml
+++ b/kubernetes/velero/helm/deployment.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: velero
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.17.0
-    helm.sh/chart: velero-11.1.1
     component: velero
 spec:
   replicas: 1
@@ -28,7 +27,6 @@ spec:
         app.kubernetes.io/instance: velero
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/version: 1.17.0
-        helm.sh/chart: velero-11.1.1
       annotations:
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"

--- a/kubernetes/velero/helm/node-agent-daemonset.yaml
+++ b/kubernetes/velero/helm/node-agent-daemonset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/name: velero
     app.kubernetes.io/instance: velero
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-11.1.1
 spec:
   selector:
     matchLabels:
@@ -22,7 +21,6 @@ spec:
         app.kubernetes.io/name: velero
         app.kubernetes.io/instance: velero
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: velero-11.1.1
       annotations:
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"

--- a/kubernetes/velero/helm/repo-maintenance-configmap.yaml
+++ b/kubernetes/velero/helm/repo-maintenance-configmap.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/name: velero
     app.kubernetes.io/instance: velero
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-11.1.1
 data:
   global: |
     {

--- a/kubernetes/velero/helm/role.yaml
+++ b/kubernetes/velero/helm/role.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/name: velero
     app.kubernetes.io/instance: velero
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-11.1.1
 rules:
 - apiGroups:
     - "*"

--- a/kubernetes/velero/helm/rolebinding.yaml
+++ b/kubernetes/velero/helm/rolebinding.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/name: velero
     app.kubernetes.io/instance: velero
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-11.1.1
 subjects:
   - kind: ServiceAccount
     namespace: velero

--- a/kubernetes/velero/helm/service.yaml
+++ b/kubernetes/velero/helm/service.yaml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/name: velero
     app.kubernetes.io/instance: velero
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-11.1.1
 spec:
   type: ClusterIP
   ports:

--- a/kubernetes/velero/helm/serviceaccount-server.yaml
+++ b/kubernetes/velero/helm/serviceaccount-server.yaml
@@ -9,5 +9,4 @@ metadata:
     app.kubernetes.io/name: velero
     app.kubernetes.io/instance: velero
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-11.1.1
 automountServiceAccountToken: true

--- a/kubernetes/velero/helm/volumesnapshotlocation.yaml
+++ b/kubernetes/velero/helm/volumesnapshotlocation.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/name: velero
     app.kubernetes.io/instance: velero
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-11.1.1
 spec:
   provider: aws
   config:

--- a/kubernetes/volume-snapshot-controller/helm/templates/deployment_controller.yaml
+++ b/kubernetes/volume-snapshot-controller/helm/templates/deployment_controller.yaml
@@ -6,7 +6,6 @@ metadata:
   name: volume-snapshot-controller
   namespace: volume-snapshot-controller
   labels:
-    helm.sh/chart: snapshot-controller-4.1.0
     app.kubernetes.io/name: snapshot-controller
     app.kubernetes.io/instance: volume-snapshot-controller
     app.kubernetes.io/version: "v8.3.0"

--- a/kubernetes/volume-snapshot-controller/helm/templates/serviceaccount_controller.yaml
+++ b/kubernetes/volume-snapshot-controller/helm/templates/serviceaccount_controller.yaml
@@ -6,7 +6,6 @@ metadata:
   name: volume-snapshot-controller
   namespace: volume-snapshot-controller
   labels:
-    helm.sh/chart: snapshot-controller-4.1.0
     app.kubernetes.io/name: snapshot-controller
     app.kubernetes.io/instance: volume-snapshot-controller
     app.kubernetes.io/version: "v8.3.0"

--- a/kubernetes/vpa/helm/templates/admission-controller-deployment.yaml
+++ b/kubernetes/vpa/helm/templates/admission-controller-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: vpa-admission-controller
   labels:
     app.kubernetes.io/component: admission-controller
-    helm.sh/chart: vpa-4.10.0
     app.kubernetes.io/name: vpa
     app.kubernetes.io/instance: vpa
     app.kubernetes.io/version: "1.4.1"

--- a/kubernetes/vpa/helm/templates/admission-controller-service-account.yaml
+++ b/kubernetes/vpa/helm/templates/admission-controller-service-account.yaml
@@ -6,7 +6,6 @@ automountServiceAccountToken: true
 metadata:
   name: vpa-admission-controller
   labels:
-    helm.sh/chart: vpa-4.10.0
     app.kubernetes.io/name: vpa
     app.kubernetes.io/instance: vpa
     app.kubernetes.io/version: "1.4.1"

--- a/kubernetes/vpa/helm/templates/recommender-deployment.yaml
+++ b/kubernetes/vpa/helm/templates/recommender-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: vpa-recommender
   labels:
     app.kubernetes.io/component: recommender
-    helm.sh/chart: vpa-4.10.0
     app.kubernetes.io/name: vpa
     app.kubernetes.io/instance: vpa
     app.kubernetes.io/version: "1.4.1"

--- a/kubernetes/vpa/helm/templates/recommender-service-account.yaml
+++ b/kubernetes/vpa/helm/templates/recommender-service-account.yaml
@@ -6,7 +6,6 @@ automountServiceAccountToken: true
 metadata:
   name: vpa-recommender
   labels:
-    helm.sh/chart: vpa-4.10.0
     app.kubernetes.io/name: vpa
     app.kubernetes.io/instance: vpa
     app.kubernetes.io/version: "1.4.1"

--- a/kubernetes/vpa/helm/templates/updater-deployment.yaml
+++ b/kubernetes/vpa/helm/templates/updater-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: vpa-updater
   labels:
     app.kubernetes.io/component: updater
-    helm.sh/chart: vpa-4.10.0
     app.kubernetes.io/name: vpa
     app.kubernetes.io/instance: vpa
     app.kubernetes.io/version: "1.4.1"

--- a/kubernetes/vpa/helm/templates/updater-service-account.yaml
+++ b/kubernetes/vpa/helm/templates/updater-service-account.yaml
@@ -6,7 +6,6 @@ automountServiceAccountToken: true
 metadata:
   name: vpa-updater
   labels:
-    helm.sh/chart: vpa-4.10.0
     app.kubernetes.io/name: vpa
     app.kubernetes.io/instance: vpa
     app.kubernetes.io/version: "1.4.1"

--- a/kubernetes/vpa/helm/templates/webhooks/mutating.yaml
+++ b/kubernetes/vpa/helm/templates/webhooks/mutating.yaml
@@ -6,7 +6,6 @@ metadata:
   name: vpa-webhook-config
   labels:
     app.kubernetes.io/component: admission-controller
-    helm.sh/chart: vpa-4.10.0
     app.kubernetes.io/name: vpa
     app.kubernetes.io/instance: vpa
     app.kubernetes.io/version: "1.4.1"


### PR DESCRIPTION
Update helm_template() to detect --output-dir and run sed to remove
lines matching helm.sh/chart from rendered YAML files. Re-render all
charts.
