### PR TITLE
Fix Proxmox ACME certificate ordering and load balancer endpoint

### DIFF
--- a/ansible/roles/proxmox/tasks/acme.yaml
+++ b/ansible/roles/proxmox/tasks/acme.yaml
@@ -63,3 +63,16 @@
       --acmedomain0 '{{ inventory_hostname }}.{{ domain }},plugin={{ proxmox_acme_plugin_name }}'
   when: >
     (inventory_hostname + '.' + domain + ',plugin=' + proxmox_acme_plugin_name) not in proxmox_node_config.stdout
+
+- name: "Check if certificate is valid"
+  ansible.builtin.command:
+    cmd: openssl verify /etc/pve/nodes/{{ inventory_hostname }}/pve-ssl.pem
+  register: proxmox_cert_valid
+  changed_when: false
+  failed_when: false
+
+- name: "Order ACME certificate"
+  ansible.builtin.command:
+    cmd: pvenode acme cert order
+  timeout: 300
+  when: proxmox_cert_valid.rc != 0

--- a/opentofu/main.tf
+++ b/opentofu/main.tf
@@ -107,7 +107,7 @@ provider "unifi" {
 }
 
 provider "proxmox" {
-  endpoint  = "https://p9.oneill.net:8006"
+  endpoint  = "https://pve.oneill.net"
   api_token = local.proxmox_api_token
   insecure  = false
 


### PR DESCRIPTION
The Proxmox ACME role was configuring the account, plugin, and domain
but never ordering the initial certificate. This caused nodes to keep
using the Proxmox internal CA cert instead of Let's Encrypt, breaking
Traefik health checks with certificate validation errors.

- Add validation check using openssl verify
- Order ACME certificate if validation fails
- Use load-balanced pve.oneill.net endpoint instead of individual node
