### PR TITLE
Remove static luser DNS records managed by ddns-route53

### DIFF
--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -2,11 +2,15 @@
 #
 # infrastructure_hosts defines all infrastructure machines with static IPs.
 # This data structure is consumed by both:
-# - unifi_user resources (DHCP reservations)
-# - aws_route53_record resources (DNS A records)
+# - unifi_user resources (DHCP reservations with internal DNS)
+# - aws_route53_record resources (public DNS A records)
 #
 # This ensures UniFi DHCP and Route53 DNS stay automatically in sync.
 # To add a new host, simply add an entry here and run `opentofu apply`.
+#
+# Optional field: public_dns (default: true)
+# - Set to false to skip creating a public Route53 record
+# - Internal DNS via UniFi is still created
 #
 # Proxmox VE hosts IP plan: 172.19.74.4x (p1=.41, p2=.42, p3=.43, etc.)
 
@@ -88,10 +92,11 @@ locals {
       note     = "Kubernetes worker node (VM)"
     }
     luser = {
-      mac      = "52:54:72:19:74:61"
-      ip       = "172.19.74.161"
-      hostname = "luser.oneill.net"
-      note     = "General purpose VM"
+      mac        = "52:54:72:19:74:61"
+      ip         = "172.19.74.161"
+      hostname   = "luser.oneill.net"
+      note       = "General purpose VM"
+      public_dns = false
     }
     # Other infrastructure
     fs2 = {

--- a/opentofu/modules/dns/fnord.tf
+++ b/opentofu/modules/dns/fnord.tf
@@ -59,14 +59,6 @@ resource "aws_route53_record" "lucy" {
   records = ["lucy.allakhazam.com."]
 }
 
-resource "aws_route53_record" "luser" {
-  zone_id = aws_route53_zone.fnord_net.zone_id
-  name    = "luser.fnord.net"
-  type    = "A"
-  ttl     = 300
-  records = ["173.73.171.201"]
-}
-
 resource "aws_route53_record" "ns1_a" {
   zone_id = aws_route53_zone.fnord_net.zone_id
   name    = "ns1.fnord.net"

--- a/opentofu/modules/dns/oneill.tf
+++ b/opentofu/modules/dns/oneill.tf
@@ -125,14 +125,6 @@ resource "aws_route53_record" "k_subdomain_ns" {
   records = aws_route53_zone.k_oneill_net.name_servers
 }
 
-resource "aws_route53_record" "oneill_luser" {
-  zone_id = aws_route53_zone.oneill_net.zone_id
-  name    = "luser.oneill.net"
-  type    = "A"
-  ttl     = 300
-  records = ["173.73.171.201"]
-}
-
 resource "aws_route53_record" "router" {
   zone_id = aws_route53_zone.oneill_net.zone_id
   name    = "router.oneill.net"
@@ -144,9 +136,10 @@ resource "aws_route53_record" "router" {
 # Infrastructure hosts - automatically synced with UniFi DHCP reservations
 # Host definitions are in ../../locals.tf (infrastructure_hosts) and shared
 # with unifi_user resources to ensure DNS and DHCP stay automatically in sync.
+# Only creates Route53 records for hosts with public_dns=true (defaults to true)
 
 resource "aws_route53_record" "infrastructure_hosts" {
-  for_each = var.infrastructure_hosts
+  for_each = { for k, v in var.infrastructure_hosts : k => v if v.public_dns }
 
   zone_id = aws_route53_zone.oneill_net.zone_id
   name    = each.value.hostname

--- a/opentofu/modules/dns/variables.tf
+++ b/opentofu/modules/dns/variables.tf
@@ -3,9 +3,10 @@
 variable "infrastructure_hosts" {
   description = "Map of infrastructure hosts with their network configuration"
   type = map(object({
-    mac      = string
-    ip       = string
-    hostname = string
-    note     = string
+    mac        = string
+    ip         = string
+    hostname   = string
+    note       = string
+    public_dns = optional(bool, true)
   }))
 }


### PR DESCRIPTION
- Remove explicit luser.oneill.net and luser.fnord.net A records
- Add optional public_dns field to infrastructure_hosts
- Set public_dns=false for luser to prevent Route53 record creation
- ddns-route53 Kubernetes service now exclusively manages these records
