### PR TITLE
Add k3 VM as Kubernetes worker

### DIFF
--- a/ansible/host_vars/k3.yaml
+++ b/ansible/host_vars/k3.yaml
@@ -1,0 +1,11 @@
+---
+manage_network: true
+interfaces_ether_interfaces:
+  - device: ens18
+    bootproto: static
+    address: "172.19.74.74"
+    netmask: "255.255.255.0"
+    gateway: 172.19.74.1
+    dnsnameservers: 172.19.74.1
+    dnssearch: oneill.net
+    allowclass: allow-hotplug

--- a/ansible/inventory/default
+++ b/ansible/inventory/default
@@ -2,6 +2,7 @@ luser ansible_host=luser.fnord.net domain=oneill.net
 flux ansible_host=flux.fnord.net domain=fnord.net
 k1 ansible_host=k1.oneill.net domain=oneill.net
 k2 ansible_host=k2.oneill.net domain=oneill.net
+k3 ansible_host=k3.oneill.net domain=oneill.net
 k4 ansible_host=k4.oneill.net domain=oneill.net
 k5 ansible_host=k5.oneill.net domain=oneill.net
 #voron2 ansible_host=voron2.oneill.net domain=oneill.net
@@ -15,6 +16,7 @@ p9 ansible_host=p9.oneill.net domain=oneill.net
 [kubernetes]
 k1
 k2
+k3
 k4
 k5
 
@@ -23,6 +25,7 @@ k1
 
 [kubernetes_node]
 k2
+k3
 k4
 k5
 

--- a/ansible/roles/pxe/files/preseed.trixie.cfg
+++ b/ansible/roles/pxe/files/preseed.trixie.cfg
@@ -67,7 +67,7 @@ d-i apt-setup/contrib boolean true
 ### Package selection
 tasksel tasksel/first multiselect ssh-server
 d-i pkgsel/upgrade select full-upgrade
-d-i pkgsel/include string openssh-server python3 ifenslave cloud-init qemu-guest-agent
+d-i pkgsel/include string openssh-server python3 sudo ifenslave cloud-init qemu-guest-agent
 
 ### Boot loader installation
 d-i grub-installer/only_debian boolean true

--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -22,6 +22,12 @@ locals {
       hostname = "k2.oneill.net"
       note     = "Kubernetes worker node"
     }
+    k3 = {
+      mac      = "52:54:72:19:74:74"
+      ip       = "172.19.74.74"
+      hostname = "k3.oneill.net"
+      note     = "Kubernetes worker node (VM)"
+    }
     k4 = {
       mac      = "b4:96:91:a0:83:54"
       ip       = "172.19.74.75"

--- a/opentofu/proxmox.tf
+++ b/opentofu/proxmox.tf
@@ -53,4 +53,59 @@ resource "proxmox_virtual_environment_vm" "k1" {
   operating_system {
     type = "l26"
   }
+
+  lifecycle {
+    ignore_changes = [node_name, started]
+  }
+}
+
+resource "proxmox_virtual_environment_vm" "k3" {
+  name      = "k3"
+  node_name = "p9"
+  vm_id     = 1074
+
+  started = false
+  on_boot = true
+
+  cpu {
+    cores   = 4
+    sockets = 1
+    type    = "x86-64-v3"
+    units   = 100
+  }
+
+  memory {
+    dedicated = 20480
+  }
+
+  agent {
+    enabled = true
+    trim    = true
+  }
+
+  scsi_hardware = "virtio-scsi-single"
+
+  disk {
+    interface    = "scsi0"
+    datastore_id = "local-zfs"
+    size         = 100
+    file_format  = "raw"
+    iothread     = true
+    discard      = "on"
+  }
+
+  network_device {
+    bridge      = "vmbr0"
+    mac_address = "52:54:72:19:74:74"
+    model       = "virtio"
+    queues      = 4
+  }
+
+  operating_system {
+    type = "l26"
+  }
+
+  lifecycle {
+    ignore_changes = [node_name, started]
+  }
 }


### PR DESCRIPTION
- Add k3 VM to Proxmox (VM ID 1074, 4 vCPUs, 20GB RAM, 100GB local-zfs)
- Add k3 to infrastructure_hosts for DHCP reservation and DNS
- Add k3 to Ansible inventory and kubernetes_node group
- Create host_vars for k3 network configuration
- Fix preseed to include sudo package
- Add lifecycle ignore_changes for node_name to allow VM migration
