### PR TITLE
Update Home Assistant helm chart to 0.3.37 (HA 2025.12.5)

### DIFF
--- a/kubernetes/hass/Chart.yaml
+++ b/kubernetes/hass/Chart.yaml
@@ -4,5 +4,5 @@ name: hass-meta
 version: 0.1.0
 dependencies:
 - name: home-assistant
-  version: 0.3.32
+  version: 0.3.37
   repository: https://pajikos.github.io/home-assistant-helm-chart/

--- a/kubernetes/hass/config/kustomization.yaml
+++ b/kubernetes/hass/config/kustomization.yaml
@@ -11,5 +11,5 @@ configMapGenerator:
   - configuration.yaml=configuration.yaml
   - input_boolean.yaml=input_boolean.yaml
   - input_select.yaml=input_select.yaml
-  - packages__temperature_alerts.yaml=packages/temperature_alerts.yaml
   - packages__office_thermostat_gaming.yaml=packages/office_thermostat_gaming.yaml
+  - packages__temperature_alerts.yaml=packages/temperature_alerts.yaml

--- a/kubernetes/hass/helm/ingress.yaml
+++ b/kubernetes/hass/helm/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: home-assistant
     app.kubernetes.io/instance: hass
-    app.kubernetes.io/version: "2025.11.3"
+    app.kubernetes.io/version: "2025.12.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt

--- a/kubernetes/hass/helm/service.yaml
+++ b/kubernetes/hass/helm/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: home-assistant
     app.kubernetes.io/instance: hass
-    app.kubernetes.io/version: "2025.11.3"
+    app.kubernetes.io/version: "2025.12.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/kubernetes/hass/helm/serviceaccount.yaml
+++ b/kubernetes/hass/helm/serviceaccount.yaml
@@ -7,5 +7,5 @@ metadata:
   labels:
     app.kubernetes.io/name: home-assistant
     app.kubernetes.io/instance: hass
-    app.kubernetes.io/version: "2025.11.3"
+    app.kubernetes.io/version: "2025.12.5"
     app.kubernetes.io/managed-by: Helm

--- a/kubernetes/hass/helm/statefulset.yaml
+++ b/kubernetes/hass/helm/statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: home-assistant
     app.kubernetes.io/instance: hass
-    app.kubernetes.io/version: "2025.11.3"
+    app.kubernetes.io/version: "2025.12.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   serviceName: hass-home-assistant
@@ -33,7 +33,7 @@ spec:
         - name: home-assistant
           securityContext:
             {}
-          image: "ghcr.io/home-assistant/home-assistant:2025.11.3"
+          image: "ghcr.io/home-assistant/home-assistant:2025.12.5"
           imagePullPolicy: IfNotPresent
           env:
             - name: DB_URL


### PR DESCRIPTION
Skips 0.3.36 to get Ring log flooding fix and latest patches.
