### PR TITLE
Disable spegel PreferSameNode traffic distribution for k8s 1.33

### DIFF
--- a/kubernetes/spegel/helm/templates/daemonset.yaml
+++ b/kubernetes/spegel/helm/templates/daemonset.yaml
@@ -42,6 +42,7 @@ spec:
           - --log-level=INFO
           - --containerd-registry-config-path=/etc/containerd/certs.d
           - --mirror-targets
+          - http://$(NODE_IP):30020
           - http://$(NODE_IP):30021
           - --resolve-tags=true
           - --prepend-existing=false
@@ -95,6 +96,7 @@ spec:
         ports:
           - name: registry
             containerPort: 5000
+            hostPort: 30020
             protocol: TCP
           - name: router
             containerPort: 5001

--- a/kubernetes/spegel/helm/templates/service.yaml
+++ b/kubernetes/spegel/helm/templates/service.yaml
@@ -33,6 +33,8 @@ metadata:
     app.kubernetes.io/instance: spegel
     app.kubernetes.io/version: "v0.5.1"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    service.kubernetes.io/topology-mode: "auto"
 spec:
   type: NodePort
   selector:
@@ -45,7 +47,6 @@ spec:
       targetPort: registry
       nodePort: 30021
       protocol: TCP
-  trafficDistribution: PreferSameNode
 ---
 # Source: spegel/templates/service.yaml
 apiVersion: v1

--- a/kubernetes/spegel/values.yaml
+++ b/kubernetes/spegel/values.yaml
@@ -1,4 +1,6 @@
 ---
 service:
   registry:
-    usePreferSameNodeTrafficDistribution: true
+    # Disabled because PreferSameNode requires the PreferSameTrafficDistribution feature gate
+    # which is alpha in k8s 1.33. Re-enable when upgrading to k8s 1.34+ where it's beta by default.
+    usePreferSameNodeTrafficDistribution: false


### PR DESCRIPTION
The PreferSameNode value for trafficDistribution requires the
PreferSameTrafficDistribution feature gate, which is alpha in k8s 1.33
and disabled by default. This was causing ArgoCD sync failures.

Disabled the feature for now - it will work in k8s 1.34+ where
PreferSameNode graduates to beta and is enabled by default.

The chart now uses an additional mirror registry on container host
port 30020 instead of relying on trafficDistribution for same-node
routing.
