### PR TITLE
Tune Go runtime and scheduling for restic backup jobs

### DIFF
--- a/ansible/group_vars/all/restic.yaml
+++ b/ansible/group_vars/all/restic.yaml
@@ -14,11 +14,18 @@ restic_global_config:
     restic-stale-lock-age: 6h
     restic-lock-retry-after: 2m
     cleanup-cache: true
+    nice: 19
+    ionice: true
+    ionice-class: 3
 restic_default_config:
   default:
     force-inactive-lock: true
     repository: "rest:https://{{ '{{' }} $repo_username {{ '}}' }}:{{ '{{' }} $repo_password {{ '}}' }}@restic.k.oneill.net/main"
     password-file: passphrase.txt
+
+    env:
+      GOGC: "10"
+      GOMAXPROCS: "1"
 
     backup:
       no-error-on-warning: true
@@ -55,27 +62,27 @@ restic_default_config:
         {% raw %}curl -sf https://hc.k.oneill.net/api/v1/checks/ \
             -d '{ "api_key": "{{ $healthcheck_management_key }}", "name": "restic-{{ .Hostname }}-{{ .Profile.Name }}", "tags": "backup ansible restic", "timeout": 259200, "channels": "*", "unique": ["name"] }'
         {% endraw %}
-      send-before: &send_before
+      send-before:
         method: POST
         url: "{% raw %}https://hc.k.oneill.net/ping/{{ $healthcheck_ping_key }}/restic-{{ .Hostname }}-{{ .Profile.Name }}/start{% endraw %}"
         body-template: body-start.txt
         headers:
-        - name: Content-Type
-          value: text/plain; charset=UTF-8
-      send-after: &send_after
+          - name: Content-Type
+            value: text/plain; charset=UTF-8
+      send-after:
         method: POST
         url: "{% raw %}https://hc.k.oneill.net/ping/{{ $healthcheck_ping_key }}/restic-{{ .Hostname }}-{{ .Profile.Name }}{% endraw %}"
         body-template: body-success.txt
         headers:
-        - name: Content-Type
-          value: text/plain; charset=UTF-8
-      send-after-fail: &send_after_fail
+          - name: Content-Type
+            value: text/plain; charset=UTF-8
+      send-after-fail:
         method: POST
         url: "{% raw %}https://hc.k.oneill.net/ping/{{ $healthcheck_ping_key }}/restic-{{ .Hostname }}-{{ .Profile.Name }}/log{% endraw %}"
         body-template: body-failure.txt
         headers:
-        - name: Content-Type
-          value: text/plain; charset=UTF-8
+          - name: Content-Type
+            value: text/plain; charset=UTF-8
 restic_prometheus_config:
   default:
     prometheus-push: https://pushgateway.k.oneill.net/

--- a/kubernetes/restic/cronjob-nfs.yaml.j2
+++ b/kubernetes/restic/cronjob-nfs.yaml.j2
@@ -6,7 +6,7 @@ metadata:
   name: resticprofile-{{ profile }}-{{ command }}
 
 spec:
-  schedule: "{{ schedule }}"
+  schedule: {{ schedule }}
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300

--- a/kubernetes/restic/cronjobs/cronjob-b2-check.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-b2-check.yaml
@@ -34,7 +34,7 @@ spec:
             - --lock-wait
             - 6h
             - check
-            image: creativeprojects/resticprofile@sha256:c5b0d32983fcde265839fef5e4d1f0e56fbc4ba8649a476bb9f49eb81efb0c1d
+            image: creativeprojects/resticprofile
             imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:

--- a/kubernetes/restic/cronjobs/cronjob-b2-forget.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-b2-forget.yaml
@@ -34,7 +34,7 @@ spec:
             - --lock-wait
             - 6h
             - forget
-            image: creativeprojects/resticprofile@sha256:c5b0d32983fcde265839fef5e4d1f0e56fbc4ba8649a476bb9f49eb81efb0c1d
+            image: creativeprojects/resticprofile
             imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:

--- a/kubernetes/restic/cronjobs/cronjob-b2.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-b2.yaml
@@ -41,7 +41,7 @@ spec:
             - --lock-wait
             - 6h
             - backup
-            image: creativeprojects/resticprofile@sha256:c5b0d32983fcde265839fef5e4d1f0e56fbc4ba8649a476bb9f49eb81efb0c1d
+            image: creativeprojects/resticprofile
             imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:

--- a/kubernetes/restic/cronjobs/cronjob-flux-check.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-flux-check.yaml
@@ -6,7 +6,7 @@ metadata:
   name: resticprofile-flux-check
 
 spec:
-  schedule: "33 17 * * 2"
+  schedule: 33 17 * * 2
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300
@@ -34,7 +34,7 @@ spec:
             - --lock-wait
             - 6h
             - check
-            image: creativeprojects/resticprofile@sha256:c5b0d32983fcde265839fef5e4d1f0e56fbc4ba8649a476bb9f49eb81efb0c1d
+            image: creativeprojects/resticprofile
             imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:

