### PR TITLE
Add Loki/logcli config and fix healthchecks 1Password path

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -22,7 +22,12 @@ fi
 # Load secrets from 1Password
 export RADARR_API_KEY=$(op read "op://infra/radarr/api_key")
 export SONARR_API_KEY=$(op read "op://infra/sonarr/api_key")
-export HEALTHCHECK_API_KEY=$(op read "op://infra/resticprofile/HEALTHCHECK_API_KEY")
+export HEALTHCHECK_API_KEY=$(op read "op://infra/healthchecks-io/api_key")
+
+# Loki/logcli configuration
+export LOKI_ADDR=https://loki.k.oneill.net
+export LOKI_USERNAME=$(op read "op://infra/loki/username")
+export LOKI_PASSWORD=$(op read "op://infra/loki/password")
 
 # ARA (Ansible Run Analysis) configuration
 # Sends playbook run data to centralized ARA server at ara.k.oneill.net


### PR DESCRIPTION
Missed from PR #848 (CrowdSec with UniFi firewall log integration):
- Add LOKI_ADDR, LOKI_USERNAME, LOKI_PASSWORD for logcli
- Fix HEALTHCHECK_API_KEY to use correct 1Password item path
