### PR TITLE
Enable Renovate kubernetes manager for image updates

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -22,6 +22,9 @@
   "lockFileMaintenance": {
     "enabled": true
   },
+  "kubernetes": {
+    "fileMatch": ["kubernetes/.+\\.yaml$"]
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Enables Renovate's built-in kubernetes manager to automatically update
Docker image references in Kubernetes manifest files (CronJobs,
Deployments, etc.) in the kubernetes/ directory.
