### PR TITLE
semaphore auto deploy

### DIFF
--- a/.github/actions/setup-argocd/action.yml
+++ b/.github/actions/setup-argocd/action.yml
@@ -5,8 +5,10 @@ description: Connect to Tailscale and ensure argocd CLI is available
 inputs:
   tailscale_oauth_client_id:
     required: true
+    description: Tailscale OAuth client ID for connecting to tailnet
   tailscale_oauth_secret:
     required: true
+    description: Tailscale OAuth client secret
 
 outputs:
   argocd_path:
@@ -17,7 +19,7 @@ runs:
   using: composite
   steps:
   - name: Connect to Tailscale
-    uses: tailscale/github-action@main
+    uses: tailscale/github-action@53acf823325fe9ca47f4cdaa951f90b4b0de5bb9  # v4.1.1
     with:
       oauth-client-id: ${{ inputs.tailscale_oauth_client_id }}
       oauth-secret: ${{ inputs.tailscale_oauth_secret }}

--- a/.github/actions/setup-semaphore/action.yml
+++ b/.github/actions/setup-semaphore/action.yml
@@ -1,0 +1,30 @@
+---
+name: Setup Semaphore environment
+description: Connect to Tailscale and configure Semaphore API access
+
+inputs:
+  tailscale_oauth_client_id:
+    required: true
+    description: Tailscale OAuth client ID for connecting to tailnet
+  tailscale_oauth_secret:
+    required: true
+    description: Tailscale OAuth client secret
+
+runs:
+  using: composite
+  steps:
+  - name: Connect to Tailscale
+    uses: tailscale/github-action@53acf823325fe9ca47f4cdaa951f90b4b0de5bb9  # v4.1.1
+    with:
+      oauth-client-id: ${{ inputs.tailscale_oauth_client_id }}
+      oauth-secret: ${{ inputs.tailscale_oauth_secret }}
+      tags: tag:github-actions
+      use-cache: true
+
+  - name: Verify Semaphore connectivity
+    shell: bash
+    run: |
+      set -euo pipefail
+      curl -sf --max-time 10 "https://semaphore.cow-banjo.ts.net/api/ping" || {
+        echo "Failed to reach Semaphore API"; exit 1
+      }

