### PR TITLE
Add Authorization header to basic-auth Authentik component

### DIFF
--- a/kubernetes/components/authentik/kustomization.yaml
+++ b/kubernetes/components/authentik/kustomization.yaml
@@ -47,7 +47,7 @@ patches:
       value: https://$http_host/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri
     - op: add
       path: /metadata/annotations/nginx.ingress.kubernetes.io~1auth-response-headers
-      value: Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid
+      value: Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid,Authorization
     - op: add
       path: /metadata/annotations/nginx.ingress.kubernetes.io~1auth-snippet
       value: |

--- a/scripts/format-kustomization
+++ b/scripts/format-kustomization
@@ -106,8 +106,12 @@ def normalize_blank_lines(doc: str) -> str:
             last_key = curr_key
             continue
 
-        # Default path: emit current line and continue
-        out.append(line)
+        # Default path: emit any collected comments and current line
+        if start < i:
+            # We collected comments but next line isn't a top-level key
+            # (e.g., comments before list items like "- target:")
+            out.extend(lines[start:i])
+        out.append(lines[i])
         i += 1
 
     return "".join(out)


### PR DESCRIPTION
The basic-auth patch was missing the Authorization header in
auth-response-headers, preventing nginx from forwarding credentials
to backend apps like Sonarr that require HTTP Basic Auth.

Also fixes format-kustomization script to preserve comments before
list items (e.g., "- target:").
