### PR TITLE
Migrate rsnapshot to Kubernetes, consolidate healthcheck secrets

### DIFF
--- a/kubernetes/restic/shared/externalsecret.yaml
+++ b/kubernetes/restic/shared/externalsecret.yaml
@@ -9,9 +9,19 @@ spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  dataFrom:
-  - extract:
+  data:
+  - secretKey: RESTIC_PASSWORD
+    remoteRef:
       key: resticprofile
+      property: RESTIC_PASSWORD
+  - secretKey: HEALTHCHECK_PING_KEY
+    remoteRef:
+      key: healthchecks-io
+      property: PING_KEY
+  - secretKey: HEALTHCHECK_API_KEY
+    remoteRef:
+      key: healthchecks-io
+      property: API_KEY
 
 ---
 apiVersion: external-secrets.io/v1

--- a/kubernetes/rsnapshot/cronjob-daily.yaml
+++ b/kubernetes/rsnapshot/cronjob-daily.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: rsnapshot-daily
+
+spec:
+  schedule: "30 3 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: rsnapshot
+            image: alpine:3.23@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375
+            command:
+            - /bin/sh
+            - -c
+            - |
+              apk add --no-cache rsnapshot openssh-client rsync curl
+              mkdir -p /backups/rsnapshot/.ssh
+              if rsnapshot -V -c /etc/rsnapshot.conf daily; then
+                curl -fsS -m 10 --retry 5 -o /dev/null "https://hc-ping.com/${HEALTHCHECK_PING_KEY}/rsnapshot-daily"
+              else
+                curl -fsS -m 10 --retry 5 -o /dev/null "https://hc-ping.com/${HEALTHCHECK_PING_KEY}/rsnapshot-daily/fail"
+                exit 1
+              fi
+            env:
+            - name: HEALTHCHECK_PING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: rsnapshot-healthcheck
+                  key: HEALTHCHECK_PING_KEY
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: false
+            volumeMounts:
+            - name: rsnapshot-config
+              mountPath: /etc/rsnapshot.conf
+              subPath: rsnapshot.conf
+              readOnly: true
+            - name: ssh-key
+              mountPath: /root/.ssh
+              readOnly: true
+            - name: ssh-config
+              mountPath: /etc/ssh/ssh_config
+              subPath: ssh-config
+              readOnly: true
+            - name: backups
+              mountPath: /backups/rsnapshot
+          volumes:
+          - name: rsnapshot-config
+            configMap:
+              name: rsnapshot-config
+          - name: ssh-key
+            secret:
+              secretName: rsnapshot-ssh-key
+              items:
+              - key: id_ed25519
+                path: id_ed25519
+                mode: 0600
+          - name: ssh-config
+            configMap:
+              name: rsnapshot-config
+          - name: backups
+            nfs:
+              server: fs2.oneill.net
+              path: /volume2/backups/rsnapshot
+          restartPolicy: OnFailure

--- a/kubernetes/rsnapshot/cronjob-monthly.yaml
+++ b/kubernetes/rsnapshot/cronjob-monthly.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: rsnapshot-monthly
+
+spec:
+  schedule: "30 2 1 * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: rsnapshot
+            image: alpine:3.23@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375
+            command:
+            - /bin/sh
+            - -c
+            - |
+              apk add --no-cache rsnapshot openssh-client rsync curl
+              mkdir -p /backups/rsnapshot/.ssh
+              if rsnapshot -c /etc/rsnapshot.conf monthly; then
+                curl -fsS -m 10 --retry 5 -o /dev/null "https://hc-ping.com/${HEALTHCHECK_PING_KEY}/rsnapshot-monthly"
+              else
+                curl -fsS -m 10 --retry 5 -o /dev/null "https://hc-ping.com/${HEALTHCHECK_PING_KEY}/rsnapshot-monthly/fail"
+                exit 1
+              fi
+            env:
+            - name: HEALTHCHECK_PING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: rsnapshot-healthcheck
+                  key: HEALTHCHECK_PING_KEY
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: false
+            volumeMounts:
+            - name: rsnapshot-config
+              mountPath: /etc/rsnapshot.conf
+              subPath: rsnapshot.conf
+              readOnly: true
+            - name: ssh-key
+              mountPath: /root/.ssh
+              readOnly: true
+            - name: ssh-config
+              mountPath: /etc/ssh/ssh_config
+              subPath: ssh-config
+              readOnly: true
+            - name: backups
+              mountPath: /backups/rsnapshot
+          volumes:
+          - name: rsnapshot-config
+            configMap:
+              name: rsnapshot-config
+          - name: ssh-key
+            secret:
+              secretName: rsnapshot-ssh-key
+              items:
+              - key: id_ed25519
+                path: id_ed25519
+                mode: 0600
+          - name: ssh-config
+            configMap:
+              name: rsnapshot-config
+          - name: backups
+            nfs:
+              server: fs2.oneill.net
+              path: /volume2/backups/rsnapshot
+          restartPolicy: OnFailure

