### PR TITLE
Add battery monitoring for outdoor sensors

### DIFF
--- a/kubernetes/hass/config/configuration.yaml
+++ b/kubernetes/hass/config/configuration.yaml
@@ -766,6 +766,46 @@ mqtt:
       manufacturer: Ecowitt
       via_device: rtl_433
 
+  - name: Soil Battery WH51 0eb421
+    unique_id: wh51_0eb421_battery
+    state_topic: rtl_433/devices/Fineoffset-WH51/0eb421
+    value_template: '{{ (value_json.battery_mV / 1000) | round(3) }}'
+    unit_of_measurement: V
+    device_class: voltage
+    expire_after: 3600
+    device:
+      identifiers: [wh51_0eb421]
+
+  - name: Soil Battery WH51 0eb446
+    unique_id: wh51_0eb446_battery
+    state_topic: rtl_433/devices/Fineoffset-WH51/0eb446
+    value_template: '{{ (value_json.battery_mV / 1000) | round(3) }}'
+    unit_of_measurement: V
+    device_class: voltage
+    expire_after: 3600
+    device:
+      identifiers: [wh51_0eb446]
+
+  - name: Soil Battery WH51 0eadc9 (Other Veggies)
+    unique_id: wh51_0eadc9_battery
+    state_topic: rtl_433/devices/Fineoffset-WH51/0eadc9
+    value_template: '{{ (value_json.battery_mV / 1000) | round(3) }}'
+    unit_of_measurement: V
+    device_class: voltage
+    expire_after: 3600
+    device:
+      identifiers: [wh51_0eadc9]
+
+  - name: Soil Battery WH51 0ed338 (Strawberries)
+    unique_id: wh51_0ed338_battery
+    state_topic: rtl_433/devices/Fineoffset-WH51/0ed338
+    value_template: '{{ (value_json.battery_mV / 1000) | round(3) }}'
+    unit_of_measurement: V
+    device_class: voltage
+    expire_after: 3600
+    device:
+      identifiers: [wh51_0ed338]
+
   - name: Rain Meter WH40 51409
     unique_id: wh40_51409_rain
     state_topic: rtl_433/devices/EcoWitt-WH40/51409
@@ -789,6 +829,16 @@ mqtt:
       manufacturer: Ecowitt
       via_device: rtl_433
 
+  - name: Rain Meter Battery WH40 51409
+    unique_id: wh40_51409_battery
+    state_topic: rtl_433/devices/EcoWitt-WH40/51409
+    value_template: '{{ value_json.battery_V | round(3) }}'
+    unit_of_measurement: V
+    device_class: voltage
+    expire_after: 3600
+    device:
+      identifiers: [wh40_51409]
+
   - name: Gas Meter Consumption
     unique_id: scmplus_98864084_consumption
     state_topic: rtl_433/devices/SCMplus/98864084
@@ -810,3 +860,59 @@ mqtt:
       name: SCM+ Gas Meter 98864084
       model: SCM+
       via_device: rtl_433
+
+  binary_sensor:
+  - name: Soil Battery Low WH51 0eb421
+    unique_id: wh51_0eb421_battery_low
+    state_topic: rtl_433/devices/Fineoffset-WH51/0eb421
+    value_template: '{{ value_json.battery_ok }}'
+    payload_on: '0'
+    payload_off: '1'
+    device_class: battery
+    expire_after: 3600
+    device:
+      identifiers: [wh51_0eb421]
+
+  - name: Soil Battery Low WH51 0eb446
+    unique_id: wh51_0eb446_battery_low
+    state_topic: rtl_433/devices/Fineoffset-WH51/0eb446
+    value_template: '{{ value_json.battery_ok }}'
+    payload_on: '0'
+    payload_off: '1'
+    device_class: battery
+    expire_after: 3600
+    device:
+      identifiers: [wh51_0eb446]
+
+  - name: Soil Battery Low WH51 0eadc9 (Other Veggies)
+    unique_id: wh51_0eadc9_battery_low
+    state_topic: rtl_433/devices/Fineoffset-WH51/0eadc9
+    value_template: '{{ value_json.battery_ok }}'
+    payload_on: '0'
+    payload_off: '1'
+    device_class: battery
+    expire_after: 3600
+    device:
+      identifiers: [wh51_0eadc9]
+
+  - name: Soil Battery Low WH51 0ed338 (Strawberries)
+    unique_id: wh51_0ed338_battery_low
+    state_topic: rtl_433/devices/Fineoffset-WH51/0ed338
+    value_template: '{{ value_json.battery_ok }}'
+    payload_on: '0'
+    payload_off: '1'
+    device_class: battery
+    expire_after: 3600
+    device:
+      identifiers: [wh51_0ed338]
+
+  - name: Rain Meter Battery Low WH40 51409
+    unique_id: wh40_51409_battery_low
+    state_topic: rtl_433/devices/EcoWitt-WH40/51409
+    value_template: '{{ value_json.battery_ok }}'
+    payload_on: '0'
+    payload_off: '1'
+    device_class: battery
+    expire_after: 3600
+    device:
+      identifiers: [wh40_51409]

--- a/kubernetes/prometheus/config/rules.yml
+++ b/kubernetes/prometheus/config/rules.yml
@@ -26,6 +26,17 @@ groups:
   - alert: Netatmo_Battery_Low
     expr: netatmo_sensor_battery_percent < 20
     for: 2h
+  - alert: Outdoor_Sensor_Battery_Low
+    expr: hass_sensor_voltage_v{entity=~"sensor.*(soil|rain).*battery.*"} < 1.2
+    for: 1h
+    annotations:
+      message: '{{ $labels.friendly_name }} is at {{ $value }}V - replace battery'
+  - alert: Outdoor_Sensor_Unavailable
+    expr: hass_entity_available{entity=~"sensor.*(soil.*moisture|rain_meter).*"} ==
+      0
+    for: 1d
+    annotations:
+      message: '{{ $labels.friendly_name }} has stopped reporting'
   - alert: LessThanAnInchOfRain
         # (sum_over_time(netatmo_sensor_rain_amount_mm[7d]) *25.4 /300) < bool 1 and (max_over_time(netatmo_sensor_temperature_celsius{module="Outdoor"}[7d])*9/5 + 32)  > bool 65
     expr: sum_over_time(netatmo_sensor_rain_amount_mm[7d]) *25.4 /300 < 1


### PR DESCRIPTION
- Add voltage sensors for WH51 soil sensors and WH40 rain meter
- Add binary low-battery sensors based on battery_ok flag
- Add HA automation for persistent notification on low battery
- Add Prometheus alerts for low voltage (<1.2V) and unavailable sensors (1d)
