### PR TITLE
Add digest pinning support to ansible role regex managers

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -62,10 +62,11 @@
         "ansible/roles/rtl433/defaults/main.yaml"
       ],
       "matchStrings": [
-        "(?:^|\\n)\\s*rtl433_image_tag:\\s*\"?(?<currentValue>[^\"\\s]+)\"?\\s*(#.*)?"
+        "rtl433_image_tag:\\s*\"(?<currentValue>[^\"]+)\"(?:\\s+#\\s*(?<currentDigest>sha256:[a-f0-9]{64}))?"
       ],
       "depNameTemplate": "hertzg/rtl_433",
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "autoReplaceStringTemplate": "rtl433_image_tag: \"{{{newValue}}}\"{{#if newDigest}} # {{{newDigest}}}{{/if}}"
     },
     {
       "customType": "regex",
@@ -73,10 +74,11 @@
         "ansible/roles/zwavejs/defaults/main.yaml"
       ],
       "matchStrings": [
-        "(?:^|\\n)\\s*zwavejs_image_tag:\\s*\"?(?<currentValue>[^\"\\s]+)\"?\\s*(#.*)?"
+        "zwavejs_image_tag:\\s*\"(?<currentValue>[^\"]+)\"(?:\\s+#\\s*(?<currentDigest>sha256:[a-f0-9]{64}))?"
       ],
       "depNameTemplate": "zwavejs/zwave-js-ui",
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "autoReplaceStringTemplate": "zwavejs_image_tag: \"{{{newValue}}}\"{{#if newDigest}} # {{{newDigest}}}{{/if}}"
     },
     {
       "customType": "regex",
@@ -84,10 +86,11 @@
         "ansible/roles/zigbee2mqtt/defaults/main.yaml"
       ],
       "matchStrings": [
-        "(?:^|\\n)\\s*zigbee2mqtt_image_tag:\\s*\"?(?<currentValue>[^\"\\s]+)\"?\\s*(#.*)?"
+        "zigbee2mqtt_image_tag:\\s*\"(?<currentValue>[^\"]+)\"(?:\\s+#\\s*(?<currentDigest>sha256:[a-f0-9]{64}))?"
       ],
       "depNameTemplate": "koenkk/zigbee2mqtt",
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "autoReplaceStringTemplate": "zigbee2mqtt_image_tag: \"{{{newValue}}}\"{{#if newDigest}} # {{{newDigest}}}{{/if}}"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
Update the regex managers for rtl433, zwavejs, and zigbee2mqtt to support
digest pinning. Added currentDigest capture group and autoReplaceStringTemplate
to enable Renovate to add SHA256 digests as comments after version tags.
