### PR TITLE
Add downloads volume mount to qui for orphan scanner

### DIFF
--- a/kubernetes/qui/deploy.yaml
+++ b/kubernetes/qui/deploy.yaml
@@ -45,7 +45,13 @@ spec:
         volumeMounts:
         - mountPath: /config
           name: config
+        - mountPath: /downloads
+          name: downloads
       volumes:
       - name: config
         persistentVolumeClaim:
           claimName: qui-config
+      - name: downloads
+        nfs:
+          server: fs2.oneill.net
+          path: /volume2/shared/downloads


### PR DESCRIPTION
Mounts the NFS downloads directory at /downloads to match qBittorrent's
path, enabling qui's orphan scanner to detect and clean up files not
tracked by any torrent.
