### PR TITLE
Add stale lock handling to resticprofile configs

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -92,12 +92,19 @@ resticprofile_sftp_servers:
     pool: repos
 
 restic_config_blocks:
+  - restic_global_config
   - restic_default_config
   - restic_prometheus_config
   - restic_pizero_config
   - restic_host_config
+restic_global_config:
+  version: "1"
+  global:
+    restic-stale-lock-age: 6h
+    restic-lock-retry-after: 2m
 restic_default_config:
   default:
+    force-inactive-lock: true
     repository: sftp:restic@luser.fnord.net:/repos/main
     password-file: passphrase.txt
 

--- a/kubernetes/resticprofile/profiles.yaml
+++ b/kubernetes/resticprofile/profiles.yaml
@@ -1,6 +1,13 @@
 ---
+version: '1'
+
+global:
+  restic-stale-lock-age: 6h
+  restic-lock-retry-after: 2m
+
 # B2 profile for direct backup to Backblaze B2
 b2:
+  force-inactive-lock: true
   repository: rclone:b2c:restic/main
   compression: max
   verbose: true
@@ -61,6 +68,7 @@ b2:
 
 # B2 copy profile (copy from local repo to B2)
 copy-main:
+  force-inactive-lock: true
   compression: max
   repository: /source/backups/restic/repos/main
   verbose: true


### PR DESCRIPTION
Automatically handles stale locks from crashed/killed backup jobs:
- Considers locks older than 6h as stale
- Retries every 2m when encountering locks
- Forces removal of stale locks via force-inactive-lock
