### PR TITLE
Cache age decryption key to avoid repeated 1Password fetches

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -14,21 +14,34 @@ PATH_add kubernetes/scripts
 PATH_add tools/recyclarr
 PATH_add tools/managarr
 
-if on_git_branch; then
-  echo && git status --short --branch &&
-  echo && git fetch --verbose
-fi
-
 # Load secrets from encrypted .secrets.age file
-# If DIRENV_AGE_KEY is not set, fetch from 1Password (requires op CLI)
+# Cache key in /tmp to avoid repeated 1Password fetches (direnv reverts exports on reload)
 if [[ -f .secrets.age ]]; then
-  if ! command -v op >/dev/null 2>&1; then
-    echo "Skipping .secrets.age: op CLI not available"
-  else
-    if [[ -z "${DIRENV_AGE_KEY:-}" ]]; then
-      echo "Fetching age decryption key from 1Password..."
-      DIRENV_AGE_KEY=$(op read "op://infra/direnv-age-key/password")
+  _age_cache="/tmp/.direnv-age-key-${USER}"
+
+  # Create cache directory with secure permissions (addresses TOCTOU concerns)
+  mkdir -p "$_age_cache" 2>/dev/null || [[ -d "$_age_cache" ]] || {
+    echo "Error: Failed to create cache directory" >&2
+    exit 1
+  }
+  chmod 700 "$_age_cache"  # Ensure permissions even if directory existed
+
+  _age_key_file="$_age_cache/key"
+
+  if [[ -f "$_age_key_file" ]]; then
+    DIRENV_AGE_KEY=$(<"$_age_key_file")
+  elif command -v op >/dev/null 2>&1; then
+    echo "Fetching age decryption key from 1Password..."
+    if DIRENV_AGE_KEY=$(op read "op://infra/direnv-age-key/password") && [[ -n "$DIRENV_AGE_KEY" ]]; then
+      (umask 077 && echo "$DIRENV_AGE_KEY" > "$_age_key_file")
+    else
+      echo "Error: Failed to fetch age decryption key from 1Password" >&2
     fi
+  else
+    echo "Skipping .secrets.age: op CLI not available and no cached key"
+  fi
+
+  if [[ -n "$DIRENV_AGE_KEY" ]]; then
     # shellcheck disable=SC1090
     source <(age -d -i <(echo "$DIRENV_AGE_KEY") .secrets.age)
   fi


### PR DESCRIPTION
Direnv reverts all exported variables before re-evaluating .envrc,
which caused the age key to be fetched from 1Password on every
shell command. Cache the key to /tmp/.direnv-age-key-$USER/ with
mode 700/600 for security.
