### PR TITLE
Add preserveResourcesOnDeletion to ApplicationSet

### DIFF
--- a/kubernetes/argocd/appset.yaml
+++ b/kubernetes/argocd/appset.yaml
@@ -8,6 +8,8 @@ metadata:
 
 spec:
   goTemplate: true
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   generators:
   - git:
       repoURL: https://github.com/claytono/infra.git
@@ -24,8 +26,6 @@ spec:
       name: '{{ regexReplaceAll "^[0-9]+-" (index .path.segments 1) "" }}'
       labels:
         app.kubernetes.io/managed-by: applicationset
-      finalizers:
-      - finalizers.argocd.argoproj.io/resources
     spec:
       project: default
       source:


### PR DESCRIPTION
When an app's git path is removed, ArgoCD's finalizer gets stuck because
it can't generate manifests from a non-existent path. This is a known
bug (argoproj/applicationset#431) with no fix.

Setting preserveResourcesOnDeletion prevents the finalizer from being
added, so apps delete cleanly when their paths are removed. Resources
must be manually deleted before removing the path, which was already
the workflow.
