### PR TITLE
Add load-balanced Proxmox UI endpoint via Traefik

### DIFF
--- a/ansible/roles/traefik/files/docker-compose.yml
+++ b/ansible/roles/traefik/files/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       # Persistent storage for Let's Encrypt certificates
       - /etc/traefik/acme:/acme
+      # Dynamic configuration for external services
+      - /etc/traefik/conf.d:/etc/traefik/conf.d:ro
     command:
       # Logging
       - "--log.level=INFO"
@@ -20,6 +22,9 @@ services:
       # Docker provider configuration
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
+      # File provider for external services
+      - "--providers.file.directory=/etc/traefik/conf.d"
+      - "--providers.file.watch=true"
       # Entry points (HTTP and HTTPS)
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"

--- a/ansible/roles/traefik/handlers/main.yml
+++ b/ansible/roles/traefik/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart traefik
+  community.docker.docker_compose_v2:
+    project_src: /etc/traefik
+    state: present
+    recreate: always

--- a/ansible/roles/traefik/tasks/main.yml
+++ b/ansible/roles/traefik/tasks/main.yml
@@ -15,6 +15,23 @@
     group: root
     mode: "0700"
 
+- name: Create traefik dynamic config directory
+  ansible.builtin.file:
+    path: /etc/traefik/conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Deploy Proxmox load balancer configuration
+  ansible.builtin.template:
+    src: conf.d/proxmox.yml.j2
+    dest: /etc/traefik/conf.d/proxmox.yml
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart traefik
+
 - name: Deploy traefik environment file
   ansible.builtin.template:
     src: traefik.env.j2

--- a/ansible/roles/traefik/templates/conf.d/proxmox.yml.j2
+++ b/ansible/roles/traefik/templates/conf.d/proxmox.yml.j2
@@ -1,0 +1,29 @@
+---
+http:
+  routers:
+    proxmox:
+      rule: "Host(`pve.oneill.net`)"
+      entryPoints:
+        - websecure
+      service: proxmox
+      tls:
+        certResolver: letsencrypt
+
+  services:
+    proxmox:
+      loadBalancer:
+        servers:
+{% for host in groups['proxmox'] %}
+          - url: "https://{{ hostvars[host]['ansible_host'] }}:8006"
+{% endfor %}
+        sticky:
+          cookie:
+            name: proxmox_server
+            secure: true
+            httpOnly: true
+        healthCheck:
+          path: /
+          interval: "10s"
+          timeout: "3s"
+          scheme: https
+        passHostHeader: false

--- a/kubernetes/homepage/services.yaml
+++ b/kubernetes/homepage/services.yaml
@@ -9,6 +9,10 @@
       icon: mdi-z-wave
 
 - Home Lab:
+  - Proxmox:
+      href: https://pve.oneill.net
+      description: Proxmox Cluster
+      icon: proxmox
   - SpiderDuo KVM:
       href: https://spiderduo.oneill.net
       description: SpiderDuo KVM

--- a/opentofu/modules/dns/oneill.tf
+++ b/opentofu/modules/dns/oneill.tf
@@ -172,6 +172,14 @@ resource "aws_route53_record" "os_install" {
   records = ["infrapi.oneill.net"]
 }
 
+resource "aws_route53_record" "pve" {
+  zone_id = aws_route53_zone.oneill_net.zone_id
+  name    = "pve.oneill.net"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["infrapi.oneill.net"]
+}
+
 # TXT record for Proxmox auto-installer URL discovery
 # The installer looks up proxmox-auto-installer.{search domain}
 resource "aws_route53_record" "proxmox_auto_installer" {


### PR DESCRIPTION
- Configure Traefik file provider for external service routing
- Add templated proxmox.yml.j2 that discovers hosts from inventory
- Enable sticky sessions and health checks for the load balancer
- Add pve.oneill.net CNAME pointing to infrapi
- Add Proxmox entry to homepage
