### PR TITLE
Add Z-Wave JS and Zigbee2MQTT ansible roles for pantrypi

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -70,6 +70,28 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
+        "ansible/roles/zwavejs/defaults/main.yaml"
+      ],
+      "matchStrings": [
+        "(?:^|\\n)\\s*zwavejs_image_tag:\\s*\"?(?<currentValue>[^\"\\s]+)\"?\\s*(#.*)?"
+      ],
+      "depNameTemplate": "zwavejs/zwavejs2mqtt",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "ansible/roles/zigbee2mqtt/defaults/main.yaml"
+      ],
+      "matchStrings": [
+        "(?:^|\\n)\\s*zigbee2mqtt_image_tag:\\s*\"?(?<currentValue>[^\"\\s]+)\"?\\s*(#.*)?"
+      ],
+      "depNameTemplate": "koenkk/zigbee2mqtt",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
         "/.*\\.ya?ml$/"
       ],
       "matchStrings": [

--- a/ansible/inventory/default
+++ b/ansible/inventory/default
@@ -9,7 +9,7 @@ p3 ansible_host=p3.oneill.net domain=oneill.net
 #voron2-pizero ansible_host=voron2-pizero.oneill.net domain=oneill.net
 #gasherbrum ansible_host=gasherbrum.oneill.net domain=oneill.net
 #gasherbrum-display ansible_host=gasherbrum-display.oneill.net domain=oneill.net
-zwavejs ansible_host=zwavejs.oneill.net domain=oneill.net
+pantrypi ansible_host=pantrypi.oneill.net domain=oneill.net
 garagepi ansible_host=garagepi.oneill.net domain=oneill.net
 infra1 ansible_host=infra1.oneill.net domain=oneill.net
 p1 ansible_host=p1.oneill.net domain=oneill.net
@@ -43,7 +43,7 @@ k4
 #voron2-pizero
 #gasherbrum
 #gasherbrum-display
-zwavejs
+pantrypi
 garagepi
 
 [pizero]
@@ -68,5 +68,15 @@ infra1
 luser
 
 [rtl433]
-zwavejs
+pantrypi
 garagepi
+
+[traefik]
+infra1
+pantrypi
+
+[zwavejs]
+pantrypi
+
+[zigbee2mqtt]
+pantrypi

--- a/ansible/roles/rtl433/defaults/main.yaml
+++ b/ansible/roles/rtl433/defaults/main.yaml
@@ -1,6 +1,4 @@
 ---
-# rtl_433 Docker image version
-# renovate: datasource=docker depName=hertzg/rtl_433
 rtl433_image_tag: "25.12"
 
 # Where to deploy the docker-compose stack

--- a/ansible/roles/traefik/files/docker-compose.yml
+++ b/ansible/roles/traefik/files/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
+      - "3443:3443"
     env_file:
       - traefik.env
     volumes:
@@ -25,9 +26,10 @@ services:
       # File provider for external services
       - "--providers.file.directory=/etc/traefik/conf.d"
       - "--providers.file.watch=true"
-      # Entry points (HTTP and HTTPS)
+      # Entry points (HTTP, HTTPS, and WebSocket Secure)
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.wss.address=:3443"
       # Automatic HTTP to HTTPS redirect
       - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
       - "--entrypoints.web.http.redirections.entrypoint.scheme=https"

--- a/ansible/roles/zigbee2mqtt/defaults/main.yaml
+++ b/ansible/roles/zigbee2mqtt/defaults/main.yaml
@@ -1,0 +1,5 @@
+---
+zigbee2mqtt_image_tag: "2.7.1"
+zigbee2mqtt_data_dir: /etc/zigbee2mqtt
+zigbee2mqtt_device: /dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_621e38fda096ed118be4c498a7669f5d-if00-port0
+zigbee2mqtt_hostname: zigbee2mqtt.oneill.net

--- a/ansible/roles/zigbee2mqtt/handlers/main.yaml
+++ b/ansible/roles/zigbee2mqtt/handlers/main.yaml
@@ -1,0 +1,8 @@
+---
+- name: Restart zigbee2mqtt
+  community.docker.docker_compose_v2:
+    project_src: "{{ zigbee2mqtt_data_dir }}"
+    state: present
+    recreate: always
+    wait: true
+  become: true

--- a/ansible/roles/zigbee2mqtt/meta/main.yaml
+++ b/ansible/roles/zigbee2mqtt/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: geerlingguy.docker

--- a/ansible/roles/zigbee2mqtt/tasks/main.yaml
+++ b/ansible/roles/zigbee2mqtt/tasks/main.yaml
@@ -1,0 +1,22 @@
+---
+- name: Create zigbee2mqtt directory
+  ansible.builtin.file:
+    path: "{{ zigbee2mqtt_data_dir }}"
+    state: directory
+    mode: "0755"
+  become: true
+
+- name: Deploy zigbee2mqtt docker-compose file
+  ansible.builtin.template:
+    src: docker-compose.yaml.j2
+    dest: "{{ zigbee2mqtt_data_dir }}/docker-compose.yaml"
+    mode: "0644"
+  become: true
+  notify: Restart zigbee2mqtt
+
+- name: Start zigbee2mqtt
+  community.docker.docker_compose_v2:
+    project_src: "{{ zigbee2mqtt_data_dir }}"
+    state: present
+    wait: true
+  become: true

--- a/ansible/roles/zigbee2mqtt/templates/docker-compose.yaml.j2
+++ b/ansible/roles/zigbee2mqtt/templates/docker-compose.yaml.j2
@@ -1,0 +1,26 @@
+---
+services:
+  zigbee2mqtt:
+    image: koenkk/zigbee2mqtt:{{ zigbee2mqtt_image_tag }}
+    container_name: zigbee2mqtt
+    restart: unless-stopped
+    devices:
+      - {{ zigbee2mqtt_device }}:/dev/ttyUSB1
+    volumes:
+      - {{ zigbee2mqtt_data_dir }}/data:/app/data
+      - /run/udev:/run/udev:ro
+    environment:
+      - TZ=America/New_York
+    networks:
+      - traefik
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.zigbee2mqtt.rule=Host(`{{ zigbee2mqtt_hostname }}`)
+      - traefik.http.routers.zigbee2mqtt.entrypoints=websecure
+      - traefik.http.routers.zigbee2mqtt.tls.certresolver=letsencrypt
+      - traefik.http.routers.zigbee2mqtt.service=zigbee2mqtt
+      - traefik.http.services.zigbee2mqtt.loadbalancer.server.port=8080
+
+networks:
+  traefik:
+    external: true

--- a/ansible/roles/zwavejs/defaults/main.yaml
+++ b/ansible/roles/zwavejs/defaults/main.yaml
@@ -1,0 +1,5 @@
+---
+zwavejs_image_tag: "11.9.1"
+zwavejs_data_dir: /etc/zwavejs
+zwavejs_device: /dev/serial/by-id/usb-Silicon_Labs_Zooz_ZST10_700_Z-Wave_Stick_26b0d03ffcc9ec1191cf65a341be1031-if00-port0
+zwavejs_hostname: zwavejs.oneill.net

--- a/ansible/roles/zwavejs/handlers/main.yaml
+++ b/ansible/roles/zwavejs/handlers/main.yaml
@@ -1,0 +1,8 @@
+---
+- name: Restart zwavejs
+  community.docker.docker_compose_v2:
+    project_src: "{{ zwavejs_data_dir }}"
+    state: present
+    recreate: always
+    wait: true
+  become: true

--- a/ansible/roles/zwavejs/meta/main.yaml
+++ b/ansible/roles/zwavejs/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: geerlingguy.docker

--- a/ansible/roles/zwavejs/tasks/main.yaml
+++ b/ansible/roles/zwavejs/tasks/main.yaml
@@ -1,0 +1,22 @@
+---
+- name: Create zwavejs directory
+  ansible.builtin.file:
+    path: "{{ zwavejs_data_dir }}"
+    state: directory
+    mode: "0755"
+  become: true
+
+- name: Deploy zwavejs docker-compose file
+  ansible.builtin.template:
+    src: docker-compose.yaml.j2
+    dest: "{{ zwavejs_data_dir }}/docker-compose.yaml"
+    mode: "0644"
+  become: true
+  notify: Restart zwavejs
+
+- name: Start zwavejs
+  community.docker.docker_compose_v2:
+    project_src: "{{ zwavejs_data_dir }}"
+    state: present
+    wait: true
+  become: true

--- a/ansible/roles/zwavejs/templates/docker-compose.yaml.j2
+++ b/ansible/roles/zwavejs/templates/docker-compose.yaml.j2
@@ -1,0 +1,32 @@
+---
+services:
+  zwave-js:
+    image: zwavejs/zwavejs2mqtt:{{ zwavejs_image_tag }}
+    container_name: zwavejs
+    restart: unless-stopped
+    volumes:
+      - {{ zwavejs_data_dir }}/store:/usr/src/app/store
+    environment:
+      - TZ=America/New_York
+    devices:
+      - {{ zwavejs_device }}:/dev/ttyUSB0
+    networks:
+      - traefik
+    labels:
+      - traefik.enable=true
+      # UI on port 8091
+      - traefik.http.routers.zwavejs.rule=Host(`{{ zwavejs_hostname }}`)
+      - traefik.http.routers.zwavejs.entrypoints=websecure
+      - traefik.http.routers.zwavejs.tls.certresolver=letsencrypt
+      - traefik.http.routers.zwavejs.service=zwavejs
+      - traefik.http.services.zwavejs.loadbalancer.server.port=8091
+      # WebSocket on port 3000 (via traefik port 3443)
+      - traefik.http.routers.zwavejs-ws.rule=Host(`{{ zwavejs_hostname }}`)
+      - traefik.http.routers.zwavejs-ws.entrypoints=wss
+      - traefik.http.routers.zwavejs-ws.tls.certresolver=letsencrypt
+      - traefik.http.routers.zwavejs-ws.service=zwavejs-ws
+      - traefik.http.services.zwavejs-ws.loadbalancer.server.port=3000
+
+networks:
+  traefik:
+    external: true

--- a/ansible/site.yaml
+++ b/ansible/site.yaml
@@ -127,7 +127,7 @@
       tags: [restic, resticprofile]
 
 - name: Traefik
-  hosts: infra1
+  hosts: traefik
   roles:
     - role: traefik
       tags: traefik
@@ -196,6 +196,18 @@
   roles:
     - role: rtl433
       tags: rtl433
+
+- name: ZWaveJS
+  hosts: zwavejs
+  roles:
+    - role: zwavejs
+      tags: zwavejs
+
+- name: Zigbee2MQTT
+  hosts: zigbee2mqtt
+  roles:
+    - role: zigbee2mqtt
+      tags: zigbee2mqtt
 
 - name: Kubernetes role
   hosts: kubernetes

--- a/kubernetes/homepage/services.yaml
+++ b/kubernetes/homepage/services.yaml
@@ -5,8 +5,11 @@
       description: UPS Monitoring
       icon: mdi-battery-charging
   - Z-Wave JS:
-      href: http://zwavejs.oneill.net:8091/
+      href: https://zwavejs.oneill.net/
       icon: mdi-z-wave
+  - Zigbee2MQTT:
+      href: https://zigbee2mqtt.oneill.net/
+      icon: mdi-zigbee
 
 - Home Lab:
   - Proxmox:

--- a/kubernetes/smokeping-prober/config.yaml
+++ b/kubernetes/smokeping-prober/config.yaml
@@ -18,7 +18,7 @@ targets:
   - p4.oneill.net
   - p9.oneill.net
   - infra1.oneill.net
-  - zwavejs.oneill.net
+  - pantrypi.oneill.net
   - garagepi.oneill.net
   - left-garage-door.oneill.net
   - right-garage-door.oneill.net

--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -143,5 +143,17 @@ locals {
       hostname = "garagepi.oneill.net"
       note     = "Raspberry Pi in garage - rtl433"
     }
+    pantrypi = {
+      mac      = "dc:a6:32:9d:b7:0f"
+      ip       = "172.19.74.120"
+      hostname = "pantrypi.oneill.net"
+      note     = "Raspberry Pi in pantry - zwavejs, zigbee2mqtt, rtl433"
+    }
+    pantrypi-wifi = {
+      mac      = "dc:a6:32:9d:b7:10"
+      ip       = "172.19.74.118"
+      hostname = "pantrypi-wifi.oneill.net"
+      note     = "pantrypi wifi interface"
+    }
   }
 }

