### PR TITLE
Add unifi-protect-backup service

### DIFF
--- a/kubernetes/unifi-protect-backup/deployment.yaml
+++ b/kubernetes/unifi-protect-backup/deployment.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: unifi-protect-backup
+  annotations:
+    reloader.stakater.com/auto: 'true'
+
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: unifi-protect-backup
+      app.kubernetes.io/instance: unifi-protect-backup
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: unifi-protect-backup
+        app.kubernetes.io/instance: unifi-protect-backup
+    spec:
+      containers:
+      - name: unifi-protect-backup
+        image: ghcr.io/ep1cman/unifi-protect-backup:0.14.1@sha256:9f1fd2b7c4ae02e88af2c976727d797213a8004c0f8d52fcc9b49a077c8caf7d
+        env:
+        - name: UFP_ADDRESS
+          value: udmp.oneill.net
+        - name: UFP_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: unifi-protect-backup
+              key: UFP_USERNAME
+        - name: UFP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: unifi-protect-backup
+              key: UFP_PASSWORD
+        - name: RCLONE_RETENTION
+          value: 90d
+        - name: RCLONE_DESTINATION
+          value: local:/data/unifi-protect
+        volumeMounts:
+        - name: unifi-protect
+          mountPath: /data/unifi-protect
+        - name: database
+          mountPath: /config/database
+      volumes:
+      - name: unifi-protect
+        nfs:
+          server: fs2.oneill.net
+          path: /volume2/shared/video/unifi-protect
+      - name: database
+        persistentVolumeClaim:
+          claimName: unifi-protect-backup-db

--- a/kubernetes/unifi-protect-backup/externalsecret.yaml
+++ b/kubernetes/unifi-protect-backup/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+  name: unifi-protect-backup
+
+spec:
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  target:
+    name: unifi-protect-backup
+    creationPolicy: Owner
+  data:
+  - secretKey: UFP_USERNAME
+    remoteRef:
+      key: unifi-protect-backup
+      property: username
+  - secretKey: UFP_PASSWORD
+    remoteRef:
+      key: unifi-protect-backup
+      property: password

--- a/kubernetes/unifi-protect-backup/kustomization.yaml
+++ b/kubernetes/unifi-protect-backup/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: unifi-protect-backup
+
+resources:
+- namespace.yaml
+- externalsecret.yaml
+- pvc.yaml
+- deployment.yaml
+
+commonAnnotations:
+  argoManaged: 'true'
+
+labels:
+
+- pairs:
+    app.kubernetes.io/name: unifi-protect-backup
+    app.kubernetes.io/instance: unifi-protect-backup
+  includeSelectors: true

--- a/kubernetes/unifi-protect-backup/namespace.yaml
+++ b/kubernetes/unifi-protect-backup/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: unifi-protect-backup
+  labels:
+    goldilocks.fairwinds.com/enabled: 'true'
+  annotations:
+    goldilocks.fairwinds.com/vpa-update-mode: InPlaceOrRecreate
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","controlledValues":"RequestsOnly"}]}'

--- a/kubernetes/unifi-protect-backup/pvc.yaml
+++ b/kubernetes/unifi-protect-backup/pvc.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+
+metadata:
+  name: unifi-protect-backup-db
+  labels:
+    velero.io/backup: 'true'
+
+spec:
+  storageClassName: synology-iscsi
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
Back up UniFi Protect detection clips to NFS storage with 90-day retention.
Clips stored at fs2:/volume2/shared/video/unifi-protect and included in
restic backups to B2.
