### PR TITLE
Remove defunct host configs for frank and pizero

### DIFF
--- a/ansible/group_vars/pizero.yaml
+++ b/ansible/group_vars/pizero.yaml
@@ -1,5 +1,0 @@
----
-node_exporter_enabled: false
-restic_pizero_config:
-  default:
-    repository: sftp:restic@luser.fnord.net:/repos/{{ ansible_hostname }}

--- a/ansible/host_vars/frank.yaml
+++ b/ansible/host_vars/frank.yaml
@@ -1,7 +1,0 @@
----
-tailscale_args: --advertise-exit-node # --accept-dns=false
-ip_forwarding_enabled: true
-restic_prometheus_config: {}
-restic_host_config:
-  default:
-    repository: sftp:restic@luser.fnord.net:/repos/{{ ansible_hostname }}


### PR DESCRIPTION
These hosts no longer exist. frank.yaml and pizero.yaml contained
stale restic SFTP backup configurations pointing to luser.
