### PR TITLE
Move ARA image pin to kustomization for automerge

### DIFF
--- a/kubernetes/ara/helm/deployment.yaml
+++ b/kubernetes/ara/helm/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       containers:
-      - image: docker.io/recordsansible/ara-api@sha256:080334c1cf9a81eabb1cc1ed1e745cd2ddb184ce92b44d3a16fd5c6871ee4b06
+      - image: docker.io/recordsansible/ara-api:latest
         imagePullPolicy: IfNotPresent
         name: ara
         env:

--- a/kubernetes/ara/kustomization.yaml
+++ b/kubernetes/ara/kustomization.yaml
@@ -23,5 +23,10 @@ patches:
     kind: Deployment
     name: ara-ara
 
+images:
+- name: docker.io/recordsansible/ara-api
+  newName: docker.io/recordsansible/ara-api
+  digest: sha256:8774f1c567a57df1b7a5bf6a9627a42e99d90a5f9eae384e9641af67856832bf
+
 commonAnnotations:
   argoManaged: 'true'

--- a/kubernetes/ara/values.yaml
+++ b/kubernetes/ara/values.yaml
@@ -1,8 +1,4 @@
 ---
-# Use official ARA image - pinned to digest to avoid automatic updates
-image: docker.io/recordsansible/ara-api@sha256:080334c1cf9a81eabb1cc1ed1e745cd2ddb184ce92b44d3a16fd5c6871ee4b06
-pullPolicy: IfNotPresent
-
 replicas: 1
 
 # Environment variables for ARA configuration


### PR DESCRIPTION
- Pin ara-api image digest in kustomization.yaml instead of values.yaml
- Remove image override from values.yaml (use chart default)
- Update to digest sha256:8774f1c (Dec 3, 2025 build)

This allows Renovate's kustomize manager to handle digest updates
with automerge enabled.
