### PR TITLE
Ansible idempotency improvements

### DIFF
--- a/ansible/group_vars/all/users.yaml
+++ b/ansible/group_vars/all/users.yaml
@@ -26,6 +26,7 @@ genericusers_users:
     shell: /bin/bash
     uid: 10001
     groups: [sudo, audio, video, dialout]
+    append: true
     pass: !vault |
       $ANSIBLE_VAULT;1.1;AES256
       31623865666436383432373566303765326238656334323163363735393337303064316137313761

--- a/ansible/group_vars/kubernetes.yaml
+++ b/ansible/group_vars/kubernetes.yaml
@@ -3,6 +3,25 @@ kernel_parameters: "nofb vga=normal"
 
 node_exporter_enabled: true
 
+# Override containerd config to include conf.d imports
+# Enables drop-in configs (e.g., nvidia runtime) without modifying main config
+containerd_config: |
+  imports = ["/etc/containerd/conf.d/*.toml"]
+  version = 3
+  [plugins]
+    [plugins.'io.containerd.cri.v1.runtime']
+      [plugins.'io.containerd.cri.v1.runtime'.containerd]
+        default_runtime_name = 'runc'
+        [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes]
+          [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]
+            runtime_type = 'io.containerd.runc.v2'
+            [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options]
+              BinaryName = '/usr/local/sbin/runc'
+              SystemdCgroup = true
+      [plugins.'io.containerd.cri.v1.runtime'.cni]
+        bin_dir = '/opt/cni/bin'
+        conf_dir = '/etc/cni/net.d'
+
 # Our goal is to stay one version behind
 kubernetes_short_version: "1.33"
 kubernetes_version: "1.33.5"

--- a/ansible/roles/kubeadm/tasks/main.yaml
+++ b/ansible/roles/kubeadm/tasks/main.yaml
@@ -7,6 +7,12 @@
   ansible.builtin.include_role:
     name: githubixx.containerd
 
+- name: Create containerd conf.d directory
+  ansible.builtin.file:
+    path: /etc/containerd/conf.d
+    state: directory
+    mode: "0755"
+
 - name: Include common tasks
   ansible.builtin.include_tasks: common.yaml
 - name: Include iscsi tasks

--- a/ansible/roles/kubeadm/tasks/nvidia.yaml
+++ b/ansible/roles/kubeadm/tasks/nvidia.yaml
@@ -63,29 +63,16 @@
     name: nvidia-container-toolkit
     update_cache: true
 
-- name: "Get checksum of NVIDIA containerd config before"
-  ansible.builtin.stat:
-    path: /etc/containerd/conf.d/99-nvidia.toml
-    checksum_algorithm: sha256
-  register: kubeadm_nvidia_config_before
-
-# Note: Do NOT add --cdi.enabled here - it causes vulkan device mount failures.
-# GPU passthrough works correctly via runtimeClassName: nvidia without forcing CDI mode.
 - name: "Configure containerd to use NVIDIA runtime"
-  ansible.builtin.command:
-    cmd: nvidia-ctk runtime configure --runtime=containerd
-  changed_when: false
-
-- name: "Get checksum of NVIDIA containerd config after"
-  ansible.builtin.stat:
-    path: /etc/containerd/conf.d/99-nvidia.toml
-    checksum_algorithm: sha256
-  register: kubeadm_nvidia_config_after
-
-- name: "Restart containerd if config changed"
-  ansible.builtin.debug:
-    msg: "NVIDIA containerd config changed, restarting containerd"
-  changed_when: kubeadm_nvidia_config_before.stat.checksum | default('') != kubeadm_nvidia_config_after.stat.checksum
+  ansible.builtin.copy:
+    dest: /etc/containerd/conf.d/99-nvidia.toml
+    mode: "0644"
+    content: |
+      [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia]
+        runtime_type = "io.containerd.runc.v2"
+        [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia.options]
+          BinaryName = "/usr/bin/nvidia-container-runtime"
+          SystemdCgroup = true
   notify: "Restart containerd"
 
 - name: "Ensure CDI directory exists"

--- a/ansible/roles/os-install/tasks/grml.yaml
+++ b/ansible/roles/os-install/tasks/grml.yaml
@@ -80,22 +80,16 @@
         state: absent
       failed_when: false
 
-- name: Create temporary config directory
-  ansible.builtin.tempfile:
-    state: directory
-    prefix: grml-config-
-  register: os_install_grml_tempdir
-
 - name: Create Grml config directory structure
   ansible.builtin.file:
-    path: "{{ os_install_grml_tempdir.path }}/root/.ssh"
+    path: /etc/os-install/assets/grml/config/root/.ssh
     state: directory
     mode: "0700"
 
 - name: Create Grml SSH authorized_keys
   ansible.builtin.copy:
     content: "{{ ssh_keys | join('\n') }}\n"
-    dest: "{{ os_install_grml_tempdir.path }}/root/.ssh/authorized_keys"
+    dest: /etc/os-install/assets/grml/config/root/.ssh/authorized_keys
     mode: "0600"
   register: os_install_grml_authorized_keys
 
@@ -108,11 +102,6 @@
   # Using tar directly because archive module can't set working directory (-C)
   # which is needed for correct relative paths in the tarball
   ansible.builtin.command:
-    cmd: "tar -cjf /etc/os-install/assets/grml/config.tbz -C {{ os_install_grml_tempdir.path }} ."
+    cmd: tar -cjf /etc/os-install/assets/grml/config.tbz -C /etc/os-install/assets/grml/config .
   when: os_install_grml_authorized_keys.changed or not os_install_grml_config_stat.stat.exists
   changed_when: true
-
-- name: Remove temporary config directory
-  ansible.builtin.file:
-    path: "{{ os_install_grml_tempdir.path }}"
-    state: absent


### PR DESCRIPTION
- Add append: true to coneill user to preserve existing groups
- Add containerd conf.d imports support for kubernetes nodes
- Replace nvidia-ctk runtime configure with direct drop-in config
- Use persistent directory for grml config instead of temp directory