--- a/kubernetes/rsnapshot/cronjob-weekly.yaml
+++ b/kubernetes/rsnapshot/cronjob-weekly.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: rsnapshot-weekly
+
+spec:
+  schedule: "0 3 * * 0"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: rsnapshot
+            image: alpine:3.23@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375
+            command:
+            - /bin/sh
+            - -c
+            - |
+              apk add --no-cache rsnapshot openssh-client rsync curl
+              mkdir -p /backups/rsnapshot/.ssh
+              if rsnapshot -c /etc/rsnapshot.conf weekly; then
+                curl -fsS -m 10 --retry 5 -o /dev/null "https://hc-ping.com/${HEALTHCHECK_PING_KEY}/rsnapshot-weekly"
+              else
+                curl -fsS -m 10 --retry 5 -o /dev/null "https://hc-ping.com/${HEALTHCHECK_PING_KEY}/rsnapshot-weekly/fail"
+                exit 1
+              fi
+            env:
+            - name: HEALTHCHECK_PING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: rsnapshot-healthcheck
+                  key: HEALTHCHECK_PING_KEY
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: false
+            volumeMounts:
+            - name: rsnapshot-config
+              mountPath: /etc/rsnapshot.conf
+              subPath: rsnapshot.conf
+              readOnly: true
+            - name: ssh-key
+              mountPath: /root/.ssh
+              readOnly: true
+            - name: ssh-config
+              mountPath: /etc/ssh/ssh_config
+              subPath: ssh-config
+              readOnly: true
+            - name: backups
+              mountPath: /backups/rsnapshot
+          volumes:
+          - name: rsnapshot-config
+            configMap:
+              name: rsnapshot-config
+          - name: ssh-key
+            secret:
+              secretName: rsnapshot-ssh-key
+              items:
+              - key: id_ed25519
+                path: id_ed25519
+                mode: 0600
+          - name: ssh-config
+            configMap:
+              name: rsnapshot-config
+          - name: backups
+            nfs:
+              server: fs2.oneill.net
+              path: /volume2/backups/rsnapshot
+          restartPolicy: OnFailure

--- a/kubernetes/rsnapshot/externalsecret.yaml
+++ b/kubernetes/rsnapshot/externalsecret.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+  name: rsnapshot-ssh-key
+
+spec:
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  target:
+    name: rsnapshot-ssh-key
+  data:
+  - secretKey: id_ed25519
+    remoteRef:
+      key: rsnapshot-k8s-private-key
+      property: private_key
+
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+  name: rsnapshot-healthcheck
+
+spec:
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  target:
+    name: rsnapshot-healthcheck
+  data:
+  - secretKey: HEALTHCHECK_PING_KEY
+    remoteRef:
+      key: healthchecks-io
+      property: PING_KEY

--- a/kubernetes/rsnapshot/kustomization.yaml
+++ b/kubernetes/rsnapshot/kustomization.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rsnapshot
+
+resources:
+- namespace.yaml
+- externalsecret.yaml
+- cronjob-daily.yaml
+- cronjob-weekly.yaml
+- cronjob-monthly.yaml
+
+commonAnnotations:
+  argoManaged: 'true'
+
+labels:
+- pairs:
+    app.kubernetes.io/name: rsnapshot
+    app.kubernetes.io/instance: rsnapshot
+  includeSelectors: true
+
+configMapGenerator:
+- name: rsnapshot-config
+  files:
+  - rsnapshot.conf
+  - ssh-config
+  options:
+    disableNameSuffixHash: true

