### PR TITLE
renovate regex fix

### DIFF
--- a/.claude/rules/tooling/renovate.md
+++ b/.claude/rules/tooling/renovate.md
@@ -22,15 +22,14 @@ Renovate uses **RE2 regex engine** which does NOT support:
 - Lookahead assertions (`(?=...)`)
 - Backreferences
 
-## autoReplaceStringTemplate Newlines
+## Multiline Matching Strategy
 
-To include newlines in `autoReplaceStringTemplate`, use `\\n` in JSON (double-escaped):
+For patterns spanning multiple lines (like comment annotations), use `matchStringsStrategy: "recursive"` instead of trying to include newlines in `autoReplaceStringTemplate`. Renovate only replaces the last match in recursive mode, so you can:
 
-```json
-"autoReplaceStringTemplate": "# comment\\n{{{prefix}}}{{{depName}}}"
-```
+1. First pattern: Match the full block (comment + value line)
+2. Second pattern: Extract only the parts to be replaced
 
-The template engine interprets `\n` as a newline escape, so JSON's `\n` (single escape) becomes empty. Double-escape to pass literal `\n` to the template engine.
+This avoids newline escaping issues entirely.
 
 ## Docker Image Annotations
 
@@ -41,4 +40,4 @@ Use comment annotations for Docker images in Ansible:
 variable_name: "image:tag@sha256:digest"
 ```
 
-The generic regex manager in `.renovaterc` handles these automatically.
+The generic regex manager in `.renovaterc` uses `matchStringsStrategy: "recursive"` to handle these - the comment identifies the block, and only the image reference is replaced.

--- a/.renovaterc
+++ b/.renovaterc
@@ -72,11 +72,13 @@
         "ansible/**/*.yaml",
         "ansible/**/*.yml"
       ],
+      "matchStringsStrategy": "recursive",
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=docker\\s*\\n(?<prefix>\\s*[a-z0-9_]+:\\s*\"?)(?<depName>[^:\"\\s]+):(?<currentValue>[^@\"\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?(?<suffix>\"?)"
+        "#\\s*renovate:\\s*datasource=docker\\s*\\n\\s*[a-z0-9_]+:\\s*\"?[^\"\\n]+\"?",
+        "(?<depName>[^:\"\\s]+):(?<currentValue>[^@\"\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
       ],
       "datasourceTemplate": "docker",
-      "autoReplaceStringTemplate": "# renovate: datasource=docker\\n{{{prefix}}}{{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}{{{suffix}}}"
+      "autoReplaceStringTemplate": "{{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
Use recursive matchStringsStrategy for Docker image annotations

Instead of trying to include newlines in autoReplaceStringTemplate
(which doesn't work reliably), use matchStringsStrategy: "recursive"
where the first pattern finds the comment+image block and the second
pattern extracts just the image reference. Renovate only replaces the
last match in recursive mode, so the comment is preserved and no
newlines are needed in the template.

This fixes the "Could not extract after autoreplace" errors that
occurred when Renovate tried to update Docker images with comment
annotations.

