### PR TITLE
Add TLS support to mosquitto

### DIFF
--- a/kubernetes/mosquitto/certificate.yaml
+++ b/kubernetes/mosquitto/certificate.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+
+metadata:
+  name: mosquitto-tls
+
+spec:
+  secretName: mosquitto-tls
+  issuerRef:
+    name: letsencrypt
+    kind: ClusterIssuer
+  dnsNames:
+  - mqtt.k.oneill.net

--- a/kubernetes/mosquitto/deploy.yaml
+++ b/kubernetes/mosquitto/deploy.yaml
@@ -41,6 +41,8 @@ spec:
         ports:
         - containerPort: 9001
         - containerPort: 1883
+        - containerPort: 8883
+        - containerPort: 8084
         volumeMounts:
         - name: config
           mountPath: /mosquitto/config
@@ -49,6 +51,9 @@ spec:
           mountPath: /mosquitto/data
         - name: generated
           mountPath: /generated
+          readOnly: true
+        - name: tls
+          mountPath: /mosquitto/certs
           readOnly: true
       volumes:
       - name: config
@@ -69,3 +74,6 @@ spec:
         configMap:
           name: create-password-file-script
           defaultMode: 0755
+      - name: tls
+        secret:
+          secretName: mosquitto-tls

--- a/kubernetes/mosquitto/kustomization.yaml
+++ b/kubernetes/mosquitto/kustomization.yaml
@@ -8,6 +8,7 @@ commonAnnotations:
   argoManaged: 'true'
 
 resources:
+- certificate.yaml
 - deploy.yaml
 - externalsecret.yaml
 - pvc.yaml

--- a/kubernetes/mosquitto/mosquitto.conf
+++ b/kubernetes/mosquitto/mosquitto.conf
@@ -11,3 +11,13 @@ protocol mqtt
 
 listener 9001
 protocol websockets
+
+listener 8883
+protocol mqtt
+certfile /mosquitto/certs/tls.crt
+keyfile /mosquitto/certs/tls.key
+
+listener 8084
+protocol websockets
+certfile /mosquitto/certs/tls.crt
+keyfile /mosquitto/certs/tls.key

--- a/kubernetes/mosquitto/service.yaml
+++ b/kubernetes/mosquitto/service.yaml
@@ -23,3 +23,9 @@ spec:
   - name: mqtt-websockets
     protocol: TCP
     port: 9001
+  - name: mqtt-tls
+    protocol: TCP
+    port: 8883
+  - name: mqtt-websockets-tls
+    protocol: TCP
+    port: 8084


### PR DESCRIPTION
- Add Let's Encrypt certificate via cert-manager
- Add TLS listener on port 8883 (MQTT) and 8084 (WebSockets)
- Plain-text ports 1883 and 9001 remain available for existing clients
- Reloader will auto-restart pod on certificate renewal
