### PR TITLE
Add office thermostat/gaming PC circuit management automation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,13 @@ repos:
     language: system
     pass_filenames: true
     files: ^kubernetes/.*\.(ya?ml)$
+  - id: beads-flush
+    name: beads pre-commit flush
+    entry: bash -c '[ "$GITHUB_ACTIONS" = "true" ] && exit 0; bd hooks run pre-commit'
+    language: system
+    pass_filenames: false
+    always_run: true
+    stages: [pre-commit]
 
 - repo: https://github.com/shellcheck-py/shellcheck-py
   rev: v0.10.0.1

--- a/kubernetes/hass/config/kustomization.yaml
+++ b/kubernetes/hass/config/kustomization.yaml
@@ -12,3 +12,4 @@ configMapGenerator:
   - input_boolean.yaml=input_boolean.yaml
   - input_select.yaml=input_select.yaml
   - packages__temperature_alerts.yaml=packages/temperature_alerts.yaml
+  - packages__office_thermostat_gaming.yaml=packages/office_thermostat_gaming.yaml

--- a/kubernetes/hass/config/packages/office_thermostat_gaming.yaml
+++ b/kubernetes/hass/config/packages/office_thermostat_gaming.yaml
@@ -1,0 +1,61 @@
+---
+# Office thermostat automation - circuit load management
+#
+# The gaming PC (szamar) and office space heater share an electrical circuit.
+# Running both simultaneously risks overloading the circuit.
+#
+# This package:
+# 1. Monitors szamar power consumption via ESPHome Sonoff S31
+# 2. Turns off the thermostat when PC power > 10W (active use)
+# 3. Restores heat mode when PC power drops (keeps existing setpoint)
+#
+# Existing automations continue to manage temperature setpoints:
+# - 5am workdays: 78°F (warm up office)
+# - 6pm: 70°F (background heating via turn_off_office_heaters script)
+# - midnight: scene.nightly + turn_off_office_heaters
+
+automation:
+- alias: Turn off office thermostat when gaming PC is active
+  id: office_thermostat_gaming_pc_on
+  description: Circuit load management - PC and heater share circuit
+  trigger:
+  - platform: numeric_state
+    entity_id: sensor.szamar_power_power
+    above: 10
+    for:
+      # Wait 1 minute to confirm sustained power draw
+      minutes: 1
+  condition:
+  - condition: state
+    entity_id: climate.office_thermostat
+    state: heat
+  action:
+  - service: climate.set_hvac_mode
+    target:
+      entity_id: climate.office_thermostat
+    data:
+      hvac_mode: 'off'
+
+- alias: Restore office thermostat when gaming PC is idle
+  id: office_thermostat_gaming_pc_off
+  description: Restore heating when PC power drops below threshold
+  trigger:
+  - platform: numeric_state
+    entity_id: sensor.szamar_power_power
+    below: 10
+    for:
+      # Wait 2 minutes to confirm PC is truly idle
+      minutes: 2
+  # Only restore if thermostat is currently off
+  # (don't interfere if manually set to something else)
+  condition:
+  - condition: state
+    entity_id: climate.office_thermostat
+    state: 'off'
+  # Restore to heat mode - existing setpoint is preserved
+  action:
+  - service: climate.set_hvac_mode
+    target:
+      entity_id: climate.office_thermostat
+    data:
+      hvac_mode: heat


### PR DESCRIPTION
The gaming PC (szamar) and office space heater share an electrical circuit.
This automation prevents circuit overload by:
- Turning off thermostat when PC power draw exceeds 10W for 1 minute
- Restoring heat mode when PC power drops below 10W for 2 minutes
