### PR TITLE
Remove fix-cache-permissions initContainer from restic cronjob

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -27,7 +27,8 @@
       "/kubernetes/.+\\.yaml$/"
     ],
     "ignorePaths": [
-      "kubernetes/**/helm/**"
+      "kubernetes/**/helm/**",
+      "kubernetes/restic/cronjobs/**"
     ]
   },
   "customManagers": [

--- a/kubernetes/restic/cronjobs/cronjob-b2.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-b2.yaml
@@ -23,13 +23,6 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
-          initContainers:
-          - name: fix-cache-permissions
-            image: alpine@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
-            command: [sh, -c, chown -R 10007:10007 /cache]
-            volumeMounts:
-            - mountPath: /cache
-              name: cache
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/kustomization.yaml
+++ b/kubernetes/restic/kustomization.yaml
@@ -28,8 +28,6 @@ configMapGenerator:
     disableNameSuffixHash: true
 
 images:
-- name: alpine
-  newTag: 3.23@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
 - name: creativeprojects/resticprofile
   newTag: 0.32.0@sha256:4baba839e9845679a7a072d7961d9156919a06f58afe69bc36b3b41e2966690b
 


### PR DESCRIPTION
- Remove alpine initContainer from cronjob-b2.yaml
- Remove unused alpine image from kustomization.yaml
- Add kubernetes/restic/cronjobs/** to renovate ignorePaths

Closes infra-56d
