### PR TITLE
Add p1 Proxmox host with configurable ZFS raid level

### DIFF
--- a/ansible/host_vars/p1.yaml
+++ b/ansible/host_vars/p1.yaml
@@ -1,0 +1,30 @@
+---
+# Auto-installer configuration
+proxmox_install_mac: "90:e2:ba:d8:2a:8c"
+proxmox_install_nic: "enp3s0f0"
+proxmox_zfs_raid: "raid1"
+
+# Enable network management for this host
+proxmox_manage_network: true
+
+# Physical interfaces (Proxmox 9.1+ naming)
+proxmox_interfaces:
+  - name: nic0
+    type: manual
+    comment: "1G onboard - unused"
+  - name: nic1
+    type: manual
+    comment: "10G port 1"
+  - name: nic2
+    type: manual
+    comment: "10G port 2 - unused"
+
+# Bridges
+proxmox_bridges:
+  - name: vmbr0
+    address: "172.19.74.41/24"
+    gateway: "172.19.74.1"
+    bridge_ports: nic1
+    bridge_stp: "off"
+    bridge_fd: "0"
+    comment: "Primary VM bridge on 10G"

--- a/ansible/inventory/default
+++ b/ansible/inventory/default
@@ -11,6 +11,7 @@ p3 ansible_host=p3.oneill.net domain=oneill.net
 #gasherbrum-display ansible_host=gasherbrum-display.oneill.net domain=oneill.net
 zwavejs ansible_host=zwavejs.oneill.net domain=oneill.net
 infra1 ansible_host=infra1.oneill.net domain=oneill.net
+p1 ansible_host=p1.oneill.net domain=oneill.net
 p2 ansible_host=p2.oneill.net domain=oneill.net
 p4 ansible_host=p4.oneill.net domain=oneill.net
 p9 ansible_host=p9.oneill.net domain=oneill.net
@@ -49,6 +50,7 @@ zwavejs
 #gasherbrum-display
 
 [proxmox]
+p1
 p2
 p3
 p4

--- a/ansible/roles/os-install/templates/proxmox-answer.toml.j2
+++ b/ansible/roles/os-install/templates/proxmox-answer.toml.j2
@@ -23,7 +23,7 @@ enabled = true
 
 [disk-setup]
 filesystem = "zfs"
-zfs.raid = "raid0"
+zfs.raid = "{{ hostvars[host]['proxmox_zfs_raid'] | default('raid0') }}"
 
 [disk-setup.filter]
 ID_BUS = "ata"

--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -13,6 +13,12 @@
 locals {
   infrastructure_hosts = {
     # Proxmox VE hosts
+    p1 = {
+      mac      = "90:e2:ba:d8:2a:8c"
+      ip       = "172.19.74.41"
+      hostname = "p1.oneill.net"
+      note     = "Proxmox VE host"
+    }
     p2 = {
       mac      = "b4:96:91:4b:34:58"
       ip       = "172.19.74.42"


### PR DESCRIPTION
- Add p1 to inventory and OpenTofu (DHCP/DNS)
- New host_vars/p1.yaml with ZFS raid1 mirror config
- Make proxmox-answer.toml.j2 ZFS raid level configurable via
  proxmox_zfs_raid variable (defaults to raid0)

p1 repurposes the old luser physical hardware with two 512GB SSDs
in a mirror configuration.
