### PR TITLE
restic: remove init containers, use inline UUID generation

### DIFF
--- a/kubernetes/restic/cronjob-nfs.yaml.j2
+++ b/kubernetes/restic/cronjob-nfs.yaml.j2
@@ -23,13 +23,6 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
-          initContainers:
-          - name: generate-uuid
-            image: alpine
-            command: [sh, -c, "apk add --no-cache util-linux && uuidgen >/tmp/uuid"]
-            volumeMounts:
-            - mountPath: /tmp
-              name: scratch
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-b2-check.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-b2-check.yaml
@@ -23,13 +23,6 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
-          initContainers:
-          - name: generate-uuid
-            image: alpine
-            command: [sh, -c, "apk add --no-cache util-linux && uuidgen >/tmp/uuid"]
-            volumeMounts:
-            - mountPath: /tmp
-              name: scratch
           containers:
           - name: resticprofile
             command:
@@ -49,10 +42,6 @@ spec:
             - secretRef:
                 name: resticprofile-rclone
             env:
-            - name: RUN_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: RCLONE_CONFIG
               value: /rclone-config/rclone.conf
             - name: RESTIC_PASSWORD

--- a/kubernetes/restic/cronjobs/cronjob-b2-forget.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-b2-forget.yaml
@@ -23,13 +23,6 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
-          initContainers:
-          - name: generate-uuid
-            image: alpine
-            command: [sh, -c, "apk add --no-cache util-linux && uuidgen >/tmp/uuid"]
-            volumeMounts:
-            - mountPath: /tmp
-              name: scratch
           containers:
           - name: resticprofile
             command:
@@ -49,10 +42,6 @@ spec:
             - secretRef:
                 name: resticprofile-rclone
             env:
-            - name: RUN_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: RCLONE_CONFIG
               value: /rclone-config/rclone.conf
             - name: RESTIC_PASSWORD

--- a/kubernetes/restic/cronjobs/cronjob-b2.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-b2.yaml
@@ -24,12 +24,6 @@ spec:
           hostname: rp-kube
           restartPolicy: OnFailure
           initContainers:
-          - name: generate-uuid
-            image: alpine
-            command: [sh, -c, "apk add --no-cache util-linux && uuidgen >/tmp/uuid"]
-            volumeMounts:
-            - mountPath: /tmp
-              name: scratch
           - name: fix-cache-permissions
             image: alpine
             command: [sh, -c, chown -R 10007:10007 /cache]
@@ -55,10 +49,6 @@ spec:
             - secretRef:
                 name: resticprofile-rclone
             env:
-            - name: RUN_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: RCLONE_CONFIG
               value: /rclone-config/rclone.conf
             - name: RESTIC_PASSWORD

--- a/kubernetes/restic/cronjobs/cronjob-flux-check.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-flux-check.yaml
@@ -23,13 +23,6 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
-          initContainers:
-          - name: generate-uuid
-            image: alpine
-            command: [sh, -c, "apk add --no-cache util-linux && uuidgen >/tmp/uuid"]
-            volumeMounts:
-            - mountPath: /tmp
-              name: scratch
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-flux-forget.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-flux-forget.yaml
@@ -23,13 +23,6 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
-          initContainers:
-          - name: generate-uuid
-            image: alpine
-            command: [sh, -c, "apk add --no-cache util-linux && uuidgen >/tmp/uuid"]
-            volumeMounts:
-            - mountPath: /tmp
-              name: scratch
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-main-check.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-main-check.yaml
@@ -23,13 +23,6 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
-          initContainers:
-          - name: generate-uuid
-            image: alpine
-            command: [sh, -c, "apk add --no-cache util-linux && uuidgen >/tmp/uuid"]
-            volumeMounts:
-            - mountPath: /tmp
-              name: scratch
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-main-copy.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-main-copy.yaml
@@ -23,13 +23,6 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
-          initContainers:
-          - name: generate-uuid
-            image: alpine
-            command: [sh, -c, "apk add --no-cache util-linux && uuidgen >/tmp/uuid"]
-            volumeMounts:
-            - mountPath: /tmp
-              name: scratch
           containers:
           - name: resticprofile
             command:
