### PR TITLE
Disable memory ballooning on Kubernetes VMs

### DIFF
--- a/ansible/host_vars/p2.yaml
+++ b/ansible/host_vars/p2.yaml
@@ -3,6 +3,10 @@
 proxmox_install_mac: "b4:96:91:4b:34:58"
 proxmox_install_nic: "enp1s0f0"
 
+# Intel iGPU passthrough (HD Graphics 4600)
+proxmox_gpu_passthrough:
+  pci_ids: "8086:0412"
+
 # Enable network management for this host
 proxmox_manage_network: true
 

--- a/ansible/host_vars/p3.yaml
+++ b/ansible/host_vars/p3.yaml
@@ -3,6 +3,10 @@
 proxmox_install_mac: "b4:96:91:39:e0:94"
 proxmox_install_nic: "enp1s0f0"
 
+# Intel iGPU passthrough (HD Graphics 4600)
+proxmox_gpu_passthrough:
+  pci_ids: "8086:0412"
+
 # Enable network management for this host
 proxmox_manage_network: true
 

--- a/ansible/host_vars/p4.yaml
+++ b/ansible/host_vars/p4.yaml
@@ -3,6 +3,10 @@
 proxmox_install_mac: "b4:96:91:a0:83:54"
 proxmox_install_nic: "enp1s0f0"
 
+# Intel iGPU passthrough (HD Graphics 4600)
+proxmox_gpu_passthrough:
+  pci_ids: "8086:0412"
+
 # Enable network management for this host
 proxmox_manage_network: true
 

--- a/ansible/host_vars/p9.yaml
+++ b/ansible/host_vars/p9.yaml
@@ -3,6 +3,10 @@
 proxmox_install_mac: "b4:96:91:39:e0:70"
 proxmox_install_nic: "enp1s0f0"
 
+# Intel iGPU passthrough (HD Graphics 4600)
+proxmox_gpu_passthrough:
+  pci_ids: "8086:0412"
+
 # Enable network management for this host
 proxmox_manage_network: true
 

--- a/opentofu/proxmox.tf
+++ b/opentofu/proxmox.tf
@@ -21,13 +21,20 @@ resource "proxmox_virtual_environment_hardware_mapping_pci" "rtx2060" {
 }
 
 # Intel iGPU hardware mapping for PCI passthrough
-# Intel HD Graphics 4600 (Haswell) on p2, p4, p9
+# Intel HD Graphics 4600 (Haswell) on p2, p3, p4, p9
 resource "proxmox_virtual_environment_hardware_mapping_pci" "intel_igpu" {
   name = "intel-igpu"
   map = [
     {
       id           = "8086:0412"
       node         = "p2"
+      path         = "0000:00:02"
+      iommu_group  = 0
+      subsystem_id = "1028:05a4"
+    },
+    {
+      id           = "8086:0412"
+      node         = "p3"
       path         = "0000:00:02"
       iommu_group  = 0
       subsystem_id = "1028:05a4"
@@ -65,7 +72,6 @@ resource "proxmox_virtual_environment_vm" "k1" {
 
   memory {
     dedicated = 8192
-    floating  = 4096
   }
 
   agent {
@@ -117,7 +123,6 @@ resource "proxmox_virtual_environment_vm" "k2" {
 
   memory {
     dedicated = 24576
-    floating  = 12288
   }
 
   agent {
@@ -166,6 +171,7 @@ resource "proxmox_virtual_environment_vm" "k3" {
 
   started = false
   on_boot = true
+  machine = "q35"
 
   cpu {
     cores   = 4
@@ -175,7 +181,6 @@ resource "proxmox_virtual_environment_vm" "k3" {
 
   memory {
     dedicated = 24576
-    floating  = 12288
   }
 
   agent {
@@ -217,6 +222,7 @@ resource "proxmox_virtual_environment_vm" "k4" {
 
   started = false
   on_boot = true
+  machine = "q35"
 
   cpu {
     cores   = 4
@@ -226,7 +232,6 @@ resource "proxmox_virtual_environment_vm" "k4" {
 
   memory {
     dedicated = 24576
-    floating  = 12288
   }
 
   agent {
@@ -250,12 +255,6 @@ resource "proxmox_virtual_environment_vm" "k4" {
     mac_address = "52:54:72:19:74:75"
     model       = "virtio"
     queues      = 4
-  }
-
-  # Intel iGPU passthrough from p4
-  hostpci {
-    device  = "hostpci0"
-    mapping = proxmox_virtual_environment_hardware_mapping_pci.intel_igpu.name
   }
 
   operating_system {


### PR DESCRIPTION
## Summary

- Remove floating memory from k1, k2, k3, k4 for static allocations
- Remove iGPU passthrough from k4 (not needed)
- Add iGPU hardware mapping for p3
- Configure iGPU passthrough on p2, p3, p4, p9 hypervisors

PCI passthrough disables memory ballooning due to device memory pinning. Static allocations prevent memory starvation issues (k4 was only seeing 12GB of its 24GB allocation).