### PR TITLE
Improve Ansible playbook idempotency

### DIFF
--- a/ansible/inventory/default
+++ b/ansible/inventory/default
@@ -15,7 +15,7 @@ infra1 ansible_host=infra1.oneill.net domain=oneill.net
 p1 ansible_host=p1.oneill.net domain=oneill.net
 p2 ansible_host=p2.oneill.net domain=oneill.net
 p4 ansible_host=p4.oneill.net domain=oneill.net
-p9 ansible_host=p9.oneill.net domain=oneill.net
+#p9 ansible_host=p9.oneill.net domain=oneill.net
 
 [kubernetes]
 k1
@@ -55,7 +55,7 @@ p1
 p2
 p3
 p4
-p9
+#p9
 
 [tailscale_disabled]
 #voron2-pizero

--- a/ansible/roles/common/vars/main.yaml
+++ b/ansible/roles/common/vars/main.yaml
@@ -10,7 +10,7 @@ common_packages_to_install:
   - bzip2
   - ca-certificates
   - curl
-  - dnsutils
+  - bind9-dnsutils
   - dstat
   - htop
   - lsb-release

--- a/ansible/roles/proxmox/tasks/oidc.yaml
+++ b/ansible/roles/proxmox/tasks/oidc.yaml
@@ -1,45 +1,13 @@
 ---
 # Configure Authentik OIDC realm for Proxmox
-# Note: No Ansible module exists for realm management; using pveum CLI
 
-- name: "Check if authentik realm exists"
-  ansible.builtin.command:
-    cmd: pveum realm list --output-format json
-  register: proxmox_realm_list
-  changed_when: false
-  run_once: true
-
-- name: "Parse realm list"
-  ansible.builtin.set_fact:
-    proxmox_authentik_realm_exists: "{{ (proxmox_realm_list.stdout | from_json) | selectattr('realm', 'equalto', 'authentik') | list | length > 0 }}"
-  run_once: true
-
-- name: "Create OIDC realm"
-  ansible.builtin.command:
-    cmd: >
-      pveum realm add authentik
-      --type openid
-      --issuer-url https://auth.k.oneill.net/application/o/proxmox/
-      --client-id {{ proxmox_oidc_client_id }}
-      --client-key {{ proxmox_oidc_client_secret }}
-      --username-claim preferred_username
-      --autocreate 1
-      --groups-claim groups
-      --comment Authentik
-  when: not proxmox_authentik_realm_exists
-  run_once: true
-  no_log: true
-
-- name: "Update OIDC realm"
-  ansible.builtin.command:
-    cmd: >
-      pveum realm modify authentik
-      --issuer-url https://auth.k.oneill.net/application/o/proxmox/
-      --client-id {{ proxmox_oidc_client_id }}
-      --client-key {{ proxmox_oidc_client_secret }}
-      --autocreate 1
-      --comment Authentik
-  when: proxmox_authentik_realm_exists
+- name: "Configure authentication realms"
+  ansible.builtin.template:
+    src: domains.cfg.j2
+    dest: /etc/pve/domains.cfg
+    owner: root
+    group: www-data
+    mode: "0640"
   run_once: true
   no_log: true
 

--- a/ansible/roles/proxmox/templates/domains.cfg.j2
+++ b/ansible/roles/proxmox/templates/domains.cfg.j2
@@ -1,0 +1,15 @@
+pam: pam
+	comment Linux PAM standard authentication
+
+pve: pve
+	comment Proxmox VE authentication server
+
+openid: authentik
+	autocreate 1
+	client-id {{ proxmox_oidc_client_id }}
+	client-key {{ proxmox_oidc_client_secret }}
+	comment Authentik
+	default 1
+	groups-claim groups
+	issuer-url https://auth.k.oneill.net/application/o/proxmox/
+	username-claim preferred_username

--- a/ansible/roles/resticprofile/tasks/install.yaml
+++ b/ansible/roles/resticprofile/tasks/install.yaml
@@ -73,11 +73,16 @@
   when: resticprofile_install_restic
 
 - name: Extract restic
-  ansible.builtin.command: "bunzip2 {{ resticprofile_tmp_dir }}/restic.bz2"
+  ansible.builtin.command:
+    cmd: "bunzip2 {{ resticprofile_tmp_dir }}/restic.bz2"
   when: resticprofile_install_restic
 
 - name: Install restic
-  ansible.builtin.command: "install {{ resticprofile_tmp_dir }}/restic {{ resticprofile_bin_dir }}/"
+  ansible.builtin.copy:
+    src: "{{ resticprofile_tmp_dir }}/restic"
+    dest: "{{ resticprofile_bin_dir }}/restic"
+    mode: "0755"
+    remote_src: true
   when: resticprofile_install_restic
 
 # Install resticprofile
@@ -100,7 +105,11 @@
   when: resticprofile_install_resticprofile
 
 - name: Install resticprofile
-  ansible.builtin.command: "install {{ resticprofile_tmp_dir }}/resticprofile {{ resticprofile_bin_dir }}/"
+  ansible.builtin.copy:
+    src: "{{ resticprofile_tmp_dir }}/resticprofile"
+    dest: "{{ resticprofile_bin_dir }}/resticprofile"
+    mode: "0755"
+    remote_src: true
   when: resticprofile_install_resticprofile
 
 # Cleanup


### PR DESCRIPTION
- Replace dnsutils with bind9-dnsutils to fix virtual package issue on
  Debian 13 (Trixie) that caused apt module to always report changed
- Add explicit changed_when: true to proxmox OIDC update task with
  comment explaining this is intentional config sync behavior
- Use copy module instead of command for resticprofile binary installs