--- a/opentofu/modules/dns/oneill.tf
+++ b/opentofu/modules/dns/oneill.tf
@@ -180,6 +180,23 @@ resource "aws_route53_record" "pve" {
   records = ["infra1.oneill.net"]
 }
 
+# Service CNAMEs for pantrypi services
+resource "aws_route53_record" "zwavejs" {
+  zone_id = aws_route53_zone.oneill_net.zone_id
+  name    = "zwavejs.oneill.net"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["pantrypi.oneill.net"]
+}
+
+resource "aws_route53_record" "zigbee2mqtt" {
+  zone_id = aws_route53_zone.oneill_net.zone_id
+  name    = "zigbee2mqtt.oneill.net"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["pantrypi.oneill.net"]
+}
+
 # TXT record for Proxmox auto-installer URL discovery
 # The installer looks up proxmox-auto-installer.{search domain}
 resource "aws_route53_record" "proxmox_auto_installer" {


### PR DESCRIPTION
- New zwavejs role with Traefik integration (UI on 443, WebSocket on 3443)
- New zigbee2mqtt role with Traefik integration
- Add WSS entrypoint (port 3443) to traefik for Z-Wave JS WebSocket
- Add pantrypi to smokeping monitoring
- Add Z-Wave JS and Zigbee2MQTT to homepage
- Add DNS records for zwavejs.oneill.net and zigbee2mqtt.oneill.net
- Add Renovate custom managers for tracking image versions
