### PR TITLE
Move Tailscale exit node from luser to infrapi

### DIFF
--- a/ansible/host_vars/flux.yaml
+++ b/ansible/host_vars/flux.yaml
@@ -1,7 +1,7 @@
 ---
 # Vultr VPS running Debian 11 (bullseye)
 # vc2-1c-1gb instance
-tailscale_args: --advertise-exit-node # --accept-dns=false
+tailscale_args: --advertise-exit-node --accept-dns=false
 tailscale_tags: ['flux']
 ip_forwarding_enabled: true
 restic_prometheus_config: {}

--- a/ansible/host_vars/infrapi.yaml
+++ b/ansible/host_vars/infrapi.yaml
@@ -1,4 +1,8 @@
 ---
+# Tailscale exit node (migrated from luser)
+tailscale_args: --advertise-routes=172.19.74.0/23,172.20.4.0/22 --advertise-exit-node --accept-dns=false
+ip_forwarding_enabled: true
+
 # UPS server host - monitors all UPS devices but does NOT shut down
 # Clients will shut themselves down when they see LOWBATT
 

--- a/ansible/host_vars/luser.yaml
+++ b/ansible/host_vars/luser.yaml
@@ -1,7 +1,4 @@
 ---
-tailscale_args: --advertise-routes=172.19.74.0/23 --advertise-exit-node --accept-dns=false
-ip_forwarding_enabled: true
-
 restic_host_config:
   default:
     backup:


### PR DESCRIPTION
Add IoT network (172.20.4.0/22) to advertised routes on all exit nodes.