--- a/kubernetes/restic/cronjobs/cronjob-flux-forget.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-flux-forget.yaml
@@ -6,7 +6,7 @@ metadata:
   name: resticprofile-flux-forget
 
 spec:
-  schedule: "33 15 * * 2"
+  schedule: 33 15 * * 2
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300
@@ -34,7 +34,7 @@ spec:
             - --lock-wait
             - 6h
             - forget
-            image: creativeprojects/resticprofile@sha256:c5b0d32983fcde265839fef5e4d1f0e56fbc4ba8649a476bb9f49eb81efb0c1d
+            image: creativeprojects/resticprofile
             imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:

--- a/kubernetes/restic/cronjobs/cronjob-main-check.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-main-check.yaml
@@ -6,7 +6,7 @@ metadata:
   name: resticprofile-main-check
 
 spec:
-  schedule: "55 15 * * 1"
+  schedule: 55 15 * * 1
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300
@@ -34,7 +34,7 @@ spec:
             - --lock-wait
             - 6h
             - check
-            image: creativeprojects/resticprofile@sha256:c5b0d32983fcde265839fef5e4d1f0e56fbc4ba8649a476bb9f49eb81efb0c1d
+            image: creativeprojects/resticprofile
             imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:

--- a/kubernetes/restic/cronjobs/cronjob-main-copy.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-main-copy.yaml
@@ -6,7 +6,7 @@ metadata:
   name: resticprofile-main-copy
 
 spec:
-  schedule: "18 5 * * *"  # 05:18 daily
+  schedule: 18 5 * * *  # 05:18 daily
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300
@@ -34,7 +34,7 @@ spec:
             - --lock-wait
             - 6h
             - copy
-            image: creativeprojects/resticprofile@sha256:c5b0d32983fcde265839fef5e4d1f0e56fbc4ba8649a476bb9f49eb81efb0c1d
+            image: creativeprojects/resticprofile
             imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:

--- a/kubernetes/restic/cronjobs/cronjob-main-forget.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-main-forget.yaml
@@ -6,7 +6,7 @@ metadata:
   name: resticprofile-main-forget
 
 spec:
-  schedule: "55 13 * * 1"
+  schedule: 55 13 * * 1
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300
@@ -34,7 +34,7 @@ spec:
             - --lock-wait
             - 6h
             - forget
-            image: creativeprojects/resticprofile@sha256:c5b0d32983fcde265839fef5e4d1f0e56fbc4ba8649a476bb9f49eb81efb0c1d
+            image: creativeprojects/resticprofile
             imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:

--- a/kubernetes/restic/cronjobs/cronjob-xtal-b2-check.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-xtal-b2-check.yaml
@@ -34,7 +34,7 @@ spec:
             - --lock-wait
             - 6h
             - check
-            image: creativeprojects/resticprofile@sha256:c5b0d32983fcde265839fef5e4d1f0e56fbc4ba8649a476bb9f49eb81efb0c1d
+            image: creativeprojects/resticprofile
             imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:

--- a/kubernetes/restic/cronjobs/cronjob-xtal-b2-forget.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-xtal-b2-forget.yaml
@@ -34,7 +34,7 @@ spec:
             - --lock-wait
             - 6h
             - forget
-            image: creativeprojects/resticprofile@sha256:c5b0d32983fcde265839fef5e4d1f0e56fbc4ba8649a476bb9f49eb81efb0c1d
+            image: creativeprojects/resticprofile
             imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:

--- a/kubernetes/restic/cronjobs/cronjob-xtal-check.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-xtal-check.yaml
@@ -6,7 +6,7 @@ metadata:
   name: resticprofile-xtal-check
 
 spec:
-  schedule: "24 8 * * 1"
+  schedule: 24 8 * * 1
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300
@@ -34,7 +34,7 @@ spec:
             - --lock-wait
             - 6h
             - check
-            image: creativeprojects/resticprofile@sha256:c5b0d32983fcde265839fef5e4d1f0e56fbc4ba8649a476bb9f49eb81efb0c1d
+            image: creativeprojects/resticprofile
             imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:

--- a/kubernetes/restic/cronjobs/cronjob-xtal-copy.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-xtal-copy.yaml
@@ -6,7 +6,7 @@ metadata:
   name: resticprofile-xtal-copy
 
 spec:
-  schedule: "48 5 * * *"  # 05:48 daily
+  schedule: 48 5 * * *  # 05:48 daily
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300
@@ -34,7 +34,7 @@ spec:
             - --lock-wait
             - 6h
             - copy
-            image: creativeprojects/resticprofile@sha256:c5b0d32983fcde265839fef5e4d1f0e56fbc4ba8649a476bb9f49eb81efb0c1d
+            image: creativeprojects/resticprofile
             imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:

