### PR TITLE
Add RPi image customization and integration test

### DIFF
--- a/.github/workflows/rpi-image-test.yaml
+++ b/.github/workflows/rpi-image-test.yaml
@@ -1,0 +1,34 @@
+---
+name: RPi Image Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  rpi-image-test:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
+
+      - name: Check for relevant changes
+        if: github.event_name != 'workflow_dispatch'
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3
+        id: filter
+        with:
+          filters: |
+            rpi:
+              - 'scripts/rpi-image-customize'
+              - 'scripts/rpi-image-test'
+              - 'ansible/roles/os-install/files/post-install.sh'
+              - 'tests/rpi/**'
+              - '.github/workflows/rpi-image-test.yaml'
+
+      - name: Run RPi integration test
+        if: github.event_name == 'workflow_dispatch' || steps.filter.outputs.rpi == 'true'
+        run: ./scripts/rpi-image-test

--- a/.renovaterc
+++ b/.renovaterc
@@ -102,6 +102,19 @@
       "depNameTemplate": "grml/grml",
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "regex:^(?<major>\\d{4})\\.(?<minor>\\d{2})$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "scripts/rpi-image-customize"
+      ],
+      "matchStrings": [
+        "RELEASE=\"(?<release>[^\"\\n]+)\"\\s*\\nIMAGE_DATE=\"(?<currentValue>\\d{4}-\\d{2}-\\d{2})\""
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "RPi-Distro/pi-gen",
+      "versioningTemplate": "regex:^(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})$",
+      "extractVersion": "^(?<version>\\d{4}-\\d{2}-\\d{2})-raspios-(?<release>[^-]+)-arm64$"
     }
   ],
   "packageRules": [

--- a/scripts/rpi-image-customize
+++ b/scripts/rpi-image-customize
@@ -1,0 +1,404 @@
+#!/bin/bash
+# Customize a Raspberry Pi OS image for homelab use
+# Downloads image if needed, mounts it, configures cloud-init for first boot
+#
+# Usage:
+#   ./scripts/rpi-image-customize --hostname <name> [--wifi] [--use-test-data] [--output PATH]
+#
+# Examples:
+#   ./scripts/rpi-image-customize --hostname zwavejs
+#   ./scripts/rpi-image-customize --hostname garage-sensor --wifi
+#   ./scripts/rpi-image-customize --hostname test-rpi --use-test-data --output /tmp/test.img
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+POST_INSTALL="$REPO_ROOT/ansible/roles/os-install/files/post-install.sh"
+
+# Image configuration
+RELEASE="trixie"
+IMAGE_DATE="2025-12-04"
+IMAGE_BASE_URL="https://downloads.raspberrypi.com/raspios_lite_arm64/images"
+IMAGE_DIR="/tmp/rpi-images"
+IMAGE_FILENAME="${IMAGE_DATE}-raspios-${RELEASE}-arm64-lite.img"
+IMAGE_XZ_FILENAME="${IMAGE_FILENAME}.xz"
+IMAGE_URL="${IMAGE_BASE_URL}/raspios_lite_arm64-${IMAGE_DATE}/${IMAGE_XZ_FILENAME}"
+IMAGE_XZ="$IMAGE_DIR/$IMAGE_XZ_FILENAME"
+IMAGE="$IMAGE_DIR/$IMAGE_FILENAME"
+
+# 1Password paths
+OP_WIFI_SSID="op://infra/wifi/network name"
+OP_WIFI_PSK="op://infra/wifi/wireless network password"
+
+# Test mode password hash (openssl passwd -6 -salt testsalt testpassword)
+TEST_ROOT_PW_HASH='$6$testsalt$mGsoypwuoRHmmi31D2IfpZdmzbF5mX0yMhb/xSVguNcCI2EkoGrxfImuLJzvurLwR3UIRGHEBAUgqW6nuriIY0'
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") --hostname <name> [--wifi] [--serial] [--use-test-data] [--output PATH]
+
+Arguments:
+    --hostname NAME   Hostname for the Pi (required)
+    --wifi            Configure for WiFi (pulls credentials from 1Password)
+    --serial          Enable serial console on GPIO 14/15 (disables Bluetooth)
+    --use-test-data   Use test credentials (no 1Password required, ethernet only)
+    --output PATH     Write customized image to PATH instead of modifying in place
+
+The script automatically downloads Raspberry Pi OS Lite ($RELEASE) if not cached.
+
+Examples:
+    $(basename "$0") --hostname zwavejs
+    $(basename "$0") --hostname garage-sensor --wifi
+    $(basename "$0") --hostname garage-sensor --wifi --serial
+    $(basename "$0") --hostname test-rpi --use-test-data --output /tmp/test.img
+EOF
+    exit 1
+}
+
+cleanup() {
+    if [[ -n "${MOUNT_POINT:-}" ]]; then
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            if [[ -n "${ATTACHED_DISK:-}" ]]; then
+                echo "Detaching $ATTACHED_DISK..."
+                hdiutil detach "$ATTACHED_DISK" -force 2>/dev/null || true
+            fi
+        else
+            if mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
+                echo "Unmounting $MOUNT_POINT..."
+                sudo umount "$MOUNT_POINT" 2>/dev/null || true
+            fi
+            if [[ -n "${LOOP_DEV:-}" ]]; then
+                sudo losetup -d "$LOOP_DEV" 2>/dev/null || true
+            fi
+        fi
+        rmdir "$MOUNT_POINT" 2>/dev/null || true
+    fi
+}
+
+trap cleanup EXIT
+
+# Helper to write files - uses sudo on Linux where mount requires root
+write_boot_file() {
+    local dest="$1"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        cat > "$dest"
+    else
+        sudo tee "$dest" > /dev/null
+    fi
+}
+
+# Helper to copy files to boot partition
+copy_boot_file() {
+    local src="$1"
+    local dest="$2"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        cp "$src" "$dest"
+        chmod +x "$dest"
+    else
+        sudo cp "$src" "$dest"
+        sudo chmod +x "$dest"
+    fi
+}
+
+# Helper to append to files on boot partition
+append_boot_file() {
+    local dest="$1"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        cat >> "$dest"
+    else
+        sudo tee -a "$dest" > /dev/null
+    fi
+}
+
+unmount_existing() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        for disk in $(hdiutil info 2>/dev/null | grep -B20 "bootfs\|raspios" | grep "/dev/disk" | awk '{print $1}' | sort -u); do
+            echo "Found existing mount from Pi image: $disk, detaching..."
+            hdiutil detach "$disk" -force 2>/dev/null || true
+        done
+    else
+        for loop in $(losetup -j "$IMAGE" 2>/dev/null | cut -d: -f1); do
+            echo "Found existing loop device: $loop, cleaning up..."
+            sudo umount "${loop}p1" 2>/dev/null || true
+            sudo losetup -d "$loop" 2>/dev/null || true
+        done
+    fi
+}
+
+download_image() {
+    mkdir -p "$IMAGE_DIR"
+
+    if [[ -f "$IMAGE" ]]; then
+        echo "Using cached image: $IMAGE"
+        return
+    fi
+
+    if [[ -f "$IMAGE_XZ" ]]; then
+        echo "Decompressing cached $IMAGE_XZ..."
+    else
+        echo "Downloading Raspberry Pi OS Lite ($RELEASE)..."
+        curl -L -o "$IMAGE_XZ" "$IMAGE_URL"
+    fi
+
+    echo "Decompressing image..."
+    xz -dk "$IMAGE_XZ"
+    echo "Image ready: $IMAGE"
+}
+
+mount_boot_partition() {
+    MOUNT_POINT=$(mktemp -d)
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "Attaching image..."
+        ATTACH_OUTPUT=$(hdiutil attach "$IMAGE" -nomount 2>&1)
+        ATTACHED_DISK=$(echo "$ATTACH_OUTPUT" | grep -E "^/dev/disk[0-9]+" | head -1 | awk '{print $1}')
+
+        if [[ -z "$ATTACHED_DISK" ]]; then
+            echo "Error: Could not attach image" >&2
+            echo "$ATTACH_OUTPUT" >&2
+            exit 1
+        fi
+
+        BOOT_PART="${ATTACHED_DISK}s1"
+        echo "Mounting boot partition $BOOT_PART..."
+        mount -t msdos "$BOOT_PART" "$MOUNT_POINT"
+    else
+        LOOP_DEV=$(sudo losetup --find --show --partscan "$IMAGE")
+        BOOT_PART="${LOOP_DEV}p1"
+
+        # Wait for partition device to appear (udev may take a moment)
+        for i in {1..10}; do
+            [[ -b "$BOOT_PART" ]] && break
+            sleep 0.5
+        done
+
+        if [[ ! -b "$BOOT_PART" ]]; then
+            echo "Error: Boot partition not found at $BOOT_PART" >&2
+            exit 1
+        fi
+
+        sudo mount "$BOOT_PART" "$MOUNT_POINT"
+    fi
+
+    echo "Boot partition mounted at $MOUNT_POINT"
+}
+
+# Parse arguments
+HOSTNAME=""
+NETWORK="ethernet"
+SERIAL="false"
+TEST_MODE="false"
+OUTPUT_PATH=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --hostname)
+            HOSTNAME="$2"
+            shift 2
+            ;;
+        --wifi)
+            NETWORK="wifi"
+            shift
+            ;;
+        --serial)
+            SERIAL="true"
+            shift
+            ;;
+        --use-test-data)
+            TEST_MODE="true"
+            shift
+            ;;
+        --output)
+            OUTPUT_PATH="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+# Test mode forces ethernet (no WiFi credentials available)
+if [[ "$TEST_MODE" == "true" ]] && [[ "$NETWORK" == "wifi" ]]; then
+    echo "Warning: --use-test-data forces ethernet-only (ignoring --wifi)" >&2
+    NETWORK="ethernet"
+fi
+
+if [[ -z "$HOSTNAME" ]]; then
+    echo "Error: --hostname required" >&2
+    usage
+fi
+
+if [[ ! -f "$POST_INSTALL" ]]; then
+    echo "Error: post-install.sh not found at $POST_INSTALL" >&2
+    exit 1
+fi
+
+echo "=== Raspberry Pi Image Customization ==="
+echo "Hostname: $HOSTNAME"
+echo "Network: $NETWORK"
+if [[ "$TEST_MODE" == "true" ]]; then
+    echo "Mode: TEST (mocked credentials)"
+fi
+echo ""
+
+unmount_existing
+download_image
+
+# If output path specified, copy image there first
+if [[ -n "$OUTPUT_PATH" ]]; then
+    echo "Copying image to $OUTPUT_PATH..."
+    cp "$IMAGE" "$OUTPUT_PATH"
+    IMAGE="$OUTPUT_PATH"
+fi
+
+mount_boot_partition
+
+# Create cloud-init user-data (format matches rpi-imager)
+if [[ "$TEST_MODE" == "true" ]]; then
+    ROOT_PW_HASH="$TEST_ROOT_PW_HASH"
+    # Find SSH public key for test mode
+    SSH_PUBKEY=""
+    for key in ~/.ssh/id_ed25519.pub ~/.ssh/id_rsa.pub; do
+        if [[ -f "$key" ]]; then
+            SSH_PUBKEY=$(cat "$key")
+            break
+        fi
+    done
+    if [[ -z "$SSH_PUBKEY" ]]; then
+        echo "Error: No SSH public key found in ~/.ssh/ (required for --use-test-data)" >&2
+        exit 1
+    fi
+else
+    ROOT_PW_HASH=$(op read "op://infra/ansible-root-password/hashed-sha512")
+    SSH_PUBKEY=$(op read "op://infra/ansible-ssh-key/public key")
+fi
+SSH_PUBKEY_ESCAPED=${SSH_PUBKEY//\'/\'\"\'\"\'}
+
+EXTRA_RUNCMD=""
+if [[ "$TEST_MODE" == "true" ]]; then
+    # Ensure test key remains after post-install overwrites authorized_keys
+    EXTRA_RUNCMD=$(cat <<EOF
+  - /bin/sh -c "mkdir -p /root/.ssh && echo '${SSH_PUBKEY_ESCAPED}' >> /root/.ssh/authorized_keys && chmod 700 /root/.ssh && chmod 600 /root/.ssh/authorized_keys"
+  - /bin/sh -c "mkdir -p /home/ansible/.ssh && echo '${SSH_PUBKEY_ESCAPED}' >> /home/ansible/.ssh/authorized_keys && chown -R ansible:ansible /home/ansible/.ssh && chmod 700 /home/ansible/.ssh && chmod 600 /home/ansible/.ssh/authorized_keys"
+EOF
+)
+fi
+
+write_boot_file "$MOUNT_POINT/user-data" <<EOF
+#cloud-config
+manage_resolv_conf: false
+
+hostname: $HOSTNAME
+manage_etc_hosts: true
+
+apt:
+  preserve_sources_list: true
+
+users:
+- name: root
+  lock_passwd: false
+  passwd: "${ROOT_PW_HASH}"
+  ssh_authorized_keys:
+    - "${SSH_PUBKEY}"
+
+enable_ssh: true
+ssh_pwauth: false
+
+runcmd:
+  - /boot/firmware/post-install.sh
+  - rm -f /boot/firmware/post-install.sh
+${EXTRA_RUNCMD}
+  - touch /run/cloud-init-complete
+EOF
+echo "Created user-data"
+
+# Create cloud-init meta-data
+write_boot_file "$MOUNT_POINT/meta-data" <<EOF
+instance-id: $HOSTNAME
+EOF
+echo "Created meta-data"
+
+# Configure network via cloud-init network-config (netplan format)
+# Format matches rpi-imager: always include ethernets, dhcp4+dhcp6, optional: true
+if [[ "$NETWORK" == "wifi" ]]; then
+    echo "Fetching WiFi credentials from 1Password..."
+    WIFI_SSID=$(op read "$OP_WIFI_SSID")
+    WIFI_PSK=$(op read "$OP_WIFI_PSK")
+
+    # Hash password using PBKDF2-SHA1, 4096 iterations (WPA2 PSK format, same as rpi-imager)
+    WIFI_PSK_HASH=$(python3 -c "import hashlib; print(hashlib.pbkdf2_hmac('sha1', '$WIFI_PSK'.encode(), '$WIFI_SSID'.encode(), 4096, 32).hex())")
+
+    write_boot_file "$MOUNT_POINT/network-config" <<EOF
+network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp4: true
+      dhcp6: true
+      optional: true
+  wifis:
+    wlan0:
+      dhcp4: true
+      dhcp6: true
+      regulatory-domain: "US"
+      access-points:
+        "${WIFI_SSID}":
+          password: "${WIFI_PSK_HASH}"
+      optional: true
+EOF
+    echo "Created network-config for WiFi (SSID: $WIFI_SSID)"
+else
+    write_boot_file "$MOUNT_POINT/network-config" <<EOF
+network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp4: true
+      dhcp6: true
+      optional: true
+EOF
+    echo "Created network-config for ethernet"
+fi
+
+# Set WiFi regulatory domain in kernel cmdline (required for first-boot WiFi)
+# Append to end of line (cmdline.txt is a single line)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    CMDLINE=$(cat "${MOUNT_POINT}/cmdline.txt")
+else
+    CMDLINE=$(sudo cat "${MOUNT_POINT}/cmdline.txt")
+fi
+echo "${CMDLINE} cfg80211.ieee80211_regdom=US" | write_boot_file "${MOUNT_POINT}/cmdline.txt"
+echo "Added WiFi regulatory domain to cmdline.txt"
+
+# Copy post-install script
+copy_boot_file "$POST_INSTALL" "$MOUNT_POINT/post-install.sh"
+echo "Copied post-install.sh"
+
+# Enable serial console for debugging via FTDI cable (optional)
+if [[ "$SERIAL" == "true" ]]; then
+    # disable-bt gives us PL011 (better UART) on GPIO 14/15 instead of mini UART
+    # This disables Bluetooth but provides reliable serial at any CPU frequency
+    append_boot_file "$MOUNT_POINT/config.txt" <<EOF
+
+# Enable serial console (PL011 UART on GPIO 14/15)
+enable_uart=1
+dtoverlay=disable-bt
+EOF
+    echo "Enabled serial console (UART on GPIO 14/15, Bluetooth disabled)"
+fi
+
+echo ""
+echo "=== Customization complete ==="
+echo ""
+echo "Image ready: $IMAGE"
+echo ""
+echo "Flash to SD card:"
+echo "  diskutil list                           # Find SD card"
+echo "  diskutil unmountDisk /dev/diskN"
+echo "  sudo dd if=$IMAGE of=/dev/rdiskN bs=4m status=progress"

--- a/scripts/rpi-image-test
+++ b/scripts/rpi-image-test
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Integration test for rpi-image-customize
+# Downloads image, customizes with --use-test-data mode, boots in QEMU, runs verification
+#
+# Usage: ./scripts/rpi-image-test
+#
+# Requires: Docker (for QEMU emulation)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST_DIR="$REPO_ROOT/tests/rpi"
+TEST_HOSTNAME="test-rpi"
+TEST_IMAGE="/tmp/rpi-test/test.img"
+
+cleanup() {
+    echo ""
+    echo "=== Cleanup ==="
+    cd "$TEST_DIR"
+    docker compose down 2>/dev/null || true
+    rm -rf /tmp/rpi-test
+}
+trap cleanup EXIT
+
+echo "=== RPi Image Integration Test ==="
+echo ""
+
+# Create temp directory for test image
+mkdir -p /tmp/rpi-test
+
+# Ensure SSH key exists (GitHub runners may not have one)
+if [[ ! -f ~/.ssh/id_ed25519.pub ]] && [[ ! -f ~/.ssh/id_rsa.pub ]]; then
+    echo "No SSH key found, generating one..."
+    mkdir -p ~/.ssh
+    ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N "" -C "rpi-test" -q
+fi
+
+# Step 1: Customize image with test credentials
+echo "=== Step 1: Customizing image ==="
+"$SCRIPT_DIR/rpi-image-customize" --hostname "$TEST_HOSTNAME" --use-test-data --output "$TEST_IMAGE"
+echo ""
+
+# Step 2: Boot in QEMU via Docker Compose
+echo "=== Step 2: Starting QEMU VM ==="
+cd "$TEST_DIR"
+export RPI_IMAGE="$TEST_IMAGE"
+
+# Build the image first
+docker compose build
+
+# Start container in background and stream logs
+docker compose up -d
+docker compose logs -f &
+LOGS_PID=$!
+
+# Wait for cloud-init to complete (indicated by /run/cloud-init-complete file)
+echo "Waiting for VM to boot and cloud-init to complete (this takes ~8 minutes)..."
+MAX_WAIT=900  # 15 minutes
+WAITED=0
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -p 2222"
+
+while ! ssh $SSH_OPTS root@localhost 'test -f /run/cloud-init-complete' 2>&1; do
+    if ! docker compose ps --format json | jq -e 'select(.State == "running")' >/dev/null 2>&1; then
+        kill $LOGS_PID 2>/dev/null || true
+        echo "ERROR: Container stopped unexpectedly"
+        exit 1
+    fi
+    if [[ $WAITED -ge $MAX_WAIT ]]; then
+        kill $LOGS_PID 2>/dev/null || true
+        echo "ERROR: Timeout waiting for cloud-init to complete"
+        exit 1
+    fi
+    sleep 15
+    WAITED=$((WAITED + 15))
+done
+
+# Stop streaming logs
+kill $LOGS_PID 2>/dev/null || true
+wait $LOGS_PID 2>/dev/null || true
+
+echo ""
+echo "Cloud-init complete, VM is ready!"
+echo ""
+
+# Step 3: Run verification tests
+echo "=== Step 3: Running verification tests ==="
+"$TEST_DIR/verify.sh" localhost 2222
+
+echo ""
+echo "=== All tests passed! ==="

--- a/tests/rpi/Dockerfile
+++ b/tests/rpi/Dockerfile
@@ -1,0 +1,19 @@
+# QEMU Raspberry Pi 3B emulator for testing RPi OS images
+FROM debian:trixie-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    qemu-system-arm \
+    qemu-utils \
+    e2fsprogs \
+    kpartx \
+    dosfstools \
+    openssh-client \
+    netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /work
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tests/rpi/docker-compose.yaml
+++ b/tests/rpi/docker-compose.yaml
@@ -1,0 +1,10 @@
+services:
+  rpi-vm:
+    build: .
+    privileged: true  # Required for losetup
+    environment:
+      - IMAGE=/images/rpi.img
+    volumes:
+      - ${RPI_IMAGE}:/images/rpi.img:ro
+    ports:
+      - "2222:22"

--- a/tests/rpi/entrypoint.sh
+++ b/tests/rpi/entrypoint.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Entrypoint for RPi QEMU test container
+# Expects a customized image from rpi-image-customize, handles QEMU-specific prep and boot
+
+set -euo pipefail
+
+IMAGE="${IMAGE:-/images/rpi.img}"
+
+if [[ ! -f "$IMAGE" ]]; then
+    echo "Error: Image not found: $IMAGE" >&2
+    exit 1
+fi
+
+echo "=== Preparing RPi image for QEMU ==="
+
+# Create working copy
+cp "$IMAGE" /work/disk.img
+qemu-img resize /work/disk.img 4G 2>/dev/null
+
+# Set up loop device with kpartx for partition access
+LOOP_DEV=$(losetup --find --show /work/disk.img)
+kpartx -av "$LOOP_DEV"
+
+# Wait for mapper devices to appear
+LOOP_NAME=$(basename "$LOOP_DEV")
+BOOT_PART="/dev/mapper/${LOOP_NAME}p1"
+for i in {1..10}; do
+    [[ -b "$BOOT_PART" ]] && break
+    sleep 0.5
+done
+
+ROOT_PART="/dev/mapper/${LOOP_NAME}p2"
+
+cleanup() {
+    kpartx -d "$LOOP_DEV" 2>/dev/null || true
+    losetup -d "$LOOP_DEV" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Mount boot partition and extract kernel/DTB
+mkdir -p /work/boot
+mount -t vfat "$BOOT_PART" /work/boot
+cp /work/boot/kernel8.img /work/kernel8.img
+cp /work/boot/bcm2710-rpi-3-b-plus.dtb /work/bcm2710-rpi-3-b-plus.dtb
+umount /work/boot
+
+# Disable systemd watchdog (causes boot loops in QEMU)
+echo "Disabling systemd watchdog..."
+debugfs -R "dump /etc/systemd/system.conf /work/system.conf" "$ROOT_PART" 2>/dev/null
+sed -i 's/^#*WatchdogDevice=.*/WatchdogDevice=\/dev\/watchdog666/' /work/system.conf
+grep -q "^WatchdogDevice=" /work/system.conf || echo "WatchdogDevice=/dev/watchdog666" >> /work/system.conf
+debugfs -w -R "rm /etc/systemd/system.conf" "$ROOT_PART" 2>/dev/null
+debugfs -w -R "write /work/system.conf /etc/systemd/system.conf" "$ROOT_PART" 2>/dev/null
+
+# Detach loop device before QEMU
+kpartx -d "$LOOP_DEV"
+losetup -d "$LOOP_DEV"
+trap - EXIT
+
+echo "=== Starting QEMU ==="
+
+# Monitor for cloud-init completion in background
+# Create signal file when cloud-init.target is reached
+monitor_boot() {
+    while read -r line; do
+        echo "$line"
+        if [[ "$line" == *"cloud-init.target"* ]]; then
+            touch /work/cloud-init-done
+        fi
+    done
+}
+
+# Run QEMU with SSH on port 22 (mapped by docker-compose)
+# raspi3b machine uses USB networking via SMSC LAN9514
+# dwc_otg params are required for USB networking to work
+qemu-system-aarch64 \
+    -machine raspi3b \
+    -cpu cortex-a72 \
+    -m 1G \
+    -kernel /work/kernel8.img \
+    -dtb /work/bcm2710-rpi-3-b-plus.dtb \
+    -drive format=raw,file=/work/disk.img,if=sd \
+    -append "rw console=ttyAMA1,115200 root=/dev/mmcblk0p2 rootdelay=1 dwc_otg.lpm_enable=0 dwc_otg.fiq_fsm_enable=0" \
+    -device usb-net,netdev=net0 \
+    -netdev user,id=net0,hostfwd=tcp::22-:22 \
+    -nographic \
+    -no-reboot 2>&1 | monitor_boot

--- a/tests/rpi/verify.sh
+++ b/tests/rpi/verify.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Verify RPi image configuration via SSH
+# Tests cloud-init, networking, and post-install.sh results
+#
+# Usage: ./verify.sh [host] [port]
+#   host: SSH host (default: localhost)
+#   port: SSH port (default: 2222)
+set -euo pipefail
+
+SSH_HOST="${1:-localhost}"
+SSH_PORT="${2:-2222}"
+SSH_USER="root"
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -p $SSH_PORT"
+
+ssh_cmd() {
+    ssh $SSH_OPTS "$SSH_USER@$SSH_HOST" "$@"
+}
+
+echo "=== Verifying RPi configuration ==="
+echo "Host: $SSH_HOST:$SSH_PORT"
+echo ""
+FAILED=0
+
+# Test 1: SSH connectivity
+if ssh_cmd 'exit 0' 2>/dev/null; then
+    echo "PASS: SSH connectivity"
+else
+    echo "FAIL: SSH connectivity"
+    exit 1
+fi
+
+# Test 2: cloud-init completed successfully
+CLOUD_STATUS=$(ssh_cmd 'cloud-init status' 2>/dev/null || echo "unknown")
+if echo "$CLOUD_STATUS" | grep -q 'done'; then
+    echo "PASS: cloud-init completed"
+else
+    echo "FAIL: cloud-init status: $CLOUD_STATUS"
+    FAILED=1
+fi
+
+# Test 3: Hostname set correctly (should match what rpi-image-customize set)
+ACTUAL_HOSTNAME=$(ssh_cmd 'hostname' 2>/dev/null)
+if [[ -n "$ACTUAL_HOSTNAME" ]]; then
+    echo "PASS: Hostname is '$ACTUAL_HOSTNAME'"
+else
+    echo "FAIL: Hostname not set"
+    FAILED=1
+fi
+
+# Test 4: Network connectivity (QEMU uses usb0, real Pi uses eth0)
+if ssh_cmd 'ip -4 addr show scope global' 2>/dev/null | grep -qE 'inet [0-9]+\.[0-9]+'; then
+    echo "PASS: Network interface has IP address"
+else
+    echo "FAIL: No network interface with IP address"
+    FAILED=1
+fi
+
+# Test 5: WiFi regulatory domain in boot cmdline.txt
+# Note: /proc/cmdline is QEMU's cmdline, not the image's. Check the file directly.
+if ssh_cmd 'cat /boot/firmware/cmdline.txt' 2>/dev/null | grep -q 'cfg80211.ieee80211_regdom=US'; then
+    echo "PASS: WiFi regulatory domain set in cmdline.txt"
+else
+    echo "FAIL: WiFi regulatory domain not in cmdline.txt"
+    FAILED=1
+fi
+
+# Test 6: post-install.sh created ansible user
+if ssh_cmd 'id ansible' &>/dev/null; then
+    echo "PASS: ansible user exists (post-install.sh ran)"
+else
+    echo "FAIL: ansible user does not exist"
+    FAILED=1
+fi
+
+# Test 7: SSH key installed for ansible
+if ssh_cmd 'test -s /home/ansible/.ssh/authorized_keys' 2>/dev/null; then
+    echo "PASS: SSH key installed for ansible"
+else
+    echo "FAIL: No SSH keys in ansible authorized_keys"
+    FAILED=1
+fi
+
+# Test 8: Passwordless sudo for ansible
+if ssh_cmd 'su - ansible -c "sudo -n true"' 2>/dev/null; then
+    echo "PASS: Passwordless sudo configured"
+else
+    echo "FAIL: Passwordless sudo not working"
+    FAILED=1
+fi
+
+if [[ $FAILED -eq 0 ]]; then
+    echo ""
+    echo "All tests passed!"
+    exit 0
+else
+    echo ""
+    echo "Some tests failed!"
+    exit 1
+fi


### PR DESCRIPTION
- rpi-image-customize: Downloads RPi OS, configures cloud-init for
  hostname, networking, and post-install setup. Supports --use-test-data
  for CI without 1Password credentials.
- rpi-image-test: Boots customized image in QEMU via Docker, validates
  cloud-init completed, hostname set, network configured, ansible user
  created with SSH key and sudo.
- GitHub Actions workflow with paths-filter for required check support.
