### PR TITLE
Pin Docker version and enable Renovate management

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -6,6 +6,17 @@ node_exporter_version: 1.10.2
 node_exporter_host: 0.0.0.0
 node_exporter_port: 9100
 node_exporter_options: --collector.textfile.directory=/var/lib/node_exporter/textfile_collector --log.level=info
+
+# Docker version pinning - managed by Renovate
+# renovate: datasource=github-releases depName=moby/moby
+docker_version: "29.1.1"
+docker_packages:
+  - "docker-ce=5:{{ docker_version }}-1~{{ ansible_distribution | lower }}.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release }}"
+  - "docker-ce-cli=5:{{ docker_version }}-1~{{ ansible_distribution | lower }}.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release }}"
+  - "docker-ce-rootless-extras=5:{{ docker_version }}-1~{{ ansible_distribution | lower }}.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release }}"
+  - "containerd.io"
+  - "docker-buildx-plugin"
+docker_packages_state: present
 # Map Ansible architecture names to node_exporter release architecture names
 node_exporter_arch: >-
   {{


### PR DESCRIPTION
- Pin Docker CE to version 29.1.1
- Configure Renovate to track moby/moby releases for updates
- Override docker_packages to include explicit version pins
- Ensures consistent Docker versions across Ansible-managed hosts
- Tested successfully on infrapi (only Ansible-managed Docker host)
