### PR TITLE
Add Tailscale endpoint for healthchecks

### DIFF
--- a/.claude/rules/ansible/usage.md
+++ b/.claude/rules/ansible/usage.md
@@ -6,9 +6,20 @@ paths: ["ansible/**/*"]
 
 ## Working Directory
 
-**Always run ansible commands from the `ansible/` directory at the root of this repository**
+**Always run ansible commands from the `ansible/` directory at the root of this
+repository**
 
 This ensures `ansible.cfg` is used for proper `roles_path` and other settings.
+
+## Deploying Changes
+
+Run `site.yaml` with a host limit to deploy changes:
+
+```bash
+cd ansible && ansible-playbook site.yaml -l <hostname>
+```
+
+Always limit to specific hosts when testing changes.
 
 ## File Extensions
 

--- a/ansible/group_vars/all/restic.yaml
+++ b/ansible/group_vars/all/restic.yaml
@@ -1,6 +1,7 @@
 ---
 restic_repo: main
 resticprofile_enabled: true
+restic_healthcheck_host: hc.k.oneill.net
 
 restic_config_blocks:
   - restic_global_config
@@ -59,26 +60,25 @@ restic_default_config:
 
       # Auto-create healthcheck if it doesn't exist (runs before send-before)
       run-before: &run_before |-
-        {% raw %}curl -sf https://hc.k.oneill.net/api/v1/checks/ \
-            -d '{ "api_key": "{{ $healthcheck_management_key }}", "name": "restic-{{ .Hostname }}-{{ .Profile.Name }}", "tags": "backup ansible restic", "timeout": 259200, "channels": "*", "unique": ["name"] }'
-        {% endraw %}
+        curl -sf https://{{ restic_healthcheck_host }}/api/v1/checks/ \
+            -d '{ "api_key": "{% raw %}{{ $healthcheck_management_key }}{% endraw %}", "name": "{% raw %}restic-{{ .Hostname }}-{{ .Profile.Name }}{% endraw %}", "tags": "backup ansible restic", "timeout": 259200, "channels": "*", "unique": ["name"] }'
       send-before:
         method: POST
-        url: "{% raw %}https://hc.k.oneill.net/ping/{{ $healthcheck_ping_key }}/restic-{{ .Hostname }}-{{ .Profile.Name }}/start{% endraw %}"
+        url: "https://{{ restic_healthcheck_host }}/ping/{% raw %}{{ $healthcheck_ping_key }}/restic-{{ .Hostname }}-{{ .Profile.Name }}{% endraw %}/start"
         body-template: body-start.txt
         headers:
           - name: Content-Type
             value: text/plain; charset=UTF-8
       send-after:
         method: POST
-        url: "{% raw %}https://hc.k.oneill.net/ping/{{ $healthcheck_ping_key }}/restic-{{ .Hostname }}-{{ .Profile.Name }}{% endraw %}"
+        url: "https://{{ restic_healthcheck_host }}/ping/{% raw %}{{ $healthcheck_ping_key }}/restic-{{ .Hostname }}-{{ .Profile.Name }}{% endraw %}"
         body-template: body-success.txt
         headers:
           - name: Content-Type
             value: text/plain; charset=UTF-8
       send-after-fail:
         method: POST
-        url: "{% raw %}https://hc.k.oneill.net/ping/{{ $healthcheck_ping_key }}/restic-{{ .Hostname }}-{{ .Profile.Name }}/log{% endraw %}"
+        url: "https://{{ restic_healthcheck_host }}/ping/{% raw %}{{ $healthcheck_ping_key }}/restic-{{ .Hostname }}-{{ .Profile.Name }}{% endraw %}/log"
         body-template: body-failure.txt
         headers:
           - name: Content-Type

--- a/ansible/host_vars/flux.yaml
+++ b/ansible/host_vars/flux.yaml
@@ -1,11 +1,13 @@
 ---
 # Vultr VPS running Debian 11 (bullseye)
 # vc2-1c-1gb instance
-tailscale_args: --advertise-exit-node --accept-dns=false
-tailscale_tags: ['flux']
+tailscale_args: --advertise-exit-node
+tailscale_tags: ["flux"]
 ip_forwarding_enabled: true
