### PR TITLE
Consolidate NFS mounts for hardlink compatibility

### DIFF
--- a/kubernetes/cross-seed/config.js
+++ b/kubernetes/cross-seed/config.js
@@ -33,7 +33,7 @@ module.exports = {
      * 		dataDirs: ["C:\\My Data\\Downloads"]
      */
     dataDirs: [
-        "/downloads/qbittorrent/completed",
+        "/shared/downloads/qbittorrent/completed",
     ],
     /**
      * Determines flexibility of naming during matching. "safe" will allow only perfect name matches
@@ -57,7 +57,7 @@ module.exports = {
     /**
      * List of directories where cross-seed will create links to scanned files.
      */
-    linkDirs: ["/downloads/qbittorrent/cross-seeds"],
+    linkDirs: ["/shared/downloads/qbittorrent/cross-seeds"],
     /**
      * cross-seed will use links of this type to inject data-based matches into your client.
      * Only relevant if dataDirs is specified.

--- a/kubernetes/cross-seed/deploy.yaml
+++ b/kubernetes/cross-seed/deploy.yaml
@@ -37,10 +37,8 @@ spec:
           mountPath: /torrents
           subPath: qBittorrent/BT_backup
           readOnly: true
-        - name: downloads
-          mountPath: /downloads
-        - name: video
-          mountPath: /video
+        - name: shared
+          mountPath: /shared
         - name: cross-seed-data
           mountPath: /cross-seeds
         env:
@@ -84,11 +82,7 @@ spec:
       - name: cross-seed-data
         persistentVolumeClaim:
           claimName: cross-seed-data
-      - name: downloads
+      - name: shared
         nfs:
           server: fs2.oneill.net
-          path: /volume2/shared/downloads
-      - name: video
-        nfs:
-          server: fs2.oneill.net
-          path: /volume2/shared/video
+          path: /volume2/shared

--- a/kubernetes/radarr/deploy.yaml
+++ b/kubernetes/radarr/deploy.yaml
@@ -31,10 +31,6 @@ spec:
         volumeMounts:
         - mountPath: /config
           name: config
-        - mountPath: /movies
-          name: movies
-        - mountPath: /downloads
-          name: downloads
         - mountPath: /shared
           name: shared
         env:
@@ -48,14 +44,6 @@ spec:
       - name: config
         persistentVolumeClaim:
           claimName: radarr-config
-      - nfs:
-          server: fs2.oneill.net
-          path: /volume2/shared/video/movies
-        name: movies
-      - nfs:
-          server: fs2.oneill.net
-          path: /volume2/shared/downloads
-        name: downloads
       - nfs:
           server: fs2.oneill.net
           path: /volume2/shared

--- a/kubernetes/sonarr/deploy.yaml
+++ b/kubernetes/sonarr/deploy.yaml
@@ -27,10 +27,6 @@ spec:
         volumeMounts:
         - mountPath: /config
           name: config
-        - mountPath: /tv
-          name: tv
-        - mountPath: /downloads
-          name: downloads
         - mountPath: /shared
           name: shared
         env:
@@ -51,14 +47,6 @@ spec:
       - name: config
         persistentVolumeClaim:
           claimName: sonarr-config
-      - nfs:
-          server: fs2.oneill.net
-          path: /volume2/shared/video/tv
-        name: tv
-      - nfs:
-          server: fs2.oneill.net
-          path: /volume2/shared/downloads
-        name: downloads
       - nfs:
           server: fs2.oneill.net
           path: /volume2/shared


### PR DESCRIPTION
Remove redundant NFS mounts from Sonarr, Radarr, and cross-seed. Each app
now uses a single /shared mount instead of separate mounts for /tv, /movies,
/downloads, and /video.

- Sonarr: Remove /tv and /downloads mounts, keep /shared
- Radarr: Remove /movies and /downloads mounts, keep /shared
- Cross-seed: Replace /downloads and /video with /shared, update config paths

This ensures hardlinks work consistently since source and destination files
are on the same mount point.
