### PR TITLE
Restore infra1 host to Ansible inventory

### DIFF
--- a/ansible/host_vars/infra1.yaml
+++ b/ansible/host_vars/infra1.yaml
@@ -1,0 +1,11 @@
+---
+# Static network configuration
+manage_network: true
+interfaces_ether_interfaces:
+  - device: eno1
+    bootproto: static
+    address: "172.19.74.31"
+    netmask: "255.255.255.0"
+    gateway: 172.19.74.1
+    dnsnameservers: 172.19.74.1
+    dnssearch: oneill.net

--- a/ansible/inventory/default
+++ b/ansible/inventory/default
@@ -10,6 +10,7 @@ p3 ansible_host=p3.oneill.net domain=oneill.net
 #gasherbrum ansible_host=gasherbrum.oneill.net domain=oneill.net
 #gasherbrum-display ansible_host=gasherbrum-display.oneill.net domain=oneill.net
 zwavejs ansible_host=zwavejs.oneill.net domain=oneill.net
+infra1 ansible_host=infra1.oneill.net domain=oneill.net
 infrapi ansible_host=infrapi.oneill.net domain=oneill.net
 p2 ansible_host=p2.oneill.net domain=oneill.net
 p4 ansible_host=p4.oneill.net domain=oneill.net


### PR DESCRIPTION
Re-add infra1 host definition and host_vars that were accidentally
removed during the SMTP relay merge (#857).
