### PR TITLE
Add zram swap role for memory pressure relief

### DIFF
--- a/ansible/group_vars/proxmox/zram.yaml
+++ b/ansible/group_vars/proxmox/zram.yaml
@@ -1,0 +1,2 @@
+---
+zram_size: "ram / 4"

--- a/ansible/roles/common/vars/main.yaml
+++ b/ansible/roles/common/vars/main.yaml
@@ -18,5 +18,6 @@ common_packages_to_install:
   - sudo
   - tmux
   - unzip
+  - util-linux
   - vim
   - openssh-client

--- a/ansible/roles/kubeadm/tasks/common.yaml
+++ b/ansible/roles/kubeadm/tasks/common.yaml
@@ -46,22 +46,6 @@
     sysctl_file: /etc/sysctl.d/99-kubernetes.conf
     reload: true
 
-- name: "Check if swap is enabled"
-  ansible.builtin.command: "swapon --show"
-  register: kubeadm_swap_status
-  changed_when: false
-  failed_when: false
-
-- name: "Turn off swap"
-  ansible.builtin.command: "swapoff -a"
-  when: kubeadm_swap_status.stdout != ""
-
-- name: "Disable swap in fstab"
-  ansible.builtin.replace:
-    path: /etc/fstab
-    regexp: "^([^#].*?\\sswap\\s+sw\\s+.*)$"
-    replace: "# \\1"
-
 - name: "Install apt-transport-https"
   ansible.builtin.apt:
     name: apt-transport-https

--- a/ansible/roles/zram/defaults/main.yaml
+++ b/ansible/roles/zram/defaults/main.yaml
@@ -1,0 +1,4 @@
+---
+zram_size: "ram / 2"
+zram_algorithm: "lz4"
+zram_page_cluster: 0

--- a/ansible/roles/zram/handlers/main.yaml
+++ b/ansible/roles/zram/handlers/main.yaml
@@ -1,0 +1,16 @@
+---
+- name: Restart systemd-zram-setup
+  ansible.builtin.systemd:
+    daemon_reload: true
+  notify: Setup zram0
+
+- name: Setup zram0
+  ansible.builtin.systemd:
+    name: systemd-zram-setup@zram0.service
+    state: restarted
+  notify: Activate zram0 swap
+
+- name: Activate zram0 swap
+  ansible.builtin.systemd:
+    name: dev-zram0.swap
+    state: started

--- a/ansible/roles/zram/tasks/main.yaml
+++ b/ansible/roles/zram/tasks/main.yaml
@@ -1,0 +1,24 @@
+---
+# systemd-zram-generator is only available in Debian 12+
+- name: Configure zram swap
+  when: ansible_distribution_major_version | int >= 12
+  block:
+    - name: Install systemd-zram-generator
+      ansible.builtin.apt:
+        name: systemd-zram-generator
+        state: present
+
+    - name: Configure zram-generator
+      ansible.builtin.template:
+        src: zram-generator.conf.j2
+        dest: /etc/systemd/zram-generator.conf
+        mode: "0644"
+      notify: Restart systemd-zram-setup
+
+    - name: Configure page-cluster for zram
+      ansible.posix.sysctl:
+        name: vm.page-cluster
+        value: "{{ zram_page_cluster }}"
+        state: present
+        sysctl_file: /etc/sysctl.d/99-zram.conf
+        reload: true

--- a/ansible/roles/zram/templates/zram-generator.conf.j2
+++ b/ansible/roles/zram/templates/zram-generator.conf.j2
@@ -1,0 +1,3 @@
+[zram0]
+zram-size = {{ zram_size }}
+compression-algorithm = {{ zram_algorithm }}

--- a/ansible/site.yaml
+++ b/ansible/site.yaml
@@ -111,6 +111,12 @@
     - role: boutetnico.fail2ban
       tags: fail2ban
 
+- name: ZRAM swap
+  hosts: all
+  roles:
+    - role: zram
+      tags: zram
+
 - name: Chrony, relaymail, and resticprofile
   hosts: all
   roles:


### PR DESCRIPTION
- New zram role using systemd-zram-generator (Debian 12+)
- Defaults: ram/2 size, LZ4 compression, page-cluster=0
- Proxmox hosts use ram/4 to leave room for ZFS ARC
- Remove swap disabling from kubeadm role (k8s 1.30+ supports NoSwap mode)
- Add util-linux to common packages for zramctl
