### PR TITLE
rpi image tag literal

### DIFF
--- a/scripts/rpi-image-customize
+++ b/scripts/rpi-image-customize
@@ -17,7 +17,6 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 POST_INSTALL="$REPO_ROOT/ansible/roles/os-install/files/post-install.sh"
 
 # Image configuration
-# renovate: datasource=github-tags depName=RPi-Distro/pi-gen
 IMAGE_TAG="2025-12-04-raspios-trixie-arm64"
 IFS='-' read -r YEAR MONTH DAY _ RELEASE _ <<<"$IMAGE_TAG"
 IMAGE_DATE="${YEAR}-${MONTH}-${DAY}"


### PR DESCRIPTION
Simplify Pi image tagging: keep a literal IMAGE_TAG and use a simple split to derive date and release for filename/URL construction. This removes sed-based parsing and relies on Renovate regex manager to bump the tag.