--- a/kubernetes/restic/cronjobs/cronjob-xtal-forget.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-xtal-forget.yaml
@@ -6,7 +6,7 @@ metadata:
   name: resticprofile-xtal-forget
 
 spec:
-  schedule: "24 6 * * 1"
+  schedule: 24 6 * * 1
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300
@@ -34,7 +34,7 @@ spec:
             - --lock-wait
             - 6h
             - forget
-            image: creativeprojects/resticprofile@sha256:c5b0d32983fcde265839fef5e4d1f0e56fbc4ba8649a476bb9f49eb81efb0c1d
+            image: creativeprojects/resticprofile
             imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:

--- a/kubernetes/restic/profiles.yaml
+++ b/kubernetes/restic/profiles.yaml
@@ -5,6 +5,9 @@ global:
   restic-stale-lock-age: 6h
   restic-lock-retry-after: 2m
   cleanup-cache: true
+  nice: 19
+  ionice: true
+  ionice-class: 3
 
 # B2 profile for direct backup to Backblaze B2
 b2:
@@ -14,7 +17,9 @@ b2:
   verbose: true
   pack-size: 64
 
-  env:
+  env: &rclone_env
+    GOGC: '10'
+    GOMAXPROCS: '1'
     RCLONE_BWLIMIT: 25M
     RCLONE_CONFIG: /rclone-config/rclone.conf
     RCLONE_RC: true
@@ -88,15 +93,7 @@ main-copy:
   verbose: true
   pack-size: 64
 
-  env:
-    RCLONE_BWLIMIT: 25M
-    RCLONE_CONFIG: /rclone-config/rclone.conf
-    RCLONE_RC: true
-    RCLONE_RC_ADDR: 0.0.0.0:5572
-    RCLONE_RC_ENABLE_METRICS: true
-    RCLONE_FAST_LIST: true
-    RESTIC_PROGRESS_FPS: '0.1'
-    RESTIC_CACHE_DIR: /cache
+  env: *rclone_env
 
   copy:
     from-repository: /source/backups/restic/repos/main
@@ -116,15 +113,7 @@ xtal-copy:
   verbose: true
   pack-size: 64
 
-  env:
-    RCLONE_BWLIMIT: 25M
-    RCLONE_CONFIG: /rclone-config/rclone.conf
-    RCLONE_RC: true
-    RCLONE_RC_ADDR: 0.0.0.0:5572
-    RCLONE_RC_ENABLE_METRICS: true
-    RCLONE_FAST_LIST: true
-    RESTIC_PROGRESS_FPS: '0.1'
-    RESTIC_CACHE_DIR: /cache
+  env: *rclone_env
 
   copy:
     from-repository: /source/backups/restic/repos/xtal
@@ -145,15 +134,7 @@ xtal-b2:
   verbose: true
   pack-size: 64
 
-  env:
-    RCLONE_BWLIMIT: 25M
-    RCLONE_CONFIG: /rclone-config/rclone.conf
-    RCLONE_RC: true
-    RCLONE_RC_ADDR: 0.0.0.0:5572
-    RCLONE_RC_ENABLE_METRICS: true
-    RCLONE_FAST_LIST: true
-    RESTIC_PROGRESS_FPS: '0.1'
-    RESTIC_CACHE_DIR: /cache
+  env: *rclone_env
 
   forget:
     keep-hourly: 24
@@ -185,6 +166,8 @@ main: &nfs_maintenance
   verbose: true
 
   env:
+    GOGC: '10'
+    GOMAXPROCS: '1'
     RESTIC_PROGRESS_FPS: '0.1'
     RESTIC_CACHE_DIR: /cache
 

--- a/kubernetes/restic/render-and-sync
+++ b/kubernetes/restic/render-and-sync
@@ -92,7 +92,7 @@ def generate_cronjobs() -> None:
                 schedule=schedule,
             )
             outfile = outdir / f"cronjob-{repo}-{command}.yaml"
-            outfile.write_text(content)
+            outfile.write_text(content.rstrip() + "\n")
             print(f"  Generated {outfile.name} (schedule: {schedule})")
 
 
@@ -223,7 +223,9 @@ def sync_healthchecks() -> None:
                     print(f"  Created/updated: {slug} (schedule: {schedule})")
             except urllib.error.HTTPError as e:
                 body = e.read().decode()
-                print(f"  Error for {slug}: {e.code} {e.reason}: {body}", file=sys.stderr)
+                print(
+                    f"  Error for {slug}: {e.code} {e.reason}: {body}", file=sys.stderr
+                )
 
 
 def sync_secrets() -> None:


### PR DESCRIPTION
- Add GOGC=10, GOMAXPROCS=1 to resticprofile env sections (K8s and Ansible)
- Add nice=19, ionice-class=3 to resticprofile global section
- Use YAML anchor for rclone env to reduce duplication in profiles.yaml
- Remove inline image digests from cronjobs (kustomize already pins)
- Fix template to add trailing newlines and unquote schedules