### PR TITLE
Fix Grafana certificate issuer typo

### DIFF
--- a/kubernetes/grafana/helm/grafana/ingress.yaml
+++ b/kubernetes/grafana/helm/grafana/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     ak-oidc-callback: "/login/generic_oauth"
     ak-type: "oidc"
-    cert-manager.io/cluster-issuer: "zerosssl"
+    cert-manager.io/cluster-issuer: "zerossl"
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: "Monitoring"
     gethomepage.dev/icon: "grafana.png"

--- a/kubernetes/grafana/values.yaml
+++ b/kubernetes/grafana/values.yaml
@@ -43,7 +43,7 @@ ingress:
   annotations:
     ak-type: oidc
     ak-oidc-callback: /login/generic_oauth
-    cert-manager.io/cluster-issuer: zerosssl
+    cert-manager.io/cluster-issuer: zerossl
     gethomepage.dev/enabled: 'true'
     gethomepage.dev/name: Grafana
     gethomepage.dev/group: Monitoring


### PR DESCRIPTION
The cluster-issuer annotation had "zerosssl" (3 s's) instead of
"zerossl" (2 s's), causing cert-manager to fail renewal.
