### PR TITLE
Convert k5 to Proxmox host p3

### DIFF
--- a/ansible/group_vars/nut.yaml
+++ b/ansible/group_vars/nut.yaml
@@ -15,7 +15,7 @@ nut_ups:
   - name: "ups2"
     driver: "usbhid-ups"
     device: auto
-    description: "UPS for luser, k2, k4, k5"
+    description: "UPS for luser, p2, p3, p4"
     extra: |
       serial = "CXXPV7000092"
   - name: "ups3"

--- a/esphome/p2-power.yaml
+++ b/esphome/p2-power.yaml
@@ -1,8 +1,8 @@
 ---
 substitutions:
-  devicename: k4-power
-  device_id: k4_power
-  human_devicename: K4
+  devicename: p2-power
+  device_id: p2_power
+  human_devicename: P2
   icon: mdi:ship-wheel
   restore_mode: always_on
 

--- a/esphome/p3-power.yaml
+++ b/esphome/p3-power.yaml
@@ -1,8 +1,8 @@
 ---
 substitutions:
-  devicename: k5-power
-  device_id: k5_power
-  human_devicename: K5
+  devicename: p3-power
+  device_id: p3_power
+  human_devicename: P3
   icon: mdi:ship-wheel
   restore_mode: always_on
 

--- a/esphome/p4-power.yaml
+++ b/esphome/p4-power.yaml
@@ -1,8 +1,8 @@
 ---
 substitutions:
-  devicename: k2-power
-  device_id: k2_power
-  human_devicename: K2
+  devicename: p4-power
+  device_id: p4_power
+  human_devicename: P4
   icon: mdi:ship-wheel
   restore_mode: always_on
 

--- a/kubernetes/network-storage-benchmark/README.md
+++ b/kubernetes/network-storage-benchmark/README.md
@@ -179,12 +179,12 @@ results retrieval automatically.
 Matrix mode tests all possible node pairs in your cluster, including the control
 plane (k1). Useful for comprehensive network validation before/after upgrades.
 
-For a 4-node cluster (k1, k2, k4, k5), matrix mode runs **12 tests**:
+For a 4-node cluster (k1, k2, k3, k4), matrix mode runs **12 tests**:
 
-- k1 → k2, k1 → k4, k1 → k5
-- k2 → k1, k2 → k4, k2 → k5
-- k4 → k1, k4 → k2, k4 → k5
-- k5 → k1, k5 → k2, k5 → k4
+- k1 → k2, k1 → k3, k1 → k4
+- k2 → k1, k2 → k3, k2 → k4
+- k3 → k1, k3 → k2, k3 → k4
+- k4 → k1, k4 → k2, k4 → k3
 
 Results are saved with node pair names in
 `./results/network-matrix-{timestamp}/` and a CSV summary file is generated for

--- a/kubernetes/network-storage-benchmark/run-benchmark.sh
+++ b/kubernetes/network-storage-benchmark/run-benchmark.sh
@@ -28,7 +28,7 @@ Commands:
   cleanup         Clean test volumes, trim iSCSI volumes, and delete namespace
 
 Storage Options:
-  --node NODE          Pin benchmark to specific node (e.g., k2, k4, k5)
+  --node NODE          Pin benchmark to specific node (e.g., k2, k3, k4)
                        If not specified, automatically selects a worker node (excludes k1)
   --storage-type TYPE  Storage type(s) to test (default: all)
                        Options: iscsi, nfs, nfs-slow, all

--- a/kubernetes/prometheus/config/prometheus.yml
+++ b/kubernetes/prometheus/config/prometheus.yml
@@ -27,8 +27,8 @@ scrape_configs:
   - targets:
     - k1.oneill.net:9100
     - k2.oneill.net:9100
+    - k3.oneill.net:9100
     - k4.oneill.net:9100
-    - k5.oneill.net:9100
 
 # scrape szamar via http on port 10445
 - job_name: hwinfo gaming pc
@@ -44,8 +44,8 @@ scrape_configs:
     module: [icmp]
   static_configs:
   - targets:
-    - og-left-door.oneill.net
-    - og-right-door.oneill.net
+    - left-garage-door.oneill.net
+    - right-garage-door.oneill.net
     - veraplus.oneill.net
     - udmp.oneill.net
     - basement-guardian.oneill.net

--- a/kubernetes/smokeping-prober/config.yaml
+++ b/kubernetes/smokeping-prober/config.yaml
@@ -11,10 +11,16 @@ targets:
   - luser.oneill.net
   - k1.oneill.net
   - k2.oneill.net
+  - k3.oneill.net
   - k4.oneill.net
-  - k5.oneill.net
-  - og-left-door.oneill.net
-  - og-right-door.oneill.net
+  - p2.oneill.net
+  - p3.oneill.net
+  - p4.oneill.net
+  - p9.oneill.net
+  - infrapi.oneill.net
+  - zwavejs.oneill.net
+  - left-garage-door.oneill.net
+  - right-garage-door.oneill.net
   - fs2.oneill.net
   interval: 1s
   network: ip


### PR DESCRIPTION
- Rename ESPHome power configs: k2→p2, k4→p4, k5→p3
- Update NUT UPS2 description to reference physical hosts (p2, p3, p4)
- Update prometheus scrape targets: k5→k3, og-*-door→*-garage-door
- Update smokeping-prober targets: k5→k3, add p2/p3/p4/p9/infrapi/zwavejs,
  og-*-door→*-garage-door
- Update network-storage-benchmark docs and help text: k5→k3
