### PR TITLE
P2V migration: luser physical to VM

### DIFF
--- a/ansible/host_vars/ansible-integration-test.yaml
+++ b/ansible/host_vars/ansible-integration-test.yaml
@@ -7,3 +7,4 @@ resticprofile_enable_scheduling: false
 setup_upgrade_update_grub: false
 hostname_manage_etc_hosts: false
 sshd_config_validation: false
+qemu_guest_agent_enabled: false

--- a/ansible/host_vars/luser.yaml
+++ b/ansible/host_vars/luser.yaml
@@ -5,23 +5,12 @@ restic_host_config:
       exclude:
         - /var/lib/libvirt/images/*
 
-
 manage_network: true
 interfaces_ether_interfaces:
-  - device: enp3s0f0
-    bootproto: manual
-interfaces_bridge_interfaces:
-  - device: br0
-    type: bridge
+  - device: ens18
     bootproto: static
     address: "172.19.74.161"
     netmask: "255.255.255.0"
     gateway: 172.19.74.1
-    mtu: 1500
-    hwaddr: "06:bc:96:51:3a:a1"
-    stp: "off"
-    ports: [enp3s0f0]
-    maxwait: 5
-    fd: 0
     dnsnameservers: 172.19.74.1
     dnssearch: oneill.net

--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -32,7 +32,18 @@
   ansible.builtin.apt:
     name: qemu-guest-agent
     state: present
-  when: ansible_virtualization_role == 'guest'
+  when:
+    - ansible_virtualization_role == 'guest'
+    - qemu_guest_agent_enabled | default(true) | bool
+
+- name: "Ensure qemu-guest-agent is enabled and started"
+  ansible.builtin.service:
+    name: qemu-guest-agent
+    state: started
+    enabled: true
+  when:
+    - ansible_virtualization_role == 'guest'
+    - qemu_guest_agent_enabled | default(true) | bool
 
 - name: "Install smartmontools on non-VM amd64 hosts"
   ansible.builtin.apt:

--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -81,6 +81,12 @@ locals {
       hostname = "k4.oneill.net"
       note     = "Kubernetes worker node (VM)"
     }
+    luser = {
+      mac      = "52:54:72:19:74:61"
+      ip       = "172.19.74.161"
+      hostname = "luser.oneill.net"
+      note     = "General purpose VM"
+    }
     # Other infrastructure
     fs2 = {
       mac      = "b4:96:91:4e:1b:ac"

--- a/opentofu/proxmox.tf
+++ b/opentofu/proxmox.tf
@@ -207,3 +207,54 @@ resource "proxmox_virtual_environment_vm" "k4" {
     ignore_changes = [node_name, started]
   }
 }
+
+resource "proxmox_virtual_environment_vm" "luser" {
+  name      = "luser"
+  node_name = "p9"
+  vm_id     = 161
+
+  started = true
+  on_boot = true
+
+  cpu {
+    cores   = 4
+    sockets = 1
+    type    = "x86-64-v3"
+  }
+
+  memory {
+    dedicated = 16384
+    floating  = 8192
+  }
+
+  agent {
+    enabled = true
+    trim    = true
+  }
+
+  scsi_hardware = "virtio-scsi-single"
+
+  disk {
+    interface    = "scsi0"
+    datastore_id = "local-zfs"
+    size         = 128
+    file_format  = "raw"
+    iothread     = true
+    discard      = "on"
+  }
+
+  network_device {
+    bridge      = "vmbr0"
+    mac_address = "52:54:72:19:74:61"
+    model       = "virtio"
+    queues      = 4
+  }
+
+  operating_system {
+    type = "l26"
+  }
+
+  lifecycle {
+    ignore_changes = [node_name, started]
+  }
+}


### PR DESCRIPTION
- Add luser VM definition in proxmox.tf (p9, 4 cores, 8-16GB balloon, 128GB)
- Add luser DHCP reservation in locals.tf with new VM MAC
- Update luser host_vars for VM network (ens18 instead of bridge)
- Enable qemu-guest-agent service on all VMs in common role