### PR TITLE
Increase ansible forks from 5 to 25

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -7,6 +7,7 @@ collections_path=galaxy/collections
 nocows = 1
 interpreter_python=auto_silent
 gathering = smart
+forks = 25
 
 [privilege_escalation]
 become=True


### PR DESCRIPTION
Tested with 11 hosts: 10m37s with forks=5 vs 9m41s with forks=15.
Setting to 25 provides headroom for future host additions.
