### PR TITLE
Remove shared proxmox.oneill.net SAN from ACME config

### DIFF
--- a/ansible/roles/proxmox/tasks/acme.yaml
+++ b/ansible/roles/proxmox/tasks/acme.yaml
@@ -61,7 +61,5 @@
     cmd: >
       pvenode config set
       --acmedomain0 '{{ inventory_hostname }}.{{ domain }},plugin={{ proxmox_acme_plugin_name }}'
-      --acmedomain1 'proxmox.{{ domain }},plugin={{ proxmox_acme_plugin_name }}'
   when: >
-    (inventory_hostname + '.' + domain + ',plugin=' + proxmox_acme_plugin_name) not in proxmox_node_config.stdout or
-    ('proxmox.' + domain + ',plugin=' + proxmox_acme_plugin_name) not in proxmox_node_config.stdout
+    (inventory_hostname + '.' + domain + ',plugin=' + proxmox_acme_plugin_name) not in proxmox_node_config.stdout


### PR DESCRIPTION
Each Proxmox node was configured with both its own hostname and the shared
proxmox.oneill.net as certificate SANs. This caused ACME finalize failures
when multiple nodes tried to obtain certificates for the same domain.
