### PR TITLE
Fix k1 interface name for Proxmox VirtIO NIC

### DIFF
--- a/ansible/host_vars/k1.yaml
+++ b/ansible/host_vars/k1.yaml
@@ -1,7 +1,7 @@
 ---
 manage_network: true
 interfaces_ether_interfaces:
-  - device: ens3
+  - device: ens18
     bootproto: static
     address: "172.19.74.134"
     netmask: "255.255.255.0"


### PR DESCRIPTION
Proxmox VMs with VirtIO network adapters use ens18, not ens3.