--- a/.github/workflows/ansible-production-deploy.yml
+++ b/.github/workflows/ansible-production-deploy.yml
@@ -1,0 +1,77 @@
+---
+name: Ansible Production Deployment
+
+on:
+  push:
+    branches: [main]
+    paths: [ansible/**]
+  workflow_dispatch:
+    inputs:
+      hosts:
+        description: 'Hosts to deploy (space-separated, or "all")'
+        required: false
+        default: 'all'
+      tags:
+        description: 'Ansible tags to run (comma-separated, e.g., "common,users")'
+        required: false
+        default: ''
+
+jobs:
+  ansible-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Wait for previous deployments
+      uses: softprops/turnstyle@15f9da4059166900981058ba251e0b652511c68f
+
+    - name: Checkout code
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+      with:
+        fetch-depth: 0
+
+    - name: Checkout trusted scripts
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+      with:
+        ref: main
+        path: trusted-main
+
+    - name: Detect Changed Hosts
+      id: detect
+      if: github.event_name != 'workflow_dispatch'
+      run: |
+        "${GITHUB_WORKSPACE}/trusted-main/scripts/ansible-detect-changes" \
+          --base-ref "${{ github.event.before }}" \
+          --head-ref "${{ github.sha }}"
+
+    - name: Set hosts
+      id: hosts
+      run: |
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          echo "hosts=${{ github.event.inputs.hosts || 'all' }}" >> "$GITHUB_OUTPUT"
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "hosts=${{ steps.detect.outputs.hosts }}" >> "$GITHUB_OUTPUT"
+          echo "has_changes=${{ steps.detect.outputs.has_changes }}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Setup Semaphore
+      if: steps.hosts.outputs.has_changes == 'true' && steps.hosts.outputs.hosts != ''
+      uses: ./trusted-main/.github/actions/setup-semaphore
+      with:
+        tailscale_oauth_client_id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+        tailscale_oauth_secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+
+    - name: Deploy via Semaphore
+      if: steps.hosts.outputs.has_changes == 'true' && steps.hosts.outputs.hosts != ''
+      env:
+        SEMAPHORE_API_TOKEN: ${{ secrets.SEMAPHORE_API_TOKEN }}
+        SEMAPHORE_URL: https://semaphore.cow-banjo.ts.net
+      run: |
+        TAGS_ARG=""
+        if [[ -n "${{ github.event.inputs.tags }}" ]]; then
+          TAGS_ARG="--tags ${{ github.event.inputs.tags }}"
+        fi
+        "${GITHUB_WORKSPACE}/trusted-main/scripts/semaphore-deploy" \
+          --hosts "${{ steps.hosts.outputs.hosts }}" \
+          --project "${{ vars.SEMAPHORE_PROJECT }}" \
+          --template "${{ vars.SEMAPHORE_TEMPLATE }}" \
+          $TAGS_ARG

--- a/.secrets.tmpl
+++ b/.secrets.tmpl
@@ -21,6 +21,9 @@ export RCLONE_CONFIG_B2C_PASSWORD2="{{ op://infra/resticprofile-rclone/RCLONE_CO
 export RCLONE_CONFIG_B2_ACCOUNT="{{ op://infra/resticprofile-rclone/RCLONE_CONFIG_B2_ACCOUNT }}"
 export RCLONE_CONFIG_B2_KEY="{{ op://infra/resticprofile-rclone/RCLONE_CONFIG_B2_KEY }}"
 
+# Semaphore (used by: scripts/semaphore-deploy)
+export SEMAPHORE_API_TOKEN="{{ op://infra/semaphore-api-token/password }}"
+
 # Velero/Kopia (used by: kubernetes/velero/run-kopia, run-rclone)
 export VELERO_RCLONE_CONFIG_B2_ACCOUNT="{{ op://infra/velero-b2-credentials/RCLONE_CONFIG_B2_ACCOUNT }}"
 export VELERO_RCLONE_CONFIG_B2_KEY="{{ op://infra/velero-b2-credentials/RCLONE_CONFIG_B2_KEY }}"

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
                 proxmoxer
                 pyyaml
                 ruamel-yaml
+                websocket-client
                 # ARA (Ansible Run Analysis) for recording playbook runs
                 (ps.buildPythonPackage rec {
                   pname = "ara";

--- a/kubernetes/semaphore/ansible-wrapper.sh
+++ b/kubernetes/semaphore/ansible-wrapper.sh
@@ -4,7 +4,9 @@
 
 export ANSIBLE_HOST_KEY_CHECKING=False
 export ANSIBLE_LOAD_CALLBACK_PLUGINS=1
-export ANSIBLE_STDOUT_CALLBACK=yaml
+# Use default callback with YAML output format (community.general.yaml was removed in v12)
+export ANSIBLE_STDOUT_CALLBACK=default
+export ANSIBLE_STDOUT_CALLBACK_RESULT_FORMAT=yaml
 
 # ARA (Ansible Run Analysis) configuration
 export ARA_API_CLIENT=http
@@ -38,7 +40,7 @@ fi
 if [ -n "$NIX_PYTHON" ]; then
   ARA_CALLBACK_PATH=$("$NIX_PYTHON" -c "import ara.setup; print(ara.setup.callback_plugins)" 2>&1 || true)
   if [ -n "$ARA_CALLBACK_PATH" ] && [[ "$ARA_CALLBACK_PATH" != *"Error"* ]] && [[ "$ARA_CALLBACK_PATH" != *"Traceback"* ]]; then
-    export ANSIBLE_CALLBACK_PLUGINS="$ARA_CALLBACK_PATH"
+    export ANSIBLE_CALLBACK_PLUGINS="$ARA_CALLBACK_PATH:callback_plugins"
     export ANSIBLE_CALLBACKS_ENABLED=ara_default
   fi
 

--- a/kubernetes/semaphore/kustomization.yaml
+++ b/kubernetes/semaphore/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - externalsecret-ara.yaml
 - externalsecret-encryption.yaml
 - externalsecret-oidc.yaml
+- tailscale-ingress.yaml
 - helm/configmap.yaml
 - helm/deployment.yaml
 - helm/ingress.yaml

--- a/kubernetes/semaphore/tailscale-ingress.yaml
+++ b/kubernetes/semaphore/tailscale-ingress.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+
+metadata:
+  name: semaphore-tailscale
+  namespace: semaphore
+  annotations:
+    tailscale.com/tags: tag:semaphore
+
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: semaphore
+      port:
+        number: 3000
+  tls:
+  - hosts:
+    - semaphore

--- a/opentofu/.terraform.lock.hcl
+++ b/opentofu/.terraform.lock.hcl
@@ -78,6 +78,29 @@ provider "registry.opentofu.org/bpg/proxmox" {
   ]
 }
 
+provider "registry.opentofu.org/cruglobal/semaphoreui" {
+  version     = "1.4.1"
+  constraints = "~> 1.4"
+  hashes = [
+    "h1:L8B3IagTwCpU0T+HBNN5oLJujxQWbCj1JT9icgzKVXg=",
+    "zh:0d325833a72e011c993ec3329db6fb65c7bd909120a8a158149f27bd426fd77c",
+    "zh:67b0e03c21c6ead1c68d140f7d72563cba2b85cf310c1ebe883f6dac31aa4969",
+    "zh:6f3da96ee51694cd7237c9feb45392dc0a3a1466b30c64602d946f1d662246de",
+    "zh:6fa00b55ba338d3835106151eb6492957dc793b09a4b96e093077cc36f6286f5",
+    "zh:7bb7db30fd210444cd18439744e9fb1fee3fabc19f5b52a7d9a1835671770f15",
+    "zh:81ee7d8c8541adf08ab39fdba924c78ca9dca98370243c8a584876f878202d8c",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:9045be8292b2c08994bb7838cbbe5f0185e2aa544e923c42fe5c659d1e80e370",
+    "zh:95c24e3439dba6e756f7a7c878ac8317b5f295be421ae467d32e142311563fff",
+    "zh:9d39f77141f9b8ce3c79ed87df3dd2eb9562a8468a8944ca8c374a36cc8573ba",
+    "zh:a4c6d876880f7bb365756ceff18f555bcce9b2e4f40af0043baefba048b63c75",
+    "zh:a95399bf601f8b39bda57709b43e1809d57d935f02624ba03593ba638e1969e5",
+    "zh:d1074872e55b6b120728eafb83648a0aeb8e01ef48c3321121248adb4ff1348b",
+    "zh:e70d9b70b468cbf78e354093eb3324bb89df88175ff031dccce8eb1aa0e83725",
+    "zh:ef77b7653f5083d4b78d1b3d17806322dd2fd7ffe995e8957f4a7fd7d442fd92",
+  ]
+}
+
 provider "registry.opentofu.org/filipowm/unifi" {
   version     = "1.0.0"
   constraints = "~> 1.0"

--- a/opentofu/github-repos.tf
+++ b/opentofu/github-repos.tf
@@ -24,3 +24,21 @@ resource "github_actions_secret" "infra_tailscale_oauth_client_secret" {
   secret_name     = "TAILSCALE_OAUTH_CLIENT_SECRET"
   plaintext_value = tailscale_oauth_client.github_actions.key
 }
+
+resource "github_actions_secret" "infra_semaphore_api_token" {
+  repository      = "infra"
+  secret_name     = "SEMAPHORE_API_TOKEN"
+  plaintext_value = local.semaphore_api_token
+}
+
+resource "github_actions_variable" "infra_semaphore_project" {
+  repository    = "infra"
+  variable_name = "SEMAPHORE_PROJECT"
+  value         = module.semaphore.project_name
+}
+
+resource "github_actions_variable" "infra_semaphore_template" {
+  repository    = "infra"
+  variable_name = "SEMAPHORE_TEMPLATE"
+  value         = module.semaphore.template_name
+}

--- a/opentofu/main.tf
+++ b/opentofu/main.tf
@@ -54,6 +54,10 @@ terraform {
       source  = "kristofferahl/healthchecksio"
       version = "~> 2.0"
     }
+    semaphoreui = {
+      source  = "CruGlobal/semaphoreui"
+      version = "~> 1.4"
+    }
   }
 
   backend "s3" {
@@ -149,4 +153,17 @@ provider "healthchecksio" {
   alias   = "canary"
   api_key = local.healthchecks_canary_api_key
   api_url = "https://hc.k.oneill.net/api/v1"
+}
+
+# Semaphore provider configuration
+provider "semaphoreui" {
+  hostname  = "semaphore.k.oneill.net"
+  protocol  = "https"
+  port      = 443
+  api_token = local.semaphore_api_token
+}
+
+module "semaphore" {
+  source                  = "./modules/semaphore"
+  ansible_ssh_private_key = local.semaphore_ansible_ssh_key
 }

--- a/opentofu/modules/semaphore/main.tf
+++ b/opentofu/modules/semaphore/main.tf
@@ -1,0 +1,55 @@
+# Semaphore Infra Project Management
+
+resource "semaphoreui_project" "infra" {
+  name = "Infra"
+}
+
+resource "semaphoreui_project_key" "none" {
+  project_id = semaphoreui_project.infra.id
+  name       = "None"
+  none       = {}
+}
+
+resource "semaphoreui_project_key" "ansible_ssh" {
+  project_id = semaphoreui_project.infra.id
+  name       = "ansible-ssh"
+  ssh = {
+    private_key = var.ansible_ssh_private_key
+  }
+}
+
+resource "semaphoreui_project_repository" "infra" {
+  project_id = semaphoreui_project.infra.id
+  name       = "claytono/infra"
+  url        = "https://github.com/claytono/infra"
+  branch     = "main"
+  ssh_key_id = semaphoreui_project_key.none.id
+}
+
+resource "semaphoreui_project_inventory" "default" {
+  project_id = semaphoreui_project.infra.id
+  name       = "default"
+  ssh_key_id = semaphoreui_project_key.ansible_ssh.id
+  file = {
+    path          = "ansible/inventory/default"
+    repository_id = semaphoreui_project_repository.infra.id
+  }
+}
+
+resource "semaphoreui_project_environment" "empty" {
+  project_id  = semaphoreui_project.infra.id
+  name        = "Empty"
+  environment = {}
+}
+
+resource "semaphoreui_project_template" "ansible_deploy" {
+  project_id                  = semaphoreui_project.infra.id
+  name                        = "ansible-deploy"
+  description                 = "Run site.yaml - pass --limit and --tags via CLI args"
+  playbook                    = "site.yaml"
+  repository_id               = semaphoreui_project_repository.infra.id
+  inventory_id                = semaphoreui_project_inventory.default.id
+  environment_id              = semaphoreui_project_environment.empty.id
+  app                         = "ansible"
+  allow_override_args_in_task = true
+}

--- a/opentofu/modules/semaphore/outputs.tf
+++ b/opentofu/modules/semaphore/outputs.tf
@@ -1,0 +1,9 @@
+output "project_name" {
+  description = "Semaphore project name"
+  value       = semaphoreui_project.infra.name
+}
+
+output "template_name" {
+  description = "Template name for triggering Ansible runs"
+  value       = semaphoreui_project_template.ansible_deploy.name
+}

--- a/opentofu/modules/semaphore/variables.tf
+++ b/opentofu/modules/semaphore/variables.tf
@@ -1,0 +1,5 @@
+variable "ansible_ssh_private_key" {
+  description = "Private SSH key for Ansible connections (from 1Password)"
+  type        = string
+  sensitive   = true
+}

--- a/opentofu/modules/semaphore/versions.tf
+++ b/opentofu/modules/semaphore/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    semaphoreui = {
+      source  = "CruGlobal/semaphoreui"
+      version = "~> 1.4"
+    }
+  }
+}

--- a/opentofu/secrets.tf
+++ b/opentofu/secrets.tf
@@ -144,3 +144,19 @@ locals {
   healthchecks_selfhosted_api_key = local.healthchecks_selfhosted_fields["api-key"]
   healthchecks_canary_api_key     = local.healthchecks_selfhosted_fields["canary-api-key"]
 }
+
+# Semaphore credentials from 1Password
+data "onepassword_item" "semaphore_api" {
+  vault = data.onepassword_vault.infra.uuid
+  title = "semaphore-api-token"
+}
+
+data "onepassword_item" "semaphore_ansible_ssh" {
+  vault = data.onepassword_vault.infra.uuid
+  title = "Semaphore Ansible"
+}
+
+locals {
+  semaphore_api_token       = data.onepassword_item.semaphore_api.password
+  semaphore_ansible_ssh_key = data.onepassword_item.semaphore_ansible_ssh.private_key
+}

--- a/opentofu/tailscale.tf
+++ b/opentofu/tailscale.tf
@@ -14,6 +14,7 @@ resource "tailscale_acl" "main" {
             "tag:k8s": ["tag:k8s-operator"],
             "tag:github-actions": [],
             "tag:argocd": ["tag:k8s-operator"],
+            "tag:semaphore": ["tag:k8s-operator"],
             "tag:flux": ["autogroup:admin"],
             "tag:restic": ["tag:k8s-operator"],
             "tag:healthchecks": ["tag:k8s-operator"],
@@ -53,12 +54,12 @@ resource "tailscale_acl" "main" {
                 "dst":    ["tag:healthchecks:443"],
             },
 
-            // Allow GitHub Actions to reach ArgoCD only
+            // Allow GitHub Actions to reach ArgoCD and Semaphore
             {
                 "action": "accept",
                 "src":    ["tag:github-actions"],
                 "proto":  "tcp",
-                "dst":    ["tag:argocd:443"],
+                "dst":    ["tag:argocd:443", "tag:semaphore:443"],
             },
 
             // Allow k8s operator to manage k8s nodes
@@ -123,7 +124,7 @@ resource "tailscale_acl" "main" {
 resource "tailscale_oauth_client" "k8s_operator" {
   description = "tailscale-operator"
   scopes      = ["devices:core", "auth_keys"]
-  tags        = ["tag:k8s-operator"]
+  tags        = ["tag:k8s-operator", "tag:semaphore"]
 }
 
 # Create OAuth client for GitHub Actions (ephemeral nodes)

--- a/scripts/ansible-detect-changes
+++ b/scripts/ansible-detect-changes
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ansible-detect-changes - Detect Ansible hosts affected by file changes
+# Outputs: hosts (space-separated or "all"), has_changes (true/false)
+
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$BASEDIR")"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/stdout}"
+
+BASE_REF="${1:-main}"
+HEAD_REF="${2:-HEAD}"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --base-ref) BASE_REF="$2"; shift 2 ;;
+    --head-ref) HEAD_REF="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+cd "$REPO_ROOT"
+
+changed_files=$(git diff --name-only "$BASE_REF"..."$HEAD_REF" | grep -E '^ansible/' || true)
+
+if [[ -z "$changed_files" ]]; then
+  echo "No ansible files changed"
+  echo "hosts=" >> "$GITHUB_OUTPUT"
+  echo "has_changes=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+hosts=()
+need_all=false
+
+while IFS= read -r file; do
+  case "$file" in
+    ansible/host_vars/*.yaml)
+      hostname=$(basename "$file" .yaml)
+      if [[ "$hostname" != "ansible-integration-test" ]] && \
+         grep -qE "^${hostname}[[:space:]]|^${hostname}$" ansible/inventory/default 2>/dev/null; then
+        [[ ! " ${hosts[*]:-} " =~ " ${hostname} " ]] && hosts+=("$hostname")
+      fi
+      ;;
+    *)
+      need_all=true
+      ;;
+  esac
+done <<< "$changed_files"
+
+if [[ "$need_all" == "true" ]]; then
+  echo "Detected changes requiring all hosts"
+  echo "hosts=all" >> "$GITHUB_OUTPUT"
+  echo "has_changes=true" >> "$GITHUB_OUTPUT"
+elif [[ ${#hosts[@]} -gt 0 ]]; then
+  echo "Detected hosts: ${hosts[*]}"
+  echo "hosts=${hosts[*]}" >> "$GITHUB_OUTPUT"
+  echo "has_changes=true" >> "$GITHUB_OUTPUT"
+else
+  echo "No deployable changes"
+  echo "hosts=" >> "$GITHUB_OUTPUT"
+  echo "has_changes=false" >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/semaphore-deploy
+++ b/scripts/semaphore-deploy
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""
+semaphore-deploy — Deploy Ansible via Semaphore with retries and ARA links
+
+This script triggers Semaphore tasks via API and tracks deployment status.
+
+HOW IT WORKS:
+1. Triggers Semaphore template with optional --limit and --tags CLI args
+2. Polls task status until completion
+3. Outputs ARA link after each attempt
+4. Summarizes all attempts with ARA links at the end if retries were needed
+5. Implements retry logic with linear backoff
+6. Exits with error code if deployment fails after all retries
+
+EXAMPLES:
+./semaphore-deploy --hosts all --project Infra --template ansible-deploy
+./semaphore-deploy --hosts "k1 k2" --project Infra --template ansible-deploy --tags common,users
+
+Usage: ./semaphore-deploy --hosts "host1 host2" --project NAME --template NAME [--tags TAGS]
+"""
+
+import argparse
+from datetime import datetime
+import os
+import re
+import sys
+import time
+from typing import Any, Optional
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError, URLError
+import json
+from websocket import create_connection, WebSocketConnectionClosedException, WebSocketTimeoutException
+
+SEMAPHORE_URL = os.environ.get("SEMAPHORE_URL", "https://semaphore.k.oneill.net")
+ARA_URL = "https://ara.k.oneill.net"
+
+
+class DeploymentError(Exception):
+    """Custom exception for deployment failures"""
+
+    pass
+
+
+class SemaphoreDeployer:
+    """Semaphore deployment manager with retry logic and ARA links"""
+
+    def __init__(
+        self,
+        token: str,
+        hosts: str,
+        project: str,
+        template: str,
+        tags: Optional[str] = None,
+        max_attempts: int = 3,
+    ):
+        self.token = token
+        self.hosts = hosts
+        self.project_name = project
+        self.template_name = template
+        self.tags = tags
+        self.max_attempts = max_attempts
+        self.attempts: list[dict] = []
+        self.project_id: Optional[int] = None
+        self.template_id: Optional[int] = None
+
+    def api_request(
+        self, method: str, endpoint: str, data: Optional[dict] = None
+    ) -> Any:
+        """Make an API request to Semaphore"""
+        url = f"{SEMAPHORE_URL}/api{endpoint}"
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+        body = json.dumps(data).encode("utf-8") if data else None
+        request = Request(url, data=body, headers=headers, method=method)
+
+        try:
+            with urlopen(request, timeout=30) as response:
+                response_data = response.read().decode("utf-8")
+                return json.loads(response_data) if response_data else {}
+        except HTTPError as e:
+            error_body = e.read().decode("utf-8") if e.fp else ""
+            raise DeploymentError(f"API error {e.code}: {error_body}")
+        except URLError as e:
+            raise DeploymentError(f"Connection error: {e.reason}")
+
+    def resolve_project_id(self) -> int:
+        """Resolve project name to ID via API"""
+        projects = self.api_request("GET", "/projects")
+        for project in projects:
+            if project.get("name") == self.project_name:
+                return project["id"]
+        raise DeploymentError(f"Project '{self.project_name}' not found")
+
+    def resolve_template_id(self, project_id: int) -> int:
+        """Resolve template name to ID via API"""
+        templates = self.api_request("GET", f"/project/{project_id}/templates")
+        for template in templates:
+            if template.get("name") == self.template_name:
+                return template["id"]
+        raise DeploymentError(
+            f"Template '{self.template_name}' not found in project {self.project_name}"
+        )
+
+    def resolve_ids(self) -> None:
+        """Resolve project and template names to IDs"""
+        print(f"Resolving project '{self.project_name}'...")
+        self.project_id = self.resolve_project_id()
+        print(f"  Found project ID: {self.project_id}")
+
+        print(f"Resolving template '{self.template_name}'...")
+        self.template_id = self.resolve_template_id(self.project_id)
+        print(f"  Found template ID: {self.template_id}")
+
+    def build_arguments(self) -> Optional[str]:
+        """Build CLI arguments as JSON string for the Semaphore task"""
+        args = []
+
+        # Add --limit if hosts is not "all"
+        if self.hosts != "all":
+            # Convert space-separated hosts to comma-separated
+            host_list = ",".join(self.hosts.split())
+            args.extend(["--limit", host_list])
+
+        # Add --tags if specified
+        if self.tags:
+            args.extend(["--tags", self.tags])
+
+        # Return JSON string or None if no args
+        return json.dumps(args) if args else None
+
+    def get_task_url(self, task_id: int) -> str:
+        """Get the Semaphore UI URL for a task"""
+        return f"{SEMAPHORE_URL}/project/{self.project_id}/history?t={task_id}"
+
+    def create_task(self) -> int:
+        """Create a new Semaphore task and return its ID"""
+        payload = {
+            "template_id": self.template_id,
+        }
+
+        arguments = self.build_arguments()
+        if arguments:
+            payload["arguments"] = arguments
+
+        print(f"Creating Semaphore task with payload: {json.dumps(payload)}")
+
+        response = self.api_request(
+            "POST", f"/project/{self.project_id}/tasks", payload
+        )
+
+        task_id = response.get("id")
+        if not task_id:
+            raise DeploymentError(f"No task ID in response: {response}")
+
+        task_url = self.get_task_url(task_id)
+        print(f"Created task {task_id}")
+        print(f"🔗 Semaphore Task: {task_url}")
+        return task_id
+
+    def get_task_status(self, task_id: int) -> dict:
+        """Get the current status of a task"""
+        return self.api_request("GET", f"/project/{self.project_id}/tasks/{task_id}")
+
+    def get_task_output(self, task_id: int) -> str:
+        """Get the output of a task"""
+        response = self.api_request(
+            "GET", f"/project/{self.project_id}/tasks/{task_id}/output"
+        )
+        # Response is a list of output lines
+        if isinstance(response, list):
+            return "\n".join(item.get("output", "") for item in response)
+        return str(response)
+
+    def stream_task_output_ws(self, task_id: int) -> str:
+        """Stream task output via WebSocket, return final status"""
+        ws_url = SEMAPHORE_URL.replace("https://", "wss://") + "/api/ws"
+
+        while True:
+            # Connect to WebSocket
+            try:
+                ws = create_connection(
+                    ws_url,
+                    header={"Authorization": f"Bearer {self.token}"},
+                    timeout=30,
+                )
+            except Exception as e:
+                print(f"WebSocket connection failed: {e}")
+                status = self.get_task_status(task_id).get("status", "unknown")
+                if status in ("success", "error", "stopped"):
+                    return status
+                time.sleep(5)
+                continue
+
+            # Stream messages
+            try:
+                ws.settimeout(60)
+                while True:
+                    try:
+                        message = ws.recv()
+                    except (WebSocketTimeoutException, WebSocketConnectionClosedException):
+                        status = self.get_task_status(task_id).get("status", "unknown")
+                        if status in ("success", "error", "stopped"):
+                            return status
+                        print("WebSocket interrupted - reconnecting...")
+                        break  # Reconnect
+
+                    try:
+                        data = json.loads(message)
+                    except json.JSONDecodeError:
+                        continue
+
+                    if data.get("task_id") != task_id:
+                        continue
+
+                    if data.get("type") == "log":
+                        timestamp = data.get("time", "")
+                        output = data.get("output", "")
+                        if timestamp:
+                            try:
+                                dt = datetime.fromisoformat(timestamp)
+                                print(f"  [{dt.strftime('%H:%M:%S.%f')[:-3]}] {output}")
+                            except ValueError:
+                                print(f"  > {output}")
+                        else:
+                            print(f"  > {output}")
+                    elif data.get("type") == "update":
+                        status = data.get("status")
+                        if status in ("success", "error", "stopped"):
+                            return status
+            finally:
+                ws.close()
+
+    def extract_ara_url(self, output: str) -> Optional[str]:
+        """Extract ARA playbook URL from task output"""
+        match = re.search(rf"ARA Playbook URL: ({ARA_URL}/playbooks/\d+\.html)", output)
+        return match.group(1) if match else None
+
+    def wait_for_task(self, task_id: int) -> tuple[bool, Optional[str]]:
+        """Wait for task using WebSocket streaming"""
+        print(f"Streaming output for task {task_id}...")
+
+        final_status = self.stream_task_output_ws(task_id)
+        success = final_status == "success"
+
+        # Fetch full output for ARA extraction
+        output = self.get_task_output(task_id)
+        ara_url = self.extract_ara_url(output)
+
+        if success:
+            print(f"✅ Task {task_id} completed successfully")
+        else:
+            print(f"❌ Task {task_id} failed with status: {final_status}")
+
+        return success, ara_url
+
+    def deploy_single_attempt(self) -> tuple[bool, Optional[str], str, int]:
+        """Run a single deployment attempt. Returns (success, ara_url, task_url, task_id)"""
+        task_id = self.create_task()
+        task_url = self.get_task_url(task_id)
+        success, ara_url = self.wait_for_task(task_id)
+
+        if ara_url:
+            print(f"📊 ARA Report: {ara_url}")
+        else:
+            print("📊 ARA Report: Not found in output")
+
+        return success, ara_url, task_url, task_id
+
+    def deploy_with_retries(self) -> bool:
+        """Deploy with retry logic"""
+        for attempt in range(1, self.max_attempts + 1):
+            print(f"\n--- Deployment attempt {attempt}/{self.max_attempts} ---")
+
+            start_time = time.time()
+            success, ara_url, task_url, task_id = self.deploy_single_attempt()
+            elapsed = time.time() - start_time
+
+            self.attempts.append({
+                "attempt": attempt,
+                "task_id": task_id,
+                "task_url": task_url,
+                "success": success,
+                "ara_url": ara_url,
+            })
+
+            if success:
+                if attempt > 1:
+                    print(f"✅ Deployment succeeded on attempt {attempt}/{self.max_attempts}")
+                return True
+
+            if attempt < self.max_attempts:
+                if elapsed < 10:
+                    print(f"❌ Attempt {attempt} failed after {elapsed:.0f}s. Retrying in 10s...")
+                    time.sleep(10)
+                else:
+                    print(f"❌ Attempt {attempt} failed after {elapsed:.0f}s. Retrying immediately...")
+
+        print(f"❌ All {self.max_attempts} attempts failed")
+        return False
+
+    def write_summary(self) -> None:
+        """Write deployment summary to console and GitHub Actions job summary"""
+        if not self.attempts:
+            return
+
+        last = self.attempts[-1]
+        status = "✅ Success" if last["success"] else "❌ Failed"
+
+        lines = [
+            "## Deployment Summary",
+            f"**Status:** {status}",
+            f"**Hosts:** {self.hosts}",
+        ]
+
+        if len(self.attempts) == 1:
+            lines.append(f"**Semaphore:** {last['task_url']}")
+            if last["ara_url"]:
+                lines.append(f"**ARA:** {last['ara_url']}")
+        else:
+            lines.append("**Attempts:**")
+            for a in self.attempts:
+                s = "✅" if a["success"] else "❌"
+                lines.append(f"- {s} Attempt {a['attempt']}: {a['task_url']}")
+                if a["ara_url"]:
+                    lines.append(f"  - ARA: {a['ara_url']}")
+
+        summary = "\n".join(lines)
+
+        # Print to console
+        print(f"\n{summary}")
+
+        # Write to GitHub Actions job summary if available
+        summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_file:
+            try:
+                with open(summary_file, "a") as f:
+                    f.write(summary + "\n")
+            except OSError as e:
+                print(f"Warning: Failed to write GitHub summary: {e}")
+
+    def deploy(self) -> None:
+        """Main deployment entry point"""
+        print(f"Starting Ansible deployment via Semaphore")
+        print(f"  Hosts: {self.hosts}")
+        print(f"  Project: {self.project_name}")
+        print(f"  Template: {self.template_name}")
+        if self.tags:
+            print(f"  Tags: {self.tags}")
+
+        self.resolve_ids()
+
+        success = self.deploy_with_retries()
+        self.write_summary()
+
+        if not success:
+            sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Deploy Ansible via Semaphore API",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    parser.add_argument(
+        "--hosts",
+        required=True,
+        help='Hosts to deploy (space-separated, or "all")',
+    )
+    parser.add_argument(
+        "--project",
+        required=True,
+        help="Semaphore project name",
+    )
+    parser.add_argument(
+        "--template",
+        required=True,
+        help="Semaphore template name",
+    )
+    parser.add_argument(
+        "--tags",
+        help="Ansible tags to run (comma-separated)",
+    )
+    parser.add_argument(
+        "--max-attempts",
+        type=int,
+        default=3,
+        help="Maximum deployment attempts (default: 3)",
+    )
+
+    args = parser.parse_args()
+
+    token = os.environ.get("SEMAPHORE_API_TOKEN")
+    if not token:
+        raise DeploymentError("SEMAPHORE_API_TOKEN environment variable is required")
+
+    deployer = SemaphoreDeployer(
+        token=token,
+        hosts=args.hosts,
+        project=args.project,
+        template=args.template,
+        tags=args.tags,
+        max_attempts=args.max_attempts,
+    )
+
+    deployer.deploy()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Automatically deploy Ansible changes via Semaphore when merged to main,
mirroring the ArgoCD pattern for Kubernetes deployments.

- OpenTofu module for Semaphore resources (project, keys, repo, inventory,
  environment, template)
- GitHub Actions workflow triggered on ansible/** changes
- Smart detection: host_vars changes target specific hosts, other changes
  run against all hosts
- Real-time log streaming from Semaphore tasks
- Deployment summary with Semaphore and ARA links
- ARA callback plugin improvements for reliable URL reporting