### PR TITLE
Enable memory ballooning on Kubernetes VMs

### DIFF
--- a/opentofu/proxmox.tf
+++ b/opentofu/proxmox.tf
@@ -23,7 +23,8 @@ resource "proxmox_virtual_environment_vm" "k1" {
   }
 
   memory {
-    dedicated = 4096
+    dedicated = 8192
+    floating  = 4096
   }
 
   agent {
@@ -73,7 +74,8 @@ resource "proxmox_virtual_environment_vm" "k2" {
   }
 
   memory {
-    dedicated = 20480
+    dedicated = 24576
+    floating  = 12288
   }
 
   agent {
@@ -123,7 +125,8 @@ resource "proxmox_virtual_environment_vm" "k3" {
   }
 
   memory {
-    dedicated = 20480
+    dedicated = 24576
+    floating  = 12288
   }
 
   agent {
@@ -173,7 +176,8 @@ resource "proxmox_virtual_environment_vm" "k4" {
   }
 
   memory {
-    dedicated = 20480
+    dedicated = 24576
+    floating  = 12288
   }
 
   agent {


### PR DESCRIPTION
Increase VM memory allocations and enable ballooning to allow VMs to
shrink when the Proxmox host needs memory:
- k1: 8GB dedicated / 4GB floating (control plane)
- k2, k3, k4: 24GB dedicated / 12GB floating (workers)

This works with zram swap in the VMs to handle memory pressure without
OOM kills during backup jobs.
