### PR TITLE
Add generic Renovate regex manager for Docker images

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -67,39 +67,16 @@
     },
     {
       "customType": "regex",
+      "description": "Docker images with comment annotations (generic)",
       "managerFilePatterns": [
-        "ansible/roles/rtl433/defaults/main.yaml"
+        "ansible/**/*.yaml",
+        "ansible/**/*.yml"
       ],
       "matchStrings": [
-        "rtl433_image_tag:\\s*\"(?<currentValue>[^@\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?\""
+        "#\\s*renovate:\\s*datasource=docker\\s*\\n(?<prefix>\\s*[a-z0-9_]+:\\s*\"?)(?<depName>[^:\"\\s]+):(?<currentValue>[^@\"\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?(?<suffix>\"?)"
       ],
-      "depNameTemplate": "hertzg/rtl_433",
       "datasourceTemplate": "docker",
-      "autoReplaceStringTemplate": "rtl433_image_tag: \"{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}\""
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "ansible/roles/zwavejs/defaults/main.yaml"
-      ],
-      "matchStrings": [
-        "zwavejs_image_tag:\\s*\"(?<currentValue>[^@\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?\""
-      ],
-      "depNameTemplate": "zwavejs/zwave-js-ui",
-      "datasourceTemplate": "docker",
-      "autoReplaceStringTemplate": "zwavejs_image_tag: \"{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}\""
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "ansible/roles/zigbee2mqtt/defaults/main.yaml"
-      ],
-      "matchStrings": [
-        "zigbee2mqtt_image_tag:\\s*\"(?<currentValue>[^@\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?\""
-      ],
-      "depNameTemplate": "koenkk/zigbee2mqtt",
-      "datasourceTemplate": "docker",
-      "autoReplaceStringTemplate": "zigbee2mqtt_image_tag: \"{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}\""
+      "autoReplaceStringTemplate": "# renovate: datasource=docker\n{{{prefix}}}{{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}{{{suffix}}}"
     },
     {
       "customType": "regex",

--- a/ansible/roles/nut/files/docker-compose.yaml
+++ b/ansible/roles/nut/files/docker-compose.yaml
@@ -1,6 +1,7 @@
 ---
 services:
   nut_webgui:
+    # renovate: datasource=docker
     image: ghcr.io/superioone/nut_webgui:0.7.1@sha256:244eec023bc3b47771819638f743d2030e838b96f6f9b6a51f1ff17a8e71e353
     restart: unless-stopped
     env_file:

--- a/ansible/roles/os-install/files/docker-compose.yaml
+++ b/ansible/roles/os-install/files/docker-compose.yaml
@@ -1,6 +1,7 @@
 ---
 services:
   dnsmasq:
+    # renovate: datasource=docker
     image: dockurr/dnsmasq:2.91@sha256:7873ce2dae1b0aa51d2c13dd4bd3aad47890c233088b3c7f6eb099a01e6e4307
     restart: unless-stopped
     cap_add:
@@ -11,6 +12,7 @@ services:
       - /etc/os-install/assets:/tftpboot:ro
 
   nginx:
+    # renovate: datasource=docker
     image: nginx:1.29-alpine@sha256:8491795299c8e739b7fcc6285d531d9812ce2666e07bd3dd8db00020ad132295
     restart: unless-stopped
     ports:
@@ -30,6 +32,7 @@ services:
       - traefik
 
   proxmox-answer:
+    # renovate: datasource=docker
     image: slothcroissant/proxmox-auto-installer-server:0.3.2@sha256:0f45d7bfe6e3cc76aa00fc578e40b80b9054e377db18a79122866fe5522bc7ed
     restart: unless-stopped
     volumes:

--- a/ansible/roles/rtl433/defaults/main.yaml
+++ b/ansible/roles/rtl433/defaults/main.yaml
@@ -1,6 +1,4 @@
 ---
-rtl433_image_tag: "25.12@sha256:c85d62f16205fdbdeb398ee464c66897854805f4aa6738876c9f2ba0874a70e0"
-
 # Where to deploy the docker-compose stack
 rtl433_install_dir: /etc/rtl433
 

--- a/ansible/roles/rtl433/files/docker-compose.yaml
+++ b/ansible/roles/rtl433/files/docker-compose.yaml
@@ -1,7 +1,8 @@
 services:
   rtl_433:
     container_name: rtl_433
-    image: hertzg/rtl_433:{{ rtl433_image_tag }}
+    # renovate: datasource=docker
+    image: hertzg/rtl_433:25.12@sha256:c85d62f16205fdbdeb398ee464c66897854805f4aa6738876c9f2ba0874a70e0
     restart: unless-stopped
     devices:
       - /dev/bus/usb:/dev/bus/usb

--- a/ansible/roles/rtl433/tasks/main.yaml
+++ b/ansible/roles/rtl433/tasks/main.yaml
@@ -8,8 +8,8 @@
     group: root
 
 - name: Deploy docker-compose.yaml
-  ansible.builtin.template:
-    src: docker-compose.yaml.j2
+  ansible.builtin.copy:
+    src: docker-compose.yaml
     dest: "{{ rtl433_install_dir }}/docker-compose.yaml"
     mode: "0644"
     owner: root

--- a/ansible/roles/traefik/files/docker-compose.yml
+++ b/ansible/roles/traefik/files/docker-compose.yml
@@ -1,6 +1,7 @@
 ---
 services:
   traefik:
+    # renovate: datasource=docker
     image: traefik:v3.6.4@sha256:c5bd185c41ba3dbb42cf8a1b9fbdc368bdc96f90c8e598134879935f64e7a7f1
     restart: unless-stopped
     ports:

--- a/ansible/roles/zigbee2mqtt/defaults/main.yaml
+++ b/ansible/roles/zigbee2mqtt/defaults/main.yaml
@@ -1,5 +1,6 @@
 ---
-zigbee2mqtt_image_tag: "2.7.1@sha256:163e7351430a95d550d5b1bb958527edc1eff115eb013ca627f3545a192e853f"
+# renovate: datasource=docker
+zigbee2mqtt_image: "koenkk/zigbee2mqtt:2.7.1@sha256:163e7351430a95d550d5b1bb958527edc1eff115eb013ca627f3545a192e853f"
 zigbee2mqtt_data_dir: /etc/zigbee2mqtt
 zigbee2mqtt_device: /dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_621e38fda096ed118be4c498a7669f5d-if00-port0
 zigbee2mqtt_hostname: zigbee2mqtt.oneill.net

--- a/ansible/roles/zigbee2mqtt/templates/docker-compose.yaml.j2
+++ b/ansible/roles/zigbee2mqtt/templates/docker-compose.yaml.j2
@@ -1,7 +1,7 @@
 ---
 services:
   zigbee2mqtt:
-    image: koenkk/zigbee2mqtt:{{ zigbee2mqtt_image_tag }}
+    image: {{ zigbee2mqtt_image }}
     container_name: zigbee2mqtt
     restart: unless-stopped
     devices:

--- a/ansible/roles/zwavejs/defaults/main.yaml
+++ b/ansible/roles/zwavejs/defaults/main.yaml
@@ -1,5 +1,6 @@
 ---
-zwavejs_image_tag: "11.9.1@sha256:a7036e59a9d7916d1f92f2fa1e0b9f4a5ed317fc8bef38756368f7c865e0e95a"
+# renovate: datasource=docker
+zwavejs_image: "zwavejs/zwave-js-ui:11.9.1@sha256:a7036e59a9d7916d1f92f2fa1e0b9f4a5ed317fc8bef38756368f7c865e0e95a"
 zwavejs_data_dir: /etc/zwavejs
 zwavejs_device: /dev/serial/by-id/usb-Silicon_Labs_Zooz_ZST10_700_Z-Wave_Stick_26b0d03ffcc9ec1191cf65a341be1031-if00-port0
 zwavejs_hostname: zwavejs.oneill.net

--- a/ansible/roles/zwavejs/templates/docker-compose.yaml.j2
+++ b/ansible/roles/zwavejs/templates/docker-compose.yaml.j2
@@ -1,7 +1,7 @@
 ---
 services:
   zwave-js:
-    image: zwavejs/zwave-js-ui:{{ zwavejs_image_tag }}
+    image: {{ zwavejs_image }}
     container_name: zwavejs
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
Replace 3 hardcoded per-image managers with a single generic regex
manager that uses comment annotations (`# renovate: datasource=docker`).

Changes:
- Add generic regex manager matching ansible/**/*.yaml and *.yml
- Convert rtl433 role from template to static docker-compose file
- Update zwavejs and zigbee2mqtt roles to use full image format
- Add annotations to static docker-compose files (traefik, nut, os-install)
- Remove old rtl433/zwavejs/zigbee2mqtt specific managers
