### PR TITLE
Fix Grml ISO mount adding entry to fstab

### DIFF
--- a/ansible/roles/os-install/tasks/grml.yaml
+++ b/ansible/roles/os-install/tasks/grml.yaml
@@ -33,7 +33,7 @@
         src: /tmp/grml.iso
         fstype: iso9660
         opts: loop,ro
-        state: mounted
+        state: ephemeral # Don't add to fstab
 
     - name: Create Grml directory
       ansible.builtin.file:


### PR DESCRIPTION
Use ephemeral mount state to avoid persisting the temporary ISO mount
in fstab, which caused boot failures when the ISO was no longer present.
