### PR TITLE
Use separate display URL for Semaphore task links

### DIFF
--- a/.github/workflows/ansible-production-deploy.yml
+++ b/.github/workflows/ansible-production-deploy.yml
@@ -78,6 +78,7 @@ jobs:
       env:
         SEMAPHORE_API_TOKEN: ${{ secrets.SEMAPHORE_API_TOKEN }}
         SEMAPHORE_URL: https://semaphore.cow-banjo.ts.net
+        SEMAPHORE_DISPLAY_URL: https://semaphore.k.oneill.net
       run: |
         TAGS_ARG=""
         if [[ -n "${{ github.event.inputs.tags }}" ]]; then

--- a/scripts/semaphore-deploy
+++ b/scripts/semaphore-deploy
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python3
 """
 semaphore-deploy — Deploy Ansible via Semaphore with retries and ARA links
@@ -32,6 +33,7 @@ import json
 from websocket import create_connection, WebSocketConnectionClosedException, WebSocketTimeoutException
 
 SEMAPHORE_URL = os.environ.get("SEMAPHORE_URL", "https://semaphore.k.oneill.net")
+SEMAPHORE_DISPLAY_URL = os.environ.get("SEMAPHORE_DISPLAY_URL", SEMAPHORE_URL)
 ARA_URL = "https://ara.k.oneill.net"
 
 
@@ -134,7 +136,7 @@ class SemaphoreDeployer:
 
     def get_task_url(self, task_id: int) -> str:
         """Get the Semaphore UI URL for a task"""
-        return f"{SEMAPHORE_URL}/project/{self.project_id}/history?t={task_id}"
+        return f"{SEMAPHORE_DISPLAY_URL}/project/{self.project_id}/history?t={task_id}"
 
     def create_task(self) -> int:
         """Create a new Semaphore task and return its ID"""


### PR DESCRIPTION
SEMAPHORE_URL is used for API access (Tailscale), while
SEMAPHORE_DISPLAY_URL is used for generating user-facing links
that work on the public network.
