### PR TITLE
Use /log endpoint for resticprofile failures

### DIFF
--- a/ansible/group_vars/all/restic.yaml
+++ b/ansible/group_vars/all/restic.yaml
@@ -50,22 +50,32 @@ restic_default_config:
         - /var/log/containers/**
         - /var/log/pods/**
 
+      # Auto-create healthcheck if it doesn't exist (runs before send-before)
       run-before: &run_before |-
-        {% raw %}curl -sf https://hc.k.oneill.net/api/v1/checks/  \
-            -d '{ "api_key": "{{ $healthcheck_management_key }}", "name": "restic-{{ .Hostname }}-{{ .Profile.Name }}", "tags": "backup ansible restic", "timeout": 259200, "channels": "*", "unique": ["name"] }' \
-          && curl -sf "https://hc.k.oneill.net/ping/{{ $healthcheck_ping_key }}/restic-{{ .Hostname }}-{{ .Profile.Name }}/start" -d "Profile: $PROFILE_NAME \
-          Command: $PROFILE_COMMAND \
-          "
+        {% raw %}curl -sf https://hc.k.oneill.net/api/v1/checks/ \
+            -d '{ "api_key": "{{ $healthcheck_management_key }}", "name": "restic-{{ .Hostname }}-{{ .Profile.Name }}", "tags": "backup ansible restic", "timeout": 259200, "channels": "*", "unique": ["name"] }'
         {% endraw %}
-      run-finally: &run_finally |-
-        {% raw %}rc="${ERROR_EXIT_CODE:-0}" \
-          && curl -sf "https://hc.k.oneill.net/ping/{{ $healthcheck_ping_key }}/restic-{{ .Hostname }}-{{ .Profile.Name }}/${rc}" -d "Profile: $PROFILE_NAME \
-          Command: $PROFILE_COMMAND \
-          Message: $ERROR_MESSAGE \
-          Command-line: $ERROR_COMMANDLINE \
-          Stderr: $ERROR_STDERR \
-          "
-        {% endraw %}
+      send-before: &send_before
+        method: POST
+        url: "{% raw %}https://hc.k.oneill.net/ping/{{ $healthcheck_ping_key }}/restic-{{ .Hostname }}-{{ .Profile.Name }}/start{% endraw %}"
+        body-template: body-start.txt
+        headers:
+        - name: Content-Type
+          value: text/plain; charset=UTF-8
+      send-after: &send_after
+        method: POST
+        url: "{% raw %}https://hc.k.oneill.net/ping/{{ $healthcheck_ping_key }}/restic-{{ .Hostname }}-{{ .Profile.Name }}{% endraw %}"
+        body-template: body-success.txt
+        headers:
+        - name: Content-Type
+          value: text/plain; charset=UTF-8
+      send-after-fail: &send_after_fail
+        method: POST
+        url: "{% raw %}https://hc.k.oneill.net/ping/{{ $healthcheck_ping_key }}/restic-{{ .Hostname }}-{{ .Profile.Name }}/log{% endraw %}"
+        body-template: body-failure.txt
+        headers:
+        - name: Content-Type
+          value: text/plain; charset=UTF-8
 restic_prometheus_config:
   default:
     prometheus-push: https://pushgateway.k.oneill.net/

--- a/ansible/roles/resticprofile/files/body-failure.txt
+++ b/ansible/roles/resticprofile/files/body-failure.txt
@@ -1,0 +1,10 @@
+Profile: {{ .ProfileName }}
+Command: {{ .ProfileCommand }}
+Exit Code: {{ .Error.ExitCode }}
+
+Error: {{ .Error.Message }}
+
+Command Line: {{ .Error.CommandLine }}
+
+Stderr:
+{{ .Error.Stderr }}

--- a/ansible/roles/resticprofile/files/body-start.txt
+++ b/ansible/roles/resticprofile/files/body-start.txt
@@ -1,0 +1,2 @@
+Profile: {{ .ProfileName }}
+Command: {{ .ProfileCommand }}

--- a/ansible/roles/resticprofile/files/body-success.txt
+++ b/ansible/roles/resticprofile/files/body-success.txt
@@ -1,0 +1,2 @@
+Profile: {{ .ProfileName }}
+Command: {{ .ProfileCommand }}

--- a/ansible/roles/resticprofile/tasks/configure-client.yaml
+++ b/ansible/roles/resticprofile/tasks/configure-client.yaml
@@ -19,6 +19,17 @@
     owner: "{{ resticprofile_client_user }}"
     mode: "0600"
 
+- name: Deploy body template files
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ resticprofile_user_info.home }}/.config/resticprofile/{{ item }}"
+    owner: "{{ resticprofile_client_user }}"
+    mode: "0644"
+  loop:
+    - body-start.txt
+    - body-success.txt
+    - body-failure.txt
+
 - name: Write config file
   ansible.builtin.template:
     src: templates/config.j2

--- a/kubernetes/restic/body-failure.txt
+++ b/kubernetes/restic/body-failure.txt
@@ -1,0 +1,10 @@
+Profile: {{ .ProfileName }}
+Command: {{ .ProfileCommand }}
+Exit Code: {{ .Error.ExitCode }}
+
+Error: {{ .Error.Message }}
+
+Command Line: {{ .Error.CommandLine }}
+
+Stderr:
+{{ .Error.Stderr }}

--- a/kubernetes/restic/body-start.txt
+++ b/kubernetes/restic/body-start.txt
@@ -1,0 +1,2 @@
+Profile: {{ .ProfileName }}
+Command: {{ .ProfileCommand }}

--- a/kubernetes/restic/body-success.txt
+++ b/kubernetes/restic/body-success.txt
@@ -1,0 +1,2 @@
+Profile: {{ .ProfileName }}
+Command: {{ .ProfileCommand }}

--- a/kubernetes/restic/kustomization.yaml
+++ b/kubernetes/restic/kustomization.yaml
@@ -15,6 +15,9 @@ commonAnnotations:
 configMapGenerator:
 - files:
   - profiles.yaml
+  - body-start.txt
+  - body-success.txt
+  - body-failure.txt
   name: resticprofile-config
   options:
     disableNameSuffixHash: true

--- a/kubernetes/restic/profiles.yaml
+++ b/kubernetes/restic/profiles.yaml
@@ -37,37 +37,45 @@ b2:
     - /source/shared/video/movies
     - /source/shared/downloads
     no-error-on-warning: true
-    run-before: &run_before |
-      [ -f /tmp/uuid ] || cat /proc/sys/kernel/random/uuid > /tmp/uuid
-      echo "Pinging start URL: https://hc.k.oneill.net/ping/${HEALTHCHECK_PING_KEY}/kube-restic-${PROFILE_NAME}-${PROFILE_COMMAND}/start?rid=$(cat /tmp/uuid)"
-      wget "https://hc.k.oneill.net/ping/${HEALTHCHECK_PING_KEY}/kube-restic-${PROFILE_NAME}-${PROFILE_COMMAND}/start?rid=$(cat /tmp/uuid)" -O - -S --post-data "Profile: $PROFILE_NAME
-      Command: $PROFILE_COMMAND
-      "
-    run-finally: &run_finally |
-      rc="${ERROR_EXIT_CODE:-0}";
-      echo "Pinging finish URL: https://hc.k.oneill.net/ping/${HEALTHCHECK_PING_KEY}/kube-restic-${PROFILE_NAME}-${PROFILE_COMMAND}/${rc}?rid=$(cat /tmp/uuid)"
-      wget "https://hc.k.oneill.net/ping/${HEALTHCHECK_PING_KEY}/kube-restic-${PROFILE_NAME}-${PROFILE_COMMAND}/${rc}?rid=$(cat /tmp/uuid)" -O - -S --post-data "Profile: $PROFILE_NAME
-      Command: $PROFILE_COMMAND
-      Message: $ERROR_MESSAGE
-      Command-line: $ERROR_COMMANDLINE
-      Stderr: $ERROR_STDERR
-      "
+    send-before: &send_before
+      method: POST
+      url: https://hc.k.oneill.net/ping/${HEALTHCHECK_PING_KEY}/kube-restic-${PROFILE_NAME}-${PROFILE_COMMAND}/start
+      body-template: /resticprofile-config/body-start.txt
+      headers:
+      - name: Content-Type
+        value: text/plain; charset=UTF-8
+    send-after: &send_after
+      method: POST
+      url: https://hc.k.oneill.net/ping/${HEALTHCHECK_PING_KEY}/kube-restic-${PROFILE_NAME}-${PROFILE_COMMAND}
+      body-template: /resticprofile-config/body-success.txt
+      headers:
+      - name: Content-Type
+        value: text/plain; charset=UTF-8
+    send-after-fail: &send_after_fail
+      method: POST
+      url: https://hc.k.oneill.net/ping/${HEALTHCHECK_PING_KEY}/kube-restic-${PROFILE_NAME}-${PROFILE_COMMAND}/log
+      body-template: /resticprofile-config/body-failure.txt
+      headers:
+      - name: Content-Type
+        value: text/plain; charset=UTF-8
   forget:
     keep-hourly: 24
     keep-daily: 14
     keep-monthly: 24
     keep-weekly: 12
     prune: true
-    run-before: *run_before
-    run-finally: *run_finally
+    send-before: *send_before
+    send-after: *send_after
+    send-after-fail: *send_after_fail
   prometheus-labels:
   - host: kubernetes
   - backend: b2
   prometheus-push: https://pushgateway.k.oneill.net/
   check:
     read-data-subset: 1%
-    run-before: *run_before
-    run-finally: *run_finally
+    send-before: *send_before
+    send-after: *send_after
+    send-after-fail: *send_after_fail
   rewrite:
     exclude:
     - /source/k8s-pv/*-resticprofile-cache*
@@ -93,8 +101,9 @@ main-copy:
   copy:
     from-repository: /source/backups/restic/repos/main
     repository: rclone:b2c:restic/main
-    run-before: *run_before
-    run-finally: *run_finally
+    send-before: *send_before
+    send-after: *send_after
+    send-after-fail: *send_after_fail
   prometheus-labels:
   - host: kubernetes
   - backend: b2
@@ -120,8 +129,9 @@ xtal-copy:
   copy:
     from-repository: /source/backups/restic/repos/xtal
     repository: rclone:b2c:restic/xtal
-    run-before: *run_before
-    run-finally: *run_finally
+    send-before: *send_before
+    send-after: *send_after
+    send-after-fail: *send_after_fail
   prometheus-labels:
   - host: kubernetes
   - backend: b2
@@ -152,13 +162,15 @@ xtal-b2:
     keep-monthly: 12
     keep-yearly: 5
     prune: true
-    run-before: *run_before
-    run-finally: *run_finally
+    send-before: *send_before
+    send-after: *send_after
+    send-after-fail: *send_after_fail
 
   check:
     read-data-subset: 1%
-    run-before: *run_before
-    run-finally: *run_finally
+    send-before: *send_before
+    send-after: *send_after
+    send-after-fail: *send_after_fail
 
   prometheus-labels:
   - host: kubernetes
@@ -182,13 +194,15 @@ main: &nfs_maintenance
     keep-weekly: 12
     keep-monthly: 24
     prune: true
-    run-before: *run_before
-    run-finally: *run_finally
+    send-before: *send_before
+    send-after: *send_after
+    send-after-fail: *send_after_fail
 
   check:
     read-data-subset: 1/10
-    run-before: *run_before
-    run-finally: *run_finally
+    send-before: *send_before
+    send-after: *send_after
+    send-after-fail: *send_after_fail
 
   prometheus-labels:
   - host: kubernetes


### PR DESCRIPTION
Switches resticprofile healthcheck pings from shell-based hooks to native
HTTP hooks. Failures now use the /log endpoint instead of /fail, which
records the event without triggering alerts during the grace period.

- Replace run-before/run-finally with send-before/send-after/send-after-fail
- Add body template files for HTTP hook payloads
- Deploy templates to ansible hosts via resticprofile role
- Keep run-before for auto-creating healthchecks via API
