### PR TITLE
Add VS Code settings for custom YAML tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.retry
 *.swp
-.vscode/
+.vscode/extensions.json
 .direnv/
 .tmp/
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+  "yaml.customTags": [
+    "!secret scalar",
+    "!include scalar",
+    "!include_dir_named scalar",
+    "!include_dir_merge_named scalar",
+    "!include_dir_list scalar",
+    "!include_dir_merge_list scalar",
+    "!env_var scalar",
+    "!env scalar",
+    "!extend scalar",
+    "!remove scalar",
+    "!lambda scalar",
+    "!vault scalar"
+  ]
+}


### PR DESCRIPTION
Configure yaml.customTags to recognize tags used by ESPHome, Home
Assistant, Ansible Vault, and other tools in this repo. This prevents
VS Code from showing spurious errors on valid YAML files.
