### PR TITLE
Exclude helm directories from Renovate kubernetes manager

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -23,7 +23,8 @@
     "enabled": true
   },
   "kubernetes": {
-    "fileMatch": ["kubernetes/.+\\.yaml$"]
+    "fileMatch": ["kubernetes/.+\\.yaml$"],
+    "ignorePaths": ["kubernetes/**/helm/**"]
   },
   "customManagers": [
     {


### PR DESCRIPTION
The kubernetes manager was incorrectly matching rendered Helm templates
in helm/ directories. Add ignorePaths to exclude these files.
