### PR TITLE
Disable offline hosts in ansible inventory

### DIFF
--- a/ansible/inventory/default
+++ b/ansible/inventory/default
@@ -3,7 +3,7 @@ flux ansible_host=flux.fnord.net domain=fnord.net
 k1 ansible_host=k1.oneill.net domain=oneill.net
 k2 ansible_host=k2.oneill.net domain=oneill.net
 k3 ansible_host=k3.oneill.net domain=oneill.net
-k4 ansible_host=k4.oneill.net domain=oneill.net
+#k4 ansible_host=k4.oneill.net domain=oneill.net
 p3 ansible_host=p3.oneill.net domain=oneill.net
 #voron2 ansible_host=voron2.oneill.net domain=oneill.net
 #voron2-pizero ansible_host=voron2-pizero.oneill.net domain=oneill.net
@@ -13,15 +13,15 @@ pantrypi ansible_host=pantrypi.oneill.net domain=oneill.net
 garagepi ansible_host=garagepi.oneill.net domain=oneill.net
 infra1 ansible_host=infra1.oneill.net domain=oneill.net
 p1 ansible_host=p1.oneill.net domain=oneill.net
-p2 ansible_host=p2.oneill.net domain=oneill.net
-p4 ansible_host=p4.oneill.net domain=oneill.net
+#p2 ansible_host=p2.oneill.net domain=oneill.net
+#p4 ansible_host=p4.oneill.net domain=oneill.net
 #p9 ansible_host=p9.oneill.net domain=oneill.net
 
 [kubernetes]
 k1
 k2
 k3
-k4
+#k4
 
 [kubernetes_master]
 k1
@@ -29,15 +29,15 @@ k1
 [kubernetes_node]
 k2
 k3
-k4
+#k4
 
 [nut]
 infra1
 
 [nut_client]
-p2
+#p2
 p3
-k4
+#k4
 
 [pi]
 #voron2-pizero
@@ -52,9 +52,9 @@ garagepi
 
 [proxmox]
 p1
-p2
+#p2
 p3
-p4
+#p4
 #p9
 
 [tailscale_disabled]


### PR DESCRIPTION
Comment out p2, p4, and k4 which are temporarily offline to prevent
ansible runs from timing out.
