### PR TITLE
Reorganize CLAUDE.md into modular .claude/rules/ structure

### DIFF
--- a/.claude/rules/ansible/usage.md
+++ b/.claude/rules/ansible/usage.md
@@ -1,0 +1,15 @@
+---
+paths: ["ansible/**/*"]
+---
+
+# Ansible Usage
+
+## Working Directory
+
+**Always run ansible commands from the `ansible/` directory at the root of this repository**
+
+This ensures `ansible.cfg` is used for proper `roles_path` and other settings.
+
+## File Extensions
+
+**Use `.yaml` extension for YAML files**, not `.yml`

--- a/.claude/rules/integrations/home-assistant.md
+++ b/.claude/rules/integrations/home-assistant.md
@@ -1,3 +1,7 @@
+---
+paths: ["kubernetes/hass/**/*"]
+---
+
 # Home Assistant Metrics and Entity Discovery
 
 Script: `kubernetes/hass/get-prom-metrics`

--- a/.claude/rules/kubernetes/deployment-pattern.md
+++ b/.claude/rules/kubernetes/deployment-pattern.md
@@ -1,0 +1,49 @@
+---
+paths: ["kubernetes/**/*"]
+---
+
+# Kubernetes Application Deployment Pattern
+
+**Critical**: This repository uses a GitOps approach with pre-rendered Helm templates, NOT direct Helm installations.
+
+## Application Structure
+
+Each Kubernetes application follows this structure:
+
+```text
+app-name/
+├── Chart.yaml          # Helm chart dependencies with specific versions
+├── values.yaml         # Chart configuration values
+├── kustomization.yaml  # Lists all resources including pre-rendered templates
+├── helm/              # Pre-rendered Helm template YAML files
+│   └── templates/
+├── render             # Script to generate helm/ directory
+└── namespace.yaml     # Application namespace (if needed)
+```
+
+## Helm Chart Workflow
+
+1. **Define Dependencies**: Update `Chart.yaml` with chart name, version, and repository
+2. **Configure Values**: Set application configuration in `values.yaml`
+3. **Render Templates**: Run `./render` script to generate static YAML in `helm/` directory
+4. **Reference in Kustomize**: List rendered templates in `kustomization.yaml` resources
+5. **Deploy**: ArgoCD deploys the kustomized manifests (note `argoManaged: 'true'` annotation is set via kustomize)
+
+## Deployment and Testing
+
+**Always use kustomize for deployments:**
+
+```bash
+kubectl apply -k <directory>      # Deploy using kustomize (standard approach)
+```
+
+Do NOT use `kubectl apply -f <file>` directly.
+
+**Testing workflow:**
+- Apply changes locally with `kubectl apply -k <directory>` to test during development
+- ArgoCD manages deployments from main branch, but apply locally first to verify changes work before committing
+- For cronjobs, trigger a manual run with: `kubectl create job --from=cronjob/<name> <test-name>`
+
+## Rendering Helm Charts
+
+Render scripts for Kubernetes applications are standardized across this repository. Refer to [helm-rendering.md](./helm-rendering.md) for the canonical render script pattern, helper usage, and best practices that apply to all applications.

--- a/.claude/rules/kubernetes/external-secrets.md
+++ b/.claude/rules/kubernetes/external-secrets.md
@@ -1,3 +1,7 @@
+---
+paths: ["kubernetes/**/externalsecret.yaml"]
+---
+
 # External Secrets Integration
 
 Applications use External Secrets Operator with:

--- a/.claude/rules/kubernetes/helm-rendering.md
+++ b/.claude/rules/kubernetes/helm-rendering.md
@@ -1,0 +1,31 @@
+---
+paths: ["kubernetes/**/render", "kubernetes/**/Chart.yaml"]
+---
+
+# Helm Chart Rendering
+
+## Render Script Pattern
+
+Each application directory contains a `render` script that generates static YAML manifests from Helm charts.
+
+### Standard Pattern
+
+```bash
+#!/bin/bash
+source "$BASEDIR/../scripts/chart-version"
+rm -rf helm tmp && mkdir tmp helm
+helm_template release-name chart-name --values values.yaml \
+  --namespace namespace --output-dir tmp
+mv tmp/*/* helm && rmdir tmp/*
+```
+
+### Key Points
+
+- **Source chart-version helper**: Located at `kubernetes/scripts/chart-version` (relative to repository root), provides `helm_template` function with correct repository/version handling
+- **Clean output**: Remove existing `helm/` and `tmp/` directories before rendering
+- **Use helm_template function**: Ensures charts are rendered with correct repository and version from `Chart.yaml`
+- **Post-processing**: Some render scripts may remove deprecated resources or perform other transformations
+
+### Critical Rule
+
+**Never run `helm install` or `helm upgrade` directly** - all deployments use pre-rendered manifests that are deployed via kustomize and managed by ArgoCD.

