### PR TITLE
Restore SSH key mount for Home Assistant szamar integration

### DIFF
--- a/kubernetes/hass/hass-externalsecrets.yaml
+++ b/kubernetes/hass/hass-externalsecrets.yaml
@@ -46,6 +46,27 @@ apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 
 metadata:
+  name: hass-ssh-key
+
+spec:
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  target:
+    name: hass-ssh-key
+    template:
+      type: kubernetes.io/ssh-auth
+  data:
+  - secretKey: ssh-privatekey
+    remoteRef:
+      key: hass-ssh-key
+      property: private key
+
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
   name: hass-caseta-certificates
 
 spec:

--- a/kubernetes/hass/helm/statefulset.yaml
+++ b/kubernetes/hass/helm/statefulset.yaml
@@ -66,6 +66,9 @@ spec:
           volumeMounts:
           - mountPath: /config
             name: hass-home-assistant
+          - mountPath: /root/.ssh
+            name: ssh-key
+            readOnly: true
       initContainers:
         - command:
           - sh
@@ -104,6 +107,13 @@ spec:
                 mode: 384
                 path: caseta.key
               name: hass-caseta-certificates
+      - name: ssh-key
+        secret:
+          defaultMode: 256
+          items:
+          - key: ssh-privatekey
+            path: id_ed25519
+          secretName: hass-ssh-key
   volumeClaimTemplates:
   - metadata:
       name: hass-home-assistant

--- a/kubernetes/hass/values.yaml
+++ b/kubernetes/hass/values.yaml
@@ -78,6 +78,19 @@ additionalVolumes:
         - key: caseta.key
           path: caseta.key
           mode: 384
+- name: ssh-key
+  secret:
+    secretName: hass-ssh-key
+    defaultMode: 256
+    items:
+    - key: ssh-privatekey
+      path: id_ed25519
+
+# Mount SSH key for szamar integration
+additionalMounts:
+- name: ssh-key
+  mountPath: /root/.ssh
+  readOnly: true
 
 # Pod annotations for Reloader
 podAnnotations:


### PR DESCRIPTION
The SSH key mount was lost during the Helm chart migration (d7e35e2c).
This caused the SSH integration for szamar to fail with "Disconnected"
status since the key at /root/.ssh/id_ed25519 was in ephemeral storage.

- Add ExternalSecret to pull SSH key from 1Password
- Add volume and mount configuration in Helm values
- Re-render statefulset with SSH key volume
