### PR TITLE
Fix proxmox group_vars directory/file conflict

### DIFF
--- a/ansible/group_vars/proxmox.yaml
+++ b/ansible/group_vars/proxmox.yaml
@@ -56,3 +56,6 @@ proxmox_nfs_storage:
 # OIDC credentials from 1Password (for Authentik integration)
 proxmox_oidc_client_id: "{{ lookup('community.general.onepassword', 'proxmox-oidc', field='client-id', vault='infra') }}"
 proxmox_oidc_client_secret: "{{ lookup('community.general.onepassword', 'proxmox-oidc', field='client-secret', vault='infra') }}"
+
+# ZRAM swap configuration (smaller for Proxmox to leave room for ZFS ARC)
+zram_size: "ram / 4"

--- a/ansible/group_vars/proxmox/zram.yaml
+++ b/ansible/group_vars/proxmox/zram.yaml
@@ -1,2 +1,0 @@
----
-zram_size: "ram / 4"


### PR DESCRIPTION
Ansible ignores group_vars/proxmox.yaml when group_vars/proxmox/
directory exists. Move zram_size into the main file and remove the
directory.
