### PR TITLE
Add homepage annotations to booklore, n8n, and openarchiver ingresses

### DIFF
--- a/kubernetes/booklore/ingress.yaml
+++ b/kubernetes/booklore/ingress.yaml
@@ -1,29 +1,36 @@
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+
 metadata:
   name: booklore
   namespace: booklore
   annotations:
     cert-manager.io/cluster-issuer: zerossl
+    gethomepage.dev/enabled: 'true'
+    gethomepage.dev/name: Booklore
+    gethomepage.dev/description: Book Library Manager
+    gethomepage.dev/group: Media
+    gethomepage.dev/icon: mdi-bookshelf
     ak-type: oidc
     ak-oidc-callback: /oauth2-callback
     ak-oidc-client-type: public
     ak-path-exclude: /api(/|$)
+
 spec:
   ingressClassName: nginx
   tls:
-    - hosts:
-        - booklore.k.oneill.net
-      secretName: booklore-tls
+  - hosts:
+    - booklore.k.oneill.net
+    secretName: booklore-tls
   rules:
-    - host: booklore.k.oneill.net
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: booklore
-                port:
-                  number: 6060
+  - host: booklore.k.oneill.net
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: booklore
+            port:
+              number: 6060

--- a/kubernetes/n8n/helm/n8n/ingress.yaml
+++ b/kubernetes/n8n/helm/n8n/ingress.yaml
@@ -12,6 +12,11 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+    gethomepage.dev/description: Workflow Automation
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Home Lab
+    gethomepage.dev/icon: n8n.png
+    gethomepage.dev/name: n8n
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
   ingressClassName: nginx

--- a/kubernetes/n8n/values.yaml
+++ b/kubernetes/n8n/values.yaml
@@ -14,6 +14,11 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+    gethomepage.dev/enabled: 'true'
+    gethomepage.dev/name: n8n
+    gethomepage.dev/description: Workflow Automation
+    gethomepage.dev/group: Home Lab
+    gethomepage.dev/icon: n8n.png
   hosts:
   - host: n8n.k.oneill.net
     paths:

--- a/kubernetes/openarchiver/ingress.yaml
+++ b/kubernetes/openarchiver/ingress.yaml
@@ -8,6 +8,11 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: zerossl
     nginx.ingress.kubernetes.io/proxy-body-size: 100m
+    gethomepage.dev/enabled: 'true'
+    gethomepage.dev/name: OpenArchiver
+    gethomepage.dev/description: Archive Browser
+    gethomepage.dev/group: Media Tools
+    gethomepage.dev/icon: mdi-archive
 
 spec:
   ingressClassName: nginx


### PR DESCRIPTION
- Booklore: Media group, book library manager
- n8n: Home Lab group, workflow automation
- OpenArchiver: Media Tools group, archive browser
