### PR TITLE
Use inline digest format for Ansible Docker images

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -70,11 +70,11 @@
         "ansible/roles/rtl433/defaults/main.yaml"
       ],
       "matchStrings": [
-        "rtl433_image_tag:\\s*\"(?<currentValue>[^\"]+)\"(?:\\s+#\\s*(?<currentDigest>sha256:[a-f0-9]{64}))?"
+        "rtl433_image_tag:\\s*\"(?<currentValue>[^@\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?\""
       ],
       "depNameTemplate": "hertzg/rtl_433",
       "datasourceTemplate": "docker",
-      "autoReplaceStringTemplate": "rtl433_image_tag: \"{{{newValue}}}\"{{#if newDigest}} # {{{newDigest}}}{{/if}}"
+      "autoReplaceStringTemplate": "rtl433_image_tag: \"{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}\""
     },
     {
       "customType": "regex",
@@ -82,11 +82,11 @@
         "ansible/roles/zwavejs/defaults/main.yaml"
       ],
       "matchStrings": [
-        "zwavejs_image_tag:\\s*\"(?<currentValue>[^\"]+)\"(?:\\s+#\\s*(?<currentDigest>sha256:[a-f0-9]{64}))?"
+        "zwavejs_image_tag:\\s*\"(?<currentValue>[^@\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?\""
       ],
       "depNameTemplate": "zwavejs/zwave-js-ui",
       "datasourceTemplate": "docker",
-      "autoReplaceStringTemplate": "zwavejs_image_tag: \"{{{newValue}}}\"{{#if newDigest}} # {{{newDigest}}}{{/if}}"
+      "autoReplaceStringTemplate": "zwavejs_image_tag: \"{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}\""
     },
     {
       "customType": "regex",
@@ -94,11 +94,11 @@
         "ansible/roles/zigbee2mqtt/defaults/main.yaml"
       ],
       "matchStrings": [
-        "zigbee2mqtt_image_tag:\\s*\"(?<currentValue>[^\"]+)\"(?:\\s+#\\s*(?<currentDigest>sha256:[a-f0-9]{64}))?"
+        "zigbee2mqtt_image_tag:\\s*\"(?<currentValue>[^@\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?\""
       ],
       "depNameTemplate": "koenkk/zigbee2mqtt",
       "datasourceTemplate": "docker",
-      "autoReplaceStringTemplate": "zigbee2mqtt_image_tag: \"{{{newValue}}}\"{{#if newDigest}} # {{{newDigest}}}{{/if}}"
+      "autoReplaceStringTemplate": "zigbee2mqtt_image_tag: \"{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}\""
     },
     {
       "customType": "regex",

--- a/ansible/roles/rtl433/defaults/main.yaml
+++ b/ansible/roles/rtl433/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-rtl433_image_tag: "25.12" # sha256:6fe54863dd3a561c9befb4c8e632e9df962cc3535b6ba5bbed15c9b95e1f9882
+rtl433_image_tag: "25.12@sha256:30704a9756bc8a7b897c7b9aaf640524eafd9ddb359bfc01af51e081c03f0918"
 
 # Where to deploy the docker-compose stack
 rtl433_install_dir: /etc/rtl433

--- a/ansible/roles/zigbee2mqtt/defaults/main.yaml
+++ b/ansible/roles/zigbee2mqtt/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-zigbee2mqtt_image_tag: "2.7.1" # sha256:163e7351430a95d550d5b1bb958527edc1eff115eb013ca627f3545a192e853f
+zigbee2mqtt_image_tag: "2.7.1@sha256:163e7351430a95d550d5b1bb958527edc1eff115eb013ca627f3545a192e853f"
 zigbee2mqtt_data_dir: /etc/zigbee2mqtt
 zigbee2mqtt_device: /dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_621e38fda096ed118be4c498a7669f5d-if00-port0
 zigbee2mqtt_hostname: zigbee2mqtt.oneill.net

--- a/ansible/roles/zwavejs/defaults/main.yaml
+++ b/ansible/roles/zwavejs/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-zwavejs_image_tag: "11.9.1" # sha256:a7036e59a9d7916d1f92f2fa1e0b9f4a5ed317fc8bef38756368f7c865e0e95a
+zwavejs_image_tag: "11.9.1@sha256:a7036e59a9d7916d1f92f2fa1e0b9f4a5ed317fc8bef38756368f7c865e0e95a"
 zwavejs_data_dir: /etc/zwavejs
 zwavejs_device: /dev/serial/by-id/usb-Silicon_Labs_Zooz_ZST10_700_Z-Wave_Stick_26b0d03ffcc9ec1191cf65a341be1031-if00-port0
 zwavejs_hostname: zwavejs.oneill.net


### PR DESCRIPTION
Move digest from comment to inline @sha256: format for rtl433, zwavejs,
and zigbee2mqtt roles. This ensures the digest is actually used by
docker-compose, not just documented.

Update Renovate regex patterns to match new format.
