### PR TITLE
Fix ansible INJECT_FACTS_AS_VARS deprecation warnings

### DIFF
--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -25,7 +25,7 @@
     name: firmware-misc-nonfree
     state: present
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_facts['distribution'] == 'Debian'
     - not common_proxmox_check.stat.exists
 
 - name: "Install qemu-guest-agent on VMs"
@@ -33,7 +33,7 @@
     name: qemu-guest-agent
     state: present
   when:
-    - ansible_virtualization_role == 'guest'
+    - ansible_facts['virtualization_role'] == 'guest'
     - qemu_guest_agent_enabled | default(true) | bool
 
 - name: "Ensure qemu-guest-agent is enabled and started"
@@ -42,7 +42,7 @@
     state: started
     enabled: true
   when:
-    - ansible_virtualization_role == 'guest'
+    - ansible_facts['virtualization_role'] == 'guest'
     - qemu_guest_agent_enabled | default(true) | bool
 
 - name: "Install smartmontools on non-VM amd64 hosts"
@@ -50,8 +50,8 @@
     name: smartmontools
     state: present
   when:
-    - ansible_architecture == 'x86_64'
-    - ansible_virtualization_role != 'guest'
+    - ansible_facts['architecture'] == 'x86_64'
+    - ansible_facts['virtualization_role'] != 'guest'
 
 - name: "Configure smartd for disk monitoring"
   ansible.builtin.template:
@@ -61,8 +61,8 @@
     owner: root
     group: root
   when:
-    - ansible_architecture == 'x86_64'
-    - ansible_virtualization_role != 'guest'
+    - ansible_facts['architecture'] == 'x86_64'
+    - ansible_facts['virtualization_role'] != 'guest'
   notify: Restart smartd
 
 - name: "Ensure smartd service is enabled and started"
@@ -71,8 +71,8 @@
     state: started
     enabled: true
   when:
-    - ansible_architecture == 'x86_64'
-    - ansible_virtualization_role != 'guest'
+    - ansible_facts['architecture'] == 'x86_64'
+    - ansible_facts['virtualization_role'] != 'guest'
 
 - name: "Turn on passwordless sudo for sudo group"
   ansible.builtin.lineinfile:
@@ -113,8 +113,8 @@
     sysctl_file: /etc/sysctl.d/99-common.conf
     reload: true
   when:
-    - ansible_architecture in ['x86_64', 'i386']
-    - ansible_virtualization_role != 'guest'
+    - ansible_facts['architecture'] in ['x86_64', 'i386']
+    - ansible_facts['virtualization_role'] != 'guest'
 
 - name: "Enable fstrim timer for SSD TRIM support"
   ansible.builtin.systemd:

--- a/ansible/roles/hostname/templates/hosts.j2
+++ b/ansible/roles/hostname/templates/hosts.j2
@@ -1,6 +1,6 @@
 127.0.0.1   localhost
 {% if hostname_hosts_ip == "real" %}
-{{ ansible_default_ipv4.address }}   {{ hostname_fqdn }} {{ hostname_short }}
+{{ ansible_facts['default_ipv4']['address'] }}   {{ hostname_fqdn }} {{ hostname_short }}
 {% else %}
 {{ hostname_hosts_ip }}   {{ hostname_fqdn }} {{ hostname_short }}
 {% endif %}

--- a/ansible/roles/setup_upgrade/tasks/main.yaml
+++ b/ansible/roles/setup_upgrade/tasks/main.yaml
@@ -25,7 +25,7 @@
     name: pve-no-subscription
     types: deb
     uris: http://download.proxmox.com/debian/pve
-    suites: "{{ ansible_distribution_release }}"
+    suites: "{{ ansible_facts['distribution_release'] }}"
     components: pve-no-subscription
     state: present
     enabled: true
@@ -51,6 +51,6 @@
     path: "/etc/default/grub"
     line: 'GRUB_CMDLINE_LINUX_DEFAULT="{{ kernel_parameters }}"'
     regexp: "^GRUB_CMDLINE_LINUX_DEFAULT\\s*="
-  when: kernel_parameters is defined and ansible_architecture == "x86_64"
+  when: kernel_parameters is defined and ansible_facts['architecture'] == "x86_64"
   notify:
     - "Update grub"

--- a/ansible/roles/zram/tasks/main.yaml
+++ b/ansible/roles/zram/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 # systemd-zram-generator is only available in Debian 12+
 - name: Configure zram swap
-  when: ansible_distribution_major_version | int >= 12
+  when: ansible_facts['distribution_major_version'] | int >= 12
   block:
     - name: Install systemd-zram-generator
       ansible.builtin.apt:


### PR DESCRIPTION
Update local roles to use ansible_facts['name'] syntax instead of
deprecated ansible_* top-level variables. This prepares for ansible-core
2.24 which will remove auto-injection of facts as top-level variables.

Affected roles:
- setup_upgrade: distribution_release, architecture
- hostname: default_ipv4.address
- common: distribution, virtualization_role, architecture
- zram: distribution_major_version