--- a/kubernetes/rsnapshot/namespace.yaml
+++ b/kubernetes/rsnapshot/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rsnapshot
+  labels:
+    goldilocks.fairwinds.com/enabled: 'true'
+  annotations:
+    goldilocks.fairwinds.com/vpa-update-mode: InPlaceOrRecreate
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","controlledValues":"RequestsOnly"}]}'

--- a/kubernetes/rsnapshot/rsnapshot.conf
+++ b/kubernetes/rsnapshot/rsnapshot.conf
@@ -1,0 +1,16 @@
+config_version	1.2
+snapshot_root	/backups/rsnapshot
+no_create_root	1
+cmd_cp	/bin/cp
+cmd_rm	/bin/rm
+cmd_rsync	/usr/bin/rsync
+cmd_ssh	/usr/bin/ssh
+cmd_du	/usr/bin/du
+interval	daily	7
+interval	weekly	4
+interval	monthly	18
+link_dest	1
+verbose	2
+loglevel	3
+lockfile	/tmp/rsnapshot.pid
+backup	root@udmp.oneill.net:/data/unifi/data/backup/	udmp/

--- a/kubernetes/rsnapshot/ssh-config
+++ b/kubernetes/rsnapshot/ssh-config
@@ -1,0 +1,4 @@
+Host *
+  StrictHostKeyChecking accept-new
+  UserKnownHostsFile /backups/rsnapshot/.ssh/known_hosts
+  IdentityFile /root/.ssh/id_ed25519

--- a/kubernetes/velero/healthcheck-externalsecret.yaml
+++ b/kubernetes/velero/healthcheck-externalsecret.yaml
@@ -17,5 +17,5 @@ spec:
   data:
   - secretKey: HEALTHCHECK_PING_KEY
     remoteRef:
-      key: velero-healthchecks
-      property: HEALTHCHECK_PING_KEY
+      key: healthchecks-io
+      property: PING_KEY

--- a/kubernetes/velero/healthcheck.sh
+++ b/kubernetes/velero/healthcheck.sh
@@ -50,7 +50,7 @@ BACKUP_COUNT=$(echo "$BACKUPS_JSON" | jq -r '.items | length')
 
 if [ "$BACKUP_COUNT" -eq 0 ]; then
   echo "ERROR: No backups found"
-  wget -q -O- "https://hc-ping.com/${HEALTHCHECK_PING_KEY}/fail" \
+  wget -q -O- "https://hc-ping.com/${HEALTHCHECK_PING_KEY}/velero-daily-backup/fail" \
     --post-data "No backups found"
   exit 1
 fi
@@ -87,12 +87,12 @@ done
 # Check if we found a successful backup
 if [ -z "$FOUND_BACKUP" ]; then
   echo "ERROR: No completed backup found in past 48 hours"
-  wget -q -O- "https://hc-ping.com/${HEALTHCHECK_PING_KEY}/fail" \
+  wget -q -O- "https://hc-ping.com/${HEALTHCHECK_PING_KEY}/velero-daily-backup/fail" \
     --post-data "No completed backup found in past 48 hours"
   exit 1
 fi
 
 # Success!
 echo "SUCCESS: Backup $FOUND_BACKUP completed successfully (${FOUND_AGE}h ago)"
-wget -q -O- "https://hc-ping.com/${HEALTHCHECK_PING_KEY}" \
+wget -q -O- "https://hc-ping.com/${HEALTHCHECK_PING_KEY}/velero-daily-backup" \
   --post-data "Backup: $FOUND_BACKUP completed successfully (${FOUND_AGE}h ago)"


### PR DESCRIPTION
- Add rsnapshot K8s CronJobs (daily/weekly/monthly) replacing luser cron
- Create unified healthchecks-io 1Password item with PING_KEY and API_KEY
- Update velero and restic to use consolidated healthchecks-io secret
- Append check name to healthcheck URLs for multi-service support