--- a/.claude/rules/opentofu/usage.md
+++ b/.claude/rules/opentofu/usage.md
@@ -1,0 +1,15 @@
+---
+paths: ["opentofu/**/*"]
+---
+
+# OpenTofu Usage
+
+## Working Directory
+
+Run `tofu apply` in the `opentofu/` directory to apply infrastructure changes (DNS, healthchecks, etc.)
+
+## Initialization
+
+**Never use `tofu init -upgrade`** - it updates providers beyond the lock file.
+
+Use plain `tofu init` instead.

--- a/.claude/rules/overview.md
+++ b/.claude/rules/overview.md
@@ -1,0 +1,5 @@
+# Development Environment
+
+This repository requires a Nix development shell with all required tools (Helm, kubectl, pre-commit hooks, linting tools).
+
+If a command fails due to missing tools, run it via `nix develop -c <command>` to execute in the Nix environment.

--- a/.claude/rules/tooling/authentik.md
+++ b/.claude/rules/tooling/authentik.md
@@ -1,0 +1,5 @@
+# Authentik Integration
+
+When setting up Authentik for new services, you must run `ak-tool` to provision them via terraform.
+
+Run `ak-tool --help` for details.

--- a/.claude/rules/tooling/ci-cd.md
+++ b/.claude/rules/tooling/ci-cd.md
@@ -1,0 +1,16 @@
+# CI/CD Integration
+
+GitHub Actions automatically:
+
+- Renders Helm charts when `Chart.yaml` or `values.yaml` files change
+- Commits rendered manifests back to pull requests
+- Validates manifests haven't diverged on main branch
+- Uses Nix development environment for consistent tooling
+
+## Checking CI Results
+
+To check CI results for a PR, run:
+
+```bash
+scripts/gh-check-actions
+```

--- a/.claude/rules/tooling/pre-commit.md
+++ b/.claude/rules/tooling/pre-commit.md
@@ -1,0 +1,20 @@
+# Pre-commit Hooks
+
+The repository uses extensive pre-commit validation including:
+
+- YAML formatting (yamlfix) and validation (yamllint)
+- Kubernetes manifest validation (kubeconform)
+- Shell script validation (shellcheck, shfmt)
+- Ansible linting
+- Terraform/OpenTofu validation
+
+## Excluded Directories
+
+The following directories are excluded from most hooks:
+
+- Rendered Helm templates: `kubernetes/*/helm/`
+- Third-party Ansible code
+
+## Usage
+
+Do not run pre-commit or linting tools manually - they run automatically on commit.

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,0 +1,7 @@
+# Development Workflow
+
+Development happens locally with direct application to the homelab infrastructure.
+
+**Always apply changes and verify they work - do not stop after writing code to ask for permission to deploy.**
+
+See technology-specific rules for deployment commands and testing procedures.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,142 +1,21 @@
-# AGENTS.md
+# Homelab Infrastructure Repository
 
 ## Overview
 
-This is a homelab infrastructure monorepo. Solutions should be appropriate for
-that sort of environment. We do not manually hack things together, but instead
-we focus on automation, repeatability, and infrastructure as code.
+This is a homelab infrastructure monorepo managed with automation, repeatability, and infrastructure as code principles.
 
-## Development Workflow
+**Detailed documentation is organized in [.claude/rules/](.claude/rules/)** including:
 
-Development happens locally with direct application to the homelab infrastructure.
-When making changes:
+- **[overview.md](.claude/rules/overview.md)** - Development environment (Nix)
+- **[workflow.md](.claude/rules/workflow.md)** - Development workflow principles
+- **[kubernetes/](.claude/rules/kubernetes/)** - Kubernetes deployment patterns (GitOps, Helm rendering, External Secrets)
+- **[ansible/](.claude/rules/ansible/)** - Ansible usage guidelines
+- **[opentofu/](.claude/rules/opentofu/)** - OpenTofu/Terraform usage
+- **[tooling/](.claude/rules/tooling/)** - Pre-commit hooks, CI/CD, and Authentik integration
+- **[integrations/](.claude/rules/integrations/)** - Home Assistant and other integrations
 
-1. **Kubernetes changes**: Apply directly with `kubectl apply -k <directory>` to
-   test during development. ArgoCD manages deployments from main branch, but we
-   apply locally first to verify changes work before committing.
-2. **OpenTofu changes**: Run `tofu apply` in the `opentofu/` directory to apply
-   infrastructure changes (DNS, healthchecks, etc.)
-3. **Ansible changes**: Run `ansible-playbook site.yaml` from `ansible/` directory
-   (or use `--limit` to target specific hosts)
-4. **Test changes**: Verify the changes work before committing. For cronjobs, you
-   can trigger a manual run with `kubectl create job --from=cronjob/<name> <test-name>`
+## Architecture Principles
 
