### PR TITLE
Add detect-hosts composite action for Ansible deploys

### DIFF
--- a/.github/actions/detect-hosts/action.yml
+++ b/.github/actions/detect-hosts/action.yml
@@ -1,0 +1,53 @@
+---
+name: Detect Ansible hosts from changes
+description: Outputs host names that changed between two refs
+
+inputs:
+  base_ref:
+    required: false
+    description: Git ref or SHA to diff from (if empty, returns all hosts)
+  head_ref:
+    required: false
+    description: Git ref or SHA to diff to (if empty, returns all hosts)
+
+outputs:
+  hosts:
+    description: Space-separated list of host names, or "all"
+    value: ${{ steps.collect.outputs.hosts }}
+  has_changes:
+    description: Whether any deployable changes were detected
+    value: ${{ steps.collect.outputs.has_changes }}
+
+runs:
+  using: composite
+  steps:
+  - name: Fetch refs (if provided)
+    shell: bash
+    run: |
+      set -euo pipefail
+      if [[ -n "${{ inputs.base_ref }}" ]]; then
+        git fetch --no-tags --prune origin "+${{ inputs.base_ref }}" || true
+      fi
+      if [[ -n "${{ inputs.head_ref }}" ]]; then
+        git fetch --no-tags --prune origin "+${{ inputs.head_ref }}" || true
+      fi
+
+  - name: Collect hosts
+    id: collect
+    shell: bash
+    run: |
+      set -euo pipefail
+      base='${{ inputs.base_ref }}'
+      head='${{ inputs.head_ref }}'
+      if [[ -z "$base" || -z "$head" ]]; then
+        # No refs provided - deploy all hosts (for workflow_dispatch or similar)
+        echo "No refs provided - targeting all hosts"
+        echo "hosts=all" >> "$GITHUB_OUTPUT"
+        echo "has_changes=true" >> "$GITHUB_OUTPUT"
+      else
+        # Use the ansible-detect-changes script for change detection
+        "${GITHUB_WORKSPACE}/trusted-main/scripts/ansible-detect-changes" \
+          --base-ref "$base" \
+          --head-ref "$head" \
+          --scan-root "${GITHUB_WORKSPACE}"
+      fi

--- a/.github/workflows/ansible-production-deploy.yml
+++ b/.github/workflows/ansible-production-deploy.yml
@@ -36,17 +36,16 @@ jobs:
 
     - name: Detect Changed Hosts
       id: detect
-      if: github.event_name != 'workflow_dispatch'
-      run: |
-        "${GITHUB_WORKSPACE}/trusted-main/scripts/ansible-detect-changes" \
-          --base-ref "${{ github.event.before }}" \
-          --head-ref "${{ github.sha }}"
+      uses: ./trusted-main/.github/actions/detect-hosts
+      with:
+        base_ref: ${{ github.event_name == 'workflow_dispatch' && '' || github.event.before }}
+        head_ref: ${{ github.event_name == 'workflow_dispatch' && '' || github.sha }}
 
-    - name: Set hosts
+    - name: Override hosts for workflow_dispatch
       id: hosts
       run: |
-        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-          echo "hosts=${{ github.event.inputs.hosts || 'all' }}" >> "$GITHUB_OUTPUT"
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.hosts }}" ]]; then
+          echo "hosts=${{ github.event.inputs.hosts }}" >> "$GITHUB_OUTPUT"
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "hosts=${{ steps.detect.outputs.hosts }}" >> "$GITHUB_OUTPUT"

--- a/scripts/ansible-detect-changes
+++ b/scripts/ansible-detect-changes
@@ -8,19 +8,24 @@ BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$BASEDIR")"
 GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/stdout}"
 
-BASE_REF="${1:-main}"
-HEAD_REF="${2:-HEAD}"
+# Default values
+BASE_REF="main"
+HEAD_REF="HEAD"
+SCAN_ROOT=""
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
   case $1 in
     --base-ref) BASE_REF="$2"; shift 2 ;;
     --head-ref) HEAD_REF="$2"; shift 2 ;;
+    --scan-root) SCAN_ROOT="$2"; shift 2 ;;
     *) shift ;;
   esac
 done
 
-cd "$REPO_ROOT"
+# Use scan root if provided, otherwise use auto-detected repo root
+EFFECTIVE_ROOT="${SCAN_ROOT:-$REPO_ROOT}"
+cd "$EFFECTIVE_ROOT"
 
 changed_files=$(git diff --name-only "$BASE_REF"..."$HEAD_REF" | grep -E '^ansible/' || true)
 


### PR DESCRIPTION
Aligns with ArgoCD pattern:
- Composite action fetches refs explicitly
- Passes --scan-root to script for correct working directory
- Script uses EFFECTIVE_ROOT like argocd-detect-apps
