### PR TITLE
garage doors: use Aqara tilt sensors for state detection

### DIFF
--- a/esphome/common/device-classes/opengarage.yaml
+++ b/esphome/common/device-classes/opengarage.yaml
@@ -12,7 +12,6 @@
 #   device_id: left_garage_door
 #   human_devicename: Left Garage Door
 #   icon: mdi:garage
-#   door_threshold: "75"  # cm - door open when distance <= this
 #
 # GPIO Pin Mapping (from OpenGarage firmware defines.h):
 #   GPIO 15 - Relay (door trigger)
@@ -36,7 +35,7 @@ logger:
   logs:
     ultrasonic.sensor: INFO  # Suppress per-reading debug messages
 
-# Ultrasonic distance sensor for door state detection
+# Ultrasonic distance sensor (kept for debugging/monitoring)
 # Settings based on OpenGarage stock firmware defaults:
 #   - Read interval (DRI): 500ms
 #   - Timeout: Cap at 450cm
@@ -63,21 +62,13 @@ sensor:
       - round: 1  # Round to nearest 0.1cm
       - delta: 1  # Only report changes >= 1cm
 
-# Garage door cover entity
-cover:
+# Door trigger button - exposed to Home Assistant for template cover control
+button:
   - platform: template
-    name: "${human_devicename}"
-    id: ${device_id}_cover
-    device_class: garage
-    icon: ${icon}
-    lambda: |-
-      if (id(${device_id}_distance).state <= ${door_threshold}) {
-        return COVER_OPEN;
-      }
-      return COVER_CLOSED;
-    open_action:
-      - script.execute: ${device_id}_trigger_door
-    close_action:
+    name: "${human_devicename} Trigger"
+    id: ${device_id}_trigger_button
+    icon: mdi:garage
+    on_press:
       - script.execute: ${device_id}_trigger_door
 
 # Relay for door trigger (internal - controlled via script)
@@ -146,16 +137,13 @@ binary_sensor:
     on_press:
       - script.execute: ${device_id}_trigger_door
 
-  # Door state sensor for chime triggers
+  # Door state from ultrasonic sensor (informational only, not authoritative)
   - platform: template
+    name: "${human_devicename} Door State"
     id: ${device_id}_door_state
-    internal: true
+    device_class: garage_door
     lambda: |-
-      return id(${device_id}_cover).position == COVER_OPEN;
-    on_press:
-      - rtttl.play: 'open:d=16,o=4,b=160:c,g'
-    on_release:
-      - rtttl.play: 'close:d=16,o=4,b=160:g,c'
+      return id(${device_id}_distance).state <= 75;
 
 # Status LED
 status_led:

--- a/esphome/opengarage-left-door.yaml
+++ b/esphome/opengarage-left-door.yaml
@@ -1,10 +1,9 @@
 ---
 substitutions:
-  devicename: left-garage-door
-  device_id: left_garage_door
-  human_devicename: Left Garage Door
+  devicename: opengarage-left-door
+  device_id: opengarage_left_door
+  human_devicename: OpenGarage Left Door
   icon: mdi:garage
-  door_threshold: "75"
 
 packages:
   wifi: !include common/wifi.yaml

--- a/esphome/opengarage-right-door.yaml
+++ b/esphome/opengarage-right-door.yaml
@@ -1,10 +1,9 @@
 ---
 substitutions:
-  devicename: right-garage-door
-  device_id: right_garage_door
-  human_devicename: Right Garage Door
+  devicename: opengarage-right-door
+  device_id: opengarage_right_door
+  human_devicename: OpenGarage Right Door
   icon: mdi:garage
-  door_threshold: "75"
 
 packages:
   wifi: !include common/wifi.yaml

--- a/kubernetes/hass/config/configuration.yaml
+++ b/kubernetes/hass/config/configuration.yaml
@@ -154,6 +154,36 @@ climate:
   max_temp: 130
   hot_tolerance: 0
 
+# Garage door covers using Aqara tilt sensors for state, ESPHome buttons for control
+cover:
+- platform: template
+  covers:
+    left_garage_door:
+      device_class: garage
+      friendly_name: Left Garage Door
+      unique_id: left_garage_door_template_cover
+      value_template: "{{ is_state('binary_sensor.left_garage_door_closed', 'off') }}"
+      open_cover:
+        service: button.press
+        target:
+          entity_id: button.opengarage_left_door_opengarage_left_door_trigger
+      close_cover:
+        service: button.press
+        target:
+          entity_id: button.opengarage_left_door_opengarage_left_door_trigger
+    right_garage_door:
+      device_class: garage
+      friendly_name: Right Garage Door
+      unique_id: right_garage_door_template_cover
+      value_template: "{{ is_state('binary_sensor.right_garage_door_closed', 'off') }}"
+      open_cover:
+        service: button.press
+        target:
+          entity_id: button.opengarage_right_door_opengarage_right_door_trigger
+      close_cover:
+        service: button.press
+        target:
+          entity_id: button.opengarage_right_door_opengarage_right_door_trigger
 generic_hygrostat:
 - name: Main Floor
   humidifier: switch.main_floor_humidifiers
@@ -300,6 +330,22 @@ switch:
           hvac_mode: 'off'
 
 template:
+
+# Garage door state from Aqara vibration sensor tilt angle
+# Closed: angle_y ~ -78 to -80 (vertical panel)
+# Open: angle_y ~ -2 to -6 (horizontal panel overhead)
+# Threshold: closed if angle_y between -90 and -65
+- binary_sensor:
+  - name: Left Garage Door Closed
+    unique_id: left_garage_door_closed
+    device_class: garage_door
+    state: >
+      {{ -90 < states('sensor.left_garage_door_vibration_angle_y') | float(-999) < -65 }}
+  - name: Right Garage Door Closed
+    unique_id: right_garage_door_closed
+    device_class: garage_door
+    state: >
+      {{ -90 < states('sensor.right_garage_door_vibration_angle_y') | float(-999) < -65 }}
 
 - sensor:
   - name: Dead ZWave Devices


### PR DESCRIPTION
Replace unreliable ultrasonic distance sensing with Aqara vibration
sensors mounted on garage door panels. The tilt angle (angle_y) reliably
indicates door position: ~-80° when closed (vertical), ~-5° when open
(horizontal overhead).

- ESPHome: remove cover entity, expose trigger button instead
- ESPHome: rename devices to opengarage-left/right-door
- ESPHome: keep ultrasonic sensor for debugging (informational only)
- HA: add template binary sensors interpreting tilt angle as door state
- HA: add template covers using tilt sensors + ESPHome buttons
