### PR TITLE
Remove broken nvidia-driver Renovate configuration

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -161,18 +161,6 @@
       ],
       "depNameTemplate": "GAM-team/got-your-back",
       "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "ansible/group_vars/kubernetes.yaml"
-      ],
-      "matchStrings": [
-        "nvidia_driver_version:\\s*\"(?<currentValue>[^\"]+)\""
-      ],
-      "depNameTemplate": "nvidia-driver",
-      "datasourceTemplate": "deb",
-      "registryUrlTemplate": "https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/?suite=./&components=.&binaryArch=x86_64"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
The deb datasource doesn't support NVIDIA's flat repository structure,
and handling Debian package revisions adds complexity. Manual updates
are more straightforward for this single package.
