### PR TITLE
Fix Docker digest automerge for kubernetes manager

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -211,7 +211,8 @@
         "digest"
       ],
       "matchManagers": [
-        "kustomize"
+        "kustomize",
+        "kubernetes"
       ],
       "minimumReleaseAge": "0 days",
       "automerge": true,


### PR DESCRIPTION
The automerge rule for Docker digest updates only matched the kustomize
manager, but images in kubernetes/*/deploy.yaml files are detected by
the kubernetes manager. Added kubernetes to the matchManagers list.
