### PR TITLE
Add k2 VM as Kubernetes worker

### DIFF
--- a/ansible/host_vars/k2.yaml
+++ b/ansible/host_vars/k2.yaml
@@ -1,7 +1,7 @@
 ---
 manage_network: true
 interfaces_ether_interfaces:
-  - device: enp1s0f0
+  - device: ens18
     bootproto: static
     address: "172.19.74.112"
     netmask: "255.255.255.0"
@@ -9,7 +9,3 @@ interfaces_ether_interfaces:
     dnsnameservers: 172.19.74.1
     dnssearch: oneill.net
     allowclass: allow-hotplug
-  - device: eno1
-    bootproto: manual
-    allowclass: manual
-    ignore_status_check: true

--- a/ansible/inventory/default
+++ b/ansible/inventory/default
@@ -1,6 +1,7 @@
 luser ansible_host=luser.fnord.net domain=oneill.net
 flux ansible_host=flux.fnord.net domain=fnord.net
 k1 ansible_host=k1.oneill.net domain=oneill.net
+k2 ansible_host=k2.oneill.net domain=oneill.net
 k3 ansible_host=k3.oneill.net domain=oneill.net
 k4 ansible_host=k4.oneill.net domain=oneill.net
 k5 ansible_host=k5.oneill.net domain=oneill.net
@@ -15,6 +16,7 @@ p9 ansible_host=p9.oneill.net domain=oneill.net
 
 [kubernetes]
 k1
+k2
 k3
 k4
 k5
@@ -23,6 +25,7 @@ k5
 k1
 
 [kubernetes_node]
+k2
 k3
 k4
 k5

--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -32,6 +32,12 @@ locals {
       hostname = "k1.oneill.net"
       note     = "Kubernetes control-plane node (VM)"
     }
+    k2 = {
+      mac      = "52:54:72:19:74:72"
+      ip       = "172.19.74.112"
+      hostname = "k2.oneill.net"
+      note     = "Kubernetes worker node (VM)"
+    }
     k3 = {
       mac      = "52:54:72:19:74:74"
       ip       = "172.19.74.74"

--- a/opentofu/proxmox.tf
+++ b/opentofu/proxmox.tf
@@ -59,6 +59,57 @@ resource "proxmox_virtual_environment_vm" "k1" {
   }
 }
 
+resource "proxmox_virtual_environment_vm" "k2" {
+  name      = "k2"
+  node_name = "p2"
+  vm_id     = 1072
+
+  started = false
+  on_boot = true
+
+  cpu {
+    cores   = 4
+    sockets = 1
+    type    = "x86-64-v3"
+    units   = 100
+  }
+
+  memory {
+    dedicated = 20480
+  }
+
+  agent {
+    enabled = true
+    trim    = true
+  }
+
+  scsi_hardware = "virtio-scsi-single"
+
+  disk {
+    interface    = "scsi0"
+    datastore_id = "local-zfs"
+    size         = 100
+    file_format  = "raw"
+    iothread     = true
+    discard      = "on"
+  }
+
+  network_device {
+    bridge      = "vmbr0"
+    mac_address = "52:54:72:19:74:72"
+    model       = "virtio"
+    queues      = 4
+  }
+
+  operating_system {
+    type = "l26"
+  }
+
+  lifecycle {
+    ignore_changes = [node_name, started]
+  }
+}
+
 resource "proxmox_virtual_environment_vm" "k3" {
   name      = "k3"
   node_name = "p9"


### PR DESCRIPTION
- Create k2 VM on p2 (4 cores, 20GB RAM, 100GB disk)
- Add k2 to infrastructure_hosts for DNS/DHCP
- Add k2 to Ansible inventory and kubernetes groups
- Update k2 network config for VM interface (ens18)