-Always apply changes and verify they work - do not stop after writing code to ask
-for permission to deploy.
-
-## Repository Structure
-
-- **`ansible/`** - System configuration and provisioning
-- **`esphome/`** - ESPHome device configurations for IoT sensors
-- **`kubernetes/`** - Kubernetes application manifests using GitOps
-- **`opentofu/`** - Cloud infrastructure (DNS, etc.)
-- **`scripts/`** - Automation and tooling
-
-## Development Environment
-
-This repository requires a Nix development shell with all required tools (Helm,
-kubectl, pre-commit hooks, linting tools). If pre-commit hooks fail due to
-missing tools (yamlfix, yamllint, kubeconform), this indicates we're not in the
-nix develop environment - ask the user to restart Claude Code in the nix develop
-environment.
-
-## Kubernetes Application Deployment Pattern
-
-**Critical**: This repository uses a GitOps approach with pre-rendered Helm
-templates, NOT direct Helm installations.
-
-Each Kubernetes application follows this structure:
-
-```text
-app-name/
-├── Chart.yaml          # Helm chart dependencies with specific versions
-├── values.yaml         # Chart configuration values
-├── kustomization.yaml  # Lists all resources including pre-rendered templates
-├── helm/              # Pre-rendered Helm template YAML files
-│   └── templates/
-├── render             # Script to generate helm/ directory
-└── namespace.yaml     # Application namespace (if needed)
-```
-
-### Helm Chart Workflow
-
-1. **Define Dependencies**: Update `Chart.yaml` with chart name, version, and
-   repository
-2. **Configure Values**: Set application configuration in `values.yaml`
-3. **Render Templates**: Run `./render` script to generate static YAML in
-   `helm/` directory
-4. **Reference in Kustomize**: List rendered templates in `kustomization.yaml`
-   resources
-5. **Deploy**: ArgoCD deploys the kustomized manifests (note
-   `argoManaged: 'true'` annotations is set via kustomize)
-
-### Rendering Helm Charts
-
-Each application directory contains a `render` script that:
-
-- Sources the `/kubernetes/scripts/chart-version` helper functions
-- Uses `helm_template` function to render charts with correct repository/version
-- Outputs static YAML files to `helm/` directory
-- May perform post-processing (removing deprecated resources, etc.)
-
-Example render script pattern:
-
-```bash
-#!/bin/bash
-source "$BASEDIR/../scripts/chart-version"
-rm -rf helm tmp && mkdir tmp helm
-helm_template release-name chart-name --values values.yaml \
-  --namespace namespace --output-dir tmp
-mv tmp/*/* helm && rmdir tmp/*
-```
-
-**Never run `helm install` or `helm upgrade` directly** - all deployments use
-pre-rendered manifests.
-
-## Common Commands
-
-### Kubernetes Deployment
-
-```bash
-kubectl apply -k <directory>      # Deploy using kustomize (standard approach)
-```
-
-### Helm Template Rendering
-
-```bash
-cd kubernetes/app-name && ./render    # Render Helm templates for specific app
-```
-
-## Pre-commit Hooks
-
-The repository uses extensive pre-commit validation including:
-
-- YAML formatting (yamlfix) and validation (yamllint)
-- Kubernetes manifest validation (kubeconform)
-- Shell script validation (shellcheck, shfmt)
-- Ansible linting
-- Terraform/OpenTofu validation
-
-Rendered Helm templates in `kubernetes/*/helm/` directories are excluded from
-most hooks.
-
-## CI/CD Integration
-
-GitHub Actions automatically:
-
-- Renders Helm charts when `Chart.yaml` or `values.yaml` files change
-- Commits rendered manifests back to pull requests
-- Validates manifests haven't diverged on main branch
-- Uses Nix development environment for consistent tooling
-
-## Additional Agent Documentation
-
-Detailed documentation for specific topics is in `.agents.d/`:
-
-- `external-secrets.md` - External Secrets Operator integration
-- `hass-metrics.md` - Home Assistant entity discovery via Prometheus metrics
-
-## Authentik
-
-When setting up Authentik for new services, you must run ak-tool to provision
-them via terraform. Run ak-tool --help for details.
+- **GitOps for Kubernetes**: ArgoCD deploys from main branch, but test locally first
+- **Infrastructure as code**: All changes tracked in version control
+- **Automation first**: Prefer scripts and tooling over manual steps


### PR DESCRIPTION
Migrated from monolithic 143-line AGENTS.md to:
- 21-line index linking to focused documentation
- 11 rules files organized by technology area
- Path-specific frontmatter for contextual rule activation
- Migrated .agents.d/ content to .claude/rules/integrations/

Changes:
- Eliminated duplication across documentation files
- Updated Nix environment guidance to use nix develop -c
- Simplified redundant glob patterns in frontmatter
- Expanded pre-commit exclusions documentation