+qemu_guest_agent_enabled: false
 restic_prometheus_config: {}
 restic_repo: flux
+restic_healthcheck_host: hc.cow-banjo.ts.net
 restic_host_config:
   default:
     # Use a dedicated repo via REST server over Tailscale. This host has limited

--- a/kubernetes/healthchecks/helm/healthchecks/common.yaml
+++ b/kubernetes/healthchecks/helm/healthchecks/common.yaml
@@ -63,7 +63,7 @@ spec:
           imagePullPolicy: IfNotPresent
           env:
             - name: ALLOWED_HOSTS
-              value: hc.k.oneill.net
+              value: hc.k.oneill.net,hc.cow-banjo.ts.net
             - name: DB
               value: postgres
             - name: DB_HOST

--- a/kubernetes/healthchecks/kustomization.yaml
+++ b/kubernetes/healthchecks/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - postgres-cluster.yaml
 - helm/healthchecks/common.yaml
 - cronjob-canary-ping.yaml
+- tailscale-ingress.yaml
 
 commonAnnotations:
   argoManaged: 'true'

--- a/kubernetes/healthchecks/tailscale-ingress.yaml
+++ b/kubernetes/healthchecks/tailscale-ingress.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+
+metadata:
+  name: healthchecks-tailscale
+  annotations:
+    tailscale.com/tags: tag:healthchecks
+
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: healthchecks
+      port:
+        number: 8000
+  tls:
+  - hosts:
+    - hc

--- a/kubernetes/healthchecks/values.yaml
+++ b/kubernetes/healthchecks/values.yaml
@@ -2,15 +2,15 @@
 healthchecks:
   controller:
     annotations:
-      reloader.stakater.com/auto: "true"
+      reloader.stakater.com/auto: 'true'
 
   env:
     TZ: America/New_York
     SITE_NAME: Healthchecks
     SITE_ROOT: https://hc.k.oneill.net
-    ALLOWED_HOSTS: hc.k.oneill.net
-    REGISTRATION_OPEN: "False"
-    DEBUG: "False"
+    ALLOWED_HOSTS: hc.k.oneill.net,hc.cow-banjo.ts.net
+    REGISTRATION_OPEN: 'False'
+    DEBUG: 'False'
 
     # Database - CloudNative-PG
     DB: postgres
@@ -29,9 +29,9 @@ healthchecks:
 
     # Email via SMTP relay
     EMAIL_HOST: smtp.k.oneill.net
-    EMAIL_PORT: "587"
+    EMAIL_PORT: '587'
     EMAIL_HOST_USER: relay@oneill.net
-    EMAIL_USE_TLS: "True"
+    EMAIL_USE_TLS: 'True'
     DEFAULT_FROM_EMAIL: healthchecks@oneill.net
 
     # Authentik forward auth - use email header for user identification

--- a/opentofu/tailscale.tf
+++ b/opentofu/tailscale.tf
@@ -16,6 +16,7 @@ resource "tailscale_acl" "main" {
             "tag:argocd": ["tag:k8s-operator"],
             "tag:flux": ["autogroup:admin"],
             "tag:restic": ["tag:k8s-operator"],
+            "tag:healthchecks": ["tag:k8s-operator"],
         },
 
         // Define access control lists for users, groups, autogroups, tags,
@@ -42,6 +43,14 @@ resource "tailscale_acl" "main" {
                 "src":    ["tag:flux"],
                 "proto":  "tcp",
                 "dst":    ["tag:restic:443"],
+            },
+
+            // Allow flux to reach healthchecks for ping notifications
+            {
+                "action": "accept",
+                "src":    ["tag:flux"],
+                "proto":  "tcp",
+                "dst":    ["tag:healthchecks:443"],
             },
 
             // Allow GitHub Actions to reach ArgoCD only


### PR DESCRIPTION
Allow flux VPS to send healthcheck pings via Tailscale since it's outside
the internal network.

- Add Tailscale ingress for healthchecks (hc.cow-banjo.ts.net)
- Update Tailscale ACL to allow tag:flux → tag:healthchecks
- Make healthcheck URL configurable in Ansible restic config
- Enable accept-dns and disable qemu-guest-agent on flux
- Add Tailscale hostname to healthchecks ALLOWED_HOSTS
- Document Ansible deployment workflow in rules
