### PR TITLE
Add availability templates to garage door covers

### DIFF
--- a/kubernetes/hass/config/configuration.yaml
+++ b/kubernetes/hass/config/configuration.yaml
@@ -185,24 +185,26 @@ template:
     unique_id: left_garage_door_template_cover
     device_class: garage
     state: "{{ 'open' if is_state('binary_sensor.left_garage_door_closed', 'off') else 'closed' }}"
+    availability: "{{ states('sensor.left_garage_door_vibration_angle_y') | is_number }}"
     open_cover:
-      service: button.press
+      action: button.press
       target:
         entity_id: button.opengarage_left_door_opengarage_left_door_trigger
     close_cover:
-      service: button.press
+      action: button.press
       target:
         entity_id: button.opengarage_left_door_opengarage_left_door_trigger
   - name: Right Garage Door
     unique_id: right_garage_door_template_cover
     device_class: garage
     state: "{{ 'open' if is_state('binary_sensor.right_garage_door_closed', 'off') else 'closed' }}"
+    availability: "{{ states('sensor.right_garage_door_vibration_angle_y') | is_number }}"
     open_cover:
-      service: button.press
+      action: button.press
       target:
         entity_id: button.opengarage_right_door_opengarage_right_door_trigger
     close_cover:
-      service: button.press
+      action: button.press
       target:
         entity_id: button.opengarage_right_door_opengarage_right_door_trigger
 


### PR DESCRIPTION
When tilt sensors are unavailable, the covers now become unavailable
instead of falsely appearing as 'closed'. This prevents automated
actions (like scene reproduction) from operating on doors when we
don't actually know their state.

Also updates service→action for modern HASS template syntax.
