### PR TITLE
Fix Renovate autoReplaceStringTemplate newline escaping

### DIFF
--- a/.claude/rules/tooling/renovate.md
+++ b/.claude/rules/tooling/renovate.md
@@ -1,0 +1,44 @@
+# Renovate Configuration
+
+## Testing Changes
+
+When modifying `.renovaterc`, always test with the local dry-run script before committing:
+
+```bash
+scripts/renovate-dryrun full
+```
+
+Modes:
+- `full` - Full dry-run including branch/PR simulation (default)
+- `extract` - Only extract dependencies
+- `lookup` - Extract and lookup new versions
+
+The script automatically checks for critical errors and exits non-zero if found. Log file: `.tmp/renovate/dryrun.log`
+
+## Key Constraints
+
+Renovate uses **RE2 regex engine** which does NOT support:
+- Lookbehind assertions (`(?<=...)`)
+- Lookahead assertions (`(?=...)`)
+- Backreferences
+
+## autoReplaceStringTemplate Newlines
+
+To include newlines in `autoReplaceStringTemplate`, use `\\n` in JSON (double-escaped):
+
+```json
+"autoReplaceStringTemplate": "# comment\\n{{{prefix}}}{{{depName}}}"
+```
+
+The template engine interprets `\n` as a newline escape, so JSON's `\n` (single escape) becomes empty. Double-escape to pass literal `\n` to the template engine.
+
+## Docker Image Annotations
+
+Use comment annotations for Docker images in Ansible:
+
+```yaml
+# renovate: datasource=docker
+variable_name: "image:tag@sha256:digest"
+```
+
+The generic regex manager in `.renovaterc` handles these automatically.

--- a/.renovaterc
+++ b/.renovaterc
@@ -76,7 +76,7 @@
         "#\\s*renovate:\\s*datasource=docker\\s*\\n(?<prefix>\\s*[a-z0-9_]+:\\s*\"?)(?<depName>[^:\"\\s]+):(?<currentValue>[^@\"\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?(?<suffix>\"?)"
       ],
       "datasourceTemplate": "docker",
-      "autoReplaceStringTemplate": "# renovate: datasource=docker\n{{{prefix}}}{{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}{{{suffix}}}"
+      "autoReplaceStringTemplate": "# renovate: datasource=docker\\n{{{prefix}}}{{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}{{{suffix}}}"
     },
     {
       "customType": "regex",

--- a/scripts/renovate-dryrun
+++ b/scripts/renovate-dryrun
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Run Renovate locally in dry-run mode for testing config changes
+# Usage: renovate-dryrun [full|extract|lookup]
+#   full    - Full dry-run including branch/PR creation simulation (default)
+#   extract - Only extract dependencies
+#   lookup  - Extract and lookup new versions
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+MODE="${1:-full}"
+LOGDIR="$REPO_ROOT/.tmp/renovate"
+mkdir -p "$LOGDIR"
+LOGFILE="$LOGDIR/dryrun.log"
+
+echo "Running Renovate dry-run (mode: $MODE)..."
+echo "Log file: $LOGFILE"
+
+docker run --rm \
+  -v "$REPO_ROOT:/usr/src/app" \
+  -e LOG_LEVEL=debug \
+  renovate/renovate:latest \
+  --platform=local \
+  --dry-run="$MODE" 2>&1 | tee "$LOGFILE"
+
+echo ""
+echo "=== Checking for critical errors ==="
+
+# Critical error patterns that indicate config or runtime failures
+ERRORS=$(grep -E \
+  "^ *(ERROR|FATAL):|config-validation|Invalid regExp|invalid perl operator|Could not extract.*after autoreplace|Error updating branch|update failure" \
+  "$LOGFILE" 2>/dev/null || true)
+
+if [[ -n "$ERRORS" ]]; then
+  echo "CRITICAL ERRORS FOUND:"
+  echo "$ERRORS"
+  exit 1
+else
+  echo "No critical errors found."
+  # Show warnings for awareness
+  WARNINGS=$(grep -E "^ *WARN:" "$LOGFILE" 2>/dev/null | grep -v "schedule\|internalChecksFilter" || true)
+  if [[ -n "$WARNINGS" ]]; then
+    echo ""
+    echo "Warnings (may be expected):"
+    echo "$WARNINGS"
+  fi
+fi


### PR DESCRIPTION
Use \\n in JSON so the template engine interprets \n as newline.
Add renovate-dryrun script for local testing with auto error checking.
