### PR TITLE
Migrate getmail from luser to Kubernetes

### DIFF
--- a/kubernetes/getmail/cronjob.yaml
+++ b/kubernetes/getmail/cronjob.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: getmail
+
+spec:
+  schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: getmail
+            image: debian:trixie-slim
+            command:
+            - /bin/sh
+            - -c
+            - |
+              apt-get update && apt-get install -y --no-install-recommends getmail6 procmail ca-certificates
+              useradd -u 10001 -m getmail
+              mkdir -p /home/getmail/.config/getmail
+              ln -sf /config/procmailrc /home/getmail/.procmailrc
+              cp /config/getmailrc /home/getmail/.config/getmail/getmailrc
+              chown -R getmail:getmail /home/getmail /mail
+              su -s /bin/sh getmail -c '/usr/bin/getmail'
+            env:
+            - name: HOME
+              value: /home/getmail
+            volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: credentials
+              mountPath: /secrets
+              readOnly: true
+            - name: mail
+              mountPath: /mail
+            - name: home
+              mountPath: /home/getmail
+          volumes:
+          - name: config
+            configMap:
+              name: getmail-config
+          - name: credentials
+            secret:
+              secretName: getmail-credentials
+          - name: mail
+            nfs:
+              server: fs2.oneill.net
+              path: /volume2/backups/mail
+          - name: home
+            emptyDir: {}
+          restartPolicy: OnFailure

--- a/kubernetes/getmail/externalsecret.yaml
+++ b/kubernetes/getmail/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+  name: getmail-credentials
+
+spec:
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  target:
+    name: getmail-credentials
+  data:
+  - secretKey: password
+    remoteRef:
+      key: getmail
+      property: gmail_app_password

--- a/kubernetes/getmail/getmailrc
+++ b/kubernetes/getmail/getmailrc
@@ -1,0 +1,15 @@
+[options]
+read_all = False
+delete = 0
+verbose = 1
+
+[retriever]
+type = SimplePOP3SSLRetriever
+server = pop.gmail.com
+username = clayton.oneill
+password_command = ("cat", "/secrets/password")
+
+[destination]
+type = MDA_external
+path = /usr/bin/procmail
+arguments = ("-f", "%(sender)")

--- a/kubernetes/getmail/kustomization.yaml
+++ b/kubernetes/getmail/kustomization.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: getmail
+
+resources:
+- namespace.yaml
+- externalsecret.yaml
+- cronjob.yaml
+
+commonAnnotations:
+  argoManaged: 'true'
+
+labels:
+- pairs:
+    app.kubernetes.io/name: getmail
+    app.kubernetes.io/instance: getmail
+  includeSelectors: true
+
+configMapGenerator:
+- name: getmail-config
+  files:
+  - getmailrc
+  - procmailrc
+  options:
+    disableNameSuffixHash: true

--- a/kubernetes/getmail/namespace.yaml
+++ b/kubernetes/getmail/namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: getmail

--- a/kubernetes/getmail/procmailrc
+++ b/kubernetes/getmail/procmailrc
@@ -1,0 +1,9 @@
+PATH=/usr/local/bin:/usr/bin:/bin
+MAILDIR=/mail
+LOGFILE=/mail/procmail.log
+LOCKFILE=/mail/.lockmail
+
+YEARMONTH=`date +%Y-%m`
+
+:0 Wi
+/mail/INBOX-$YEARMONTH


### PR DESCRIPTION
- Hourly CronJob fetches email from Gmail POP3
- Uses getmail6 + procmail on debian:trixie-slim
- Stores mbox files on NFS at fs2:/volume2/backups/mail
- Gmail app password stored in 1Password (infra/getmail)