@@ -49,10 +42,6 @@ spec:
             - secretRef:
                 name: resticprofile-rclone
             env:
-            - name: RUN_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: RCLONE_CONFIG
               value: /rclone-config/rclone.conf
             - name: RESTIC_FROM_PASSWORD

--- a/kubernetes/restic/cronjobs/cronjob-main-forget.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-main-forget.yaml
@@ -23,13 +23,6 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
-          initContainers:
-          - name: generate-uuid
-            image: alpine
-            command: [sh, -c, "apk add --no-cache util-linux && uuidgen >/tmp/uuid"]
-            volumeMounts:
-            - mountPath: /tmp
-              name: scratch
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-xtal-check.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-xtal-check.yaml
@@ -23,13 +23,6 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
-          initContainers:
-          - name: generate-uuid
-            image: alpine
-            command: [sh, -c, "apk add --no-cache util-linux && uuidgen >/tmp/uuid"]
-            volumeMounts:
-            - mountPath: /tmp
-              name: scratch
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-xtal-forget.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-xtal-forget.yaml
@@ -23,13 +23,6 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
-          initContainers:
-          - name: generate-uuid
-            image: alpine
-            command: [sh, -c, "apk add --no-cache util-linux && uuidgen >/tmp/uuid"]
-            volumeMounts:
-            - mountPath: /tmp
-              name: scratch
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/kustomization.yaml
+++ b/kubernetes/restic/kustomization.yaml
@@ -28,7 +28,7 @@ images:
 - name: alpine
   newTag: 3.23@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375
 - name: creativeprojects/resticprofile
-  newTag: 0.31.0@sha256:ab06bd60e726e18c04539be8b9feb6688793d7a9cf1ef49be8b095ac24578609
+  newTag: 0.32.0@sha256:c49c2e885a82c28eb5a38d77af7f700cf7ebbaf3de48d5e4c9d5f8c035f3197e
 
 labels:
 - includeSelectors: true

--- a/kubernetes/restic/profiles.yaml
+++ b/kubernetes/restic/profiles.yaml
@@ -38,6 +38,7 @@ b2:
     - /source/shared/downloads
     no-error-on-warning: true
     run-before: &run_before |
+      [ -f /tmp/uuid ] || cat /proc/sys/kernel/random/uuid > /tmp/uuid
       echo "Pinging start URL: https://hc.k.oneill.net/ping/${HEALTHCHECK_PING_KEY}/kube-restic-${PROFILE_NAME}-${PROFILE_COMMAND}/start?rid=$(cat /tmp/uuid)"
       wget "https://hc.k.oneill.net/ping/${HEALTHCHECK_PING_KEY}/kube-restic-${PROFILE_NAME}-${PROFILE_COMMAND}/start?rid=$(cat /tmp/uuid)" -O - -S --post-data "Profile: $PROFILE_NAME
       Command: $PROFILE_COMMAND
@@ -76,7 +77,6 @@ b2:
 main-copy:
   force-inactive-lock: true
   compression: max
-  repository: /source/backups/restic/repos/main
   verbose: true
   pack-size: 64
 
@@ -91,6 +91,7 @@ main-copy:
     RESTIC_CACHE_DIR: /cache
 
   copy:
+    from-repository: /source/backups/restic/repos/main
     repository: rclone:b2c:restic/main
     run-before: *run_before
     run-finally: *run_finally


### PR DESCRIPTION
- Replace Alpine init container with /proc/sys/kernel/random/uuid
- Remove unused RUN_ID env var from all cronjobs
- Use from-repository for main-copy profile (v0.32.0 feature)
