### PR TITLE
Fix sysctl for Debian Trixie

### DIFF
--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -83,11 +83,23 @@
     group: root
   when: manage_resolv_conf | default(false) | bool
 
+- name: "Configure sysctl for inotify"
+  ansible.posix.sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    state: present
+    sysctl_file: /etc/sysctl.d/99-common.conf
+    reload: true
+  loop:
+    - { name: "fs.inotify.max_user_watches", value: "1048576" }
+    - { name: "fs.inotify.max_user_instances", value: "4096" }
+
 - name: "Configure NMI watchdog sysctl"
   ansible.posix.sysctl:
     name: kernel.nmi_watchdog
     value: "1"
     state: present
+    sysctl_file: /etc/sysctl.d/99-common.conf
     reload: true
   when:
     - ansible_architecture in ['x86_64', 'i386']

--- a/ansible/roles/kubeadm/tasks/common.yaml
+++ b/ansible/roles/kubeadm/tasks/common.yaml
@@ -25,31 +25,26 @@
     name: "{{ item.name }}"
     value: "{{ item.value }}"
     state: present
+    sysctl_file: /etc/sysctl.d/99-kubernetes.conf
     reload: true
   with_items:
     - { name: "net.bridge.bridge-nf-call-iptables", value: "1" }
     - { name: "net.ipv4.ip_forward", value: "1" }
     - { name: "net.bridge.bridge-nf-call-ip6tables", value: "1" }
 
-- name: Configure sysctl for inotify (Grafana/K8s nodes)
-  ansible.posix.sysctl:
-    name: "{{ item.name }}"
-    value: "{{ item.value }}"
-    state: present
-    reload: true
-  loop:
-    - { name: "fs.inotify.max_user_watches", value: "1048576" }
-    - { name: "fs.inotify.max_user_instances", value: "4096" }
-
 - name: "Disabling accepting ICMP redirects"
   ansible.posix.sysctl:
     name: "net.ipv4.conf.all.accept_redirects"
     value: "0"
+    sysctl_file: /etc/sysctl.d/99-kubernetes.conf
+    reload: true
 
 - name: "Disabling sending ICMP redirects"
   ansible.posix.sysctl:
     name: "net.ipv4.conf.all.send_redirects"
     value: "0"
+    sysctl_file: /etc/sysctl.d/99-kubernetes.conf
+    reload: true
 
 - name: "Check if swap is enabled"
   ansible.builtin.command: "swapon --show"


### PR DESCRIPTION
Debian 13 (Trixie) no longer reads /etc/sysctl.conf on boot - systemd-sysctl
only reads from /etc/sysctl.d/. Add sysctl_file parameter to all sysctl tasks.

- common role: Add inotify settings, use /etc/sysctl.d/99-common.conf
- kubeadm role: Use /etc/sysctl.d/99-kubernetes.conf, remove inotify (now in common)
