### PR TITLE
Migrate from zwavejs2mqtt to zwave-js-ui Docker image

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -75,7 +75,7 @@
       "matchStrings": [
         "(?:^|\\n)\\s*zwavejs_image_tag:\\s*\"?(?<currentValue>[^\"\\s]+)\"?\\s*(#.*)?"
       ],
-      "depNameTemplate": "zwavejs/zwavejs2mqtt",
+      "depNameTemplate": "zwavejs/zwave-js-ui",
       "datasourceTemplate": "docker"
     },
     {

--- a/ansible/roles/zwavejs/templates/docker-compose.yaml.j2
+++ b/ansible/roles/zwavejs/templates/docker-compose.yaml.j2
@@ -1,7 +1,7 @@
 ---
 services:
   zwave-js:
-    image: zwavejs/zwavejs2mqtt:{{ zwavejs_image_tag }}
+    image: zwavejs/zwave-js-ui:{{ zwavejs_image_tag }}
     container_name: zwavejs
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
The zwavejs2mqtt project was officially renamed to Z-Wave JS UI. Update to use
the current image name zwavejs/zwave-js-ui instead of the deprecated
zwavejs/zwavejs2mqtt.
