### PR TITLE
Include docker-compose manager in Ansible automerge rule

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -233,7 +233,8 @@
         "docker"
       ],
       "matchManagers": [
-        "custom.regex"
+        "custom.regex",
+        "docker-compose"
       ],
       "matchFileNames": [
         "ansible/**"


### PR DESCRIPTION
The existing rule for auto-merging Docker digest updates in Ansible
files only matched custom.regex manager. Files like docker-compose.yaml
were detected by the native docker-compose manager, so the automerge
rule didn't apply and they got stuck waiting for stability-days.
