### PR TITLE
luser cleanup

### DIFF
--- a/ansible/host_vars/luser.yaml
+++ b/ansible/host_vars/luser.yaml
@@ -1,10 +1,4 @@
 ---
-restic_host_config:
-  default:
-    backup:
-      exclude:
-        - /var/lib/libvirt/images/*
-
 manage_network: true
 interfaces_ether_interfaces:
   - device: ens18


### PR DESCRIPTION
## Summary
- Remove unused libvirt restic exclusion from luser host_vars (libvirt not installed)

This is part of the luser cleanup after upgrading from Debian 11 (Bullseye) to Debian 13 (Trixie).