### PR TITLE
Move nut_webgui environment config to env file

### DIFF
--- a/ansible/roles/nut/files/docker-compose.yaml
+++ b/ansible/roles/nut/files/docker-compose.yaml
@@ -5,14 +5,6 @@ services:
     restart: unless-stopped
     env_file:
       - nut_webgui.env
-    environment:
-      UPSD_ADDR: "${HOSTNAME}.oneill.net"
-      UPSD_PORT: "3493"
-      UPSD_USER: "monuser"
-      UPSD_PASS: "secret"
-      POLL_FREQ: "30"
-      POLL_INTERVAL: "2"
-      LOG_LEVEL: "info"
     labels:
       # Enable Traefik for this container (since exposedbydefault=false)
       - "traefik.enable=true"

--- a/ansible/roles/nut/templates/webgui.env.j2
+++ b/ansible/roles/nut/templates/webgui.env.j2
@@ -1,1 +1,7 @@
-HOSTNAME={{ inventory_hostname }}
+UPSD_ADDR={{ inventory_hostname }}.oneill.net
+UPSD_PORT=3493
+UPSD_USER=monuser
+UPSD_PASS=secret
+POLL_FREQ=30
+POLL_INTERVAL=2
+LOG_LEVEL=info


### PR DESCRIPTION
Remove environment variables from docker-compose.yaml and consolidate
them into the templated webgui.env.j2 file. This fixes an issue where
docker-compose was using shell variable interpolation for UPSD_ADDR
which could produce incorrect values.
