### PR TITLE
Add staleness detection for .secrets.age

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -44,6 +44,20 @@ if [[ -f .secrets.age ]]; then
   if [[ -n "$DIRENV_AGE_KEY" ]]; then
     # shellcheck disable=SC1090
     source <(age -d -i <(echo "$DIRENV_AGE_KEY") .secrets.age)
+
+    # Check if .secrets.age is stale (template changed since generation)
+    if [[ -f ".secrets.tmpl.hash" ]]; then
+      _current_hash=$(sha256sum .secrets.tmpl | cut -d' ' -f1)
+      _stored_hash=$(<.secrets.tmpl.hash)
+      if [[ "$_current_hash" != "$_stored_hash" ]]; then
+        _red=$'\033[1;31m'
+        _reset=$'\033[0m'
+        echo ""
+        echo "${_red}⚠️  STALE SECRETS: .secrets.tmpl has changed since .secrets.age was generated${_reset}"
+        echo "${_red}   Run: bootstrap-secrets --apply direnv${_reset}"
+        echo ""
+      fi
+    fi
   fi
 fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode/extensions.json
 .direnv/
 .secrets.age
+.secrets.tmpl.hash
 .tmp/
 
 # Ansible

--- a/scripts/bootstrap-secrets
+++ b/scripts/bootstrap-secrets
@@ -137,6 +137,8 @@ bootstrap_direnv() {
       echo "❌ Failed to encrypt secrets. Check that .secrets.tmpl references are valid."
       exit 1
     fi
+    # Store template hash for staleness detection
+    sha256sum .secrets.tmpl | cut -d' ' -f1 > .secrets.tmpl.hash
     echo "✅ Updated .secrets.age"
   else
     # Generate what the new file would look like and compare


### PR DESCRIPTION
Store hash of .secrets.tmpl when generating .secrets.age, and check on
direnv load to warn if template has changed since secrets were generated.
