### PR TITLE
Fix B2 application key bucket_id deprecation

### DIFF
--- a/opentofu/b2.tf
+++ b/opentofu/b2.tf
@@ -24,8 +24,8 @@ resource "b2_bucket" "velero_backups" {
 
 # Application key for Velero with access to velero-backups bucket
 resource "b2_application_key" "velero" {
-  key_name  = "velero-backups"
-  bucket_id = b2_bucket.velero_backups.bucket_id
+  key_name   = "velero-backups"
+  bucket_ids = [b2_bucket.velero_backups.bucket_id]
 
   capabilities = [
     "listBuckets",


### PR DESCRIPTION
## Summary
Update b2_application_key resource to use bucket_ids instead of the deprecated bucket_id attribute

## Changes
- Changed `bucket_id` to `bucket_ids` in the velero application key resource
- Version 0.12.0 of the B2 provider added support for multi-bucket application keys via the bucket_ids list and deprecated the singular bucket_id attribute
- Configuration validated successfully with `tofu validate`
- Deprecation warning no longer appears in `tofu plan`