### PR TITLE
Fix Proxmox ACME certificate check

### DIFF
--- a/ansible/roles/proxmox/tasks/acme.yaml
+++ b/ansible/roles/proxmox/tasks/acme.yaml
@@ -64,15 +64,14 @@
   when: >
     (inventory_hostname + '.' + domain + ',plugin=' + proxmox_acme_plugin_name) not in proxmox_node_config.stdout
 
-- name: "Check if certificate is valid"
-  ansible.builtin.command:
-    cmd: openssl verify /etc/pve/nodes/{{ inventory_hostname }}/pve-ssl.pem
-  register: proxmox_cert_valid
-  changed_when: false
+- name: "Get ACME certificate info"
+  community.crypto.x509_certificate_info:
+    path: /etc/pve/nodes/{{ inventory_hostname }}/pveproxy-ssl.pem
+  register: proxmox_cert_info
   failed_when: false
 
 - name: "Order ACME certificate"
   ansible.builtin.command:
     cmd: pvenode acme cert order
   timeout: 300
-  when: proxmox_cert_valid.rc != 0
+  when: proxmox_cert_info.issuer.organizationName | default('') != "Let's Encrypt"


### PR DESCRIPTION
The ACME task was checking pve-ssl.pem (Proxmox internal CA cert) instead
of pveproxy-ssl.pem (the ACME-managed web UI cert). Additionally, openssl
verify failed on valid LE certs due to chain verification issues.

Switch to community.crypto.x509_certificate_info module to check if
pveproxy-ssl.pem exists and is issued by Let's Encrypt.
