### PR TITLE
Fix INJECT_FACTS_AS_VARS deprecation warnings

### DIFF
--- a/.claude/rules/ansible/semaphore.md
+++ b/.claude/rules/ansible/semaphore.md
@@ -1,0 +1,36 @@
+# Semaphore Deployment (Optional)
+
+## When to Use Semaphore
+
+Semaphore deploys from the **git repository**, not local changes. This makes it
+unsuitable for interactive development.
+
+Use Semaphore when:
+
+- Deploying committed, pushed changes
+- Running from CI/CD pipelines
+
+Use CLI directly when:
+
+- Developing or testing local changes (most of the time)
+- Iterating on fixes
+- Debugging with verbose output
+
+## Running via Semaphore
+
+```bash
+# Deploy to specific hosts
+semaphore-deploy --hosts "hostname" --project Infra --template ansible-deploy
+
+# Deploy to all hosts
+semaphore-deploy --hosts all --project Infra --template ansible-deploy
+
+# With specific tags
+semaphore-deploy --hosts all --project Infra --template ansible-deploy --tags common
+```
+
+## Capturing Output
+
+```bash
+semaphore-deploy --hosts all --project Infra --template ansible-deploy 2>&1 | tee output.log
+```

--- a/ansible/group_vars/all/docker.yaml
+++ b/ansible/group_vars/all/docker.yaml
@@ -3,9 +3,9 @@
 # renovate: datasource=github-releases depName=moby/moby
 docker_version: "29.1.1"
 docker_packages:
-  - "docker-ce=5:{{ docker_version }}-1~{{ ansible_distribution | lower }}.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release }}"
-  - "docker-ce-cli=5:{{ docker_version }}-1~{{ ansible_distribution | lower }}.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release }}"
-  - "docker-ce-rootless-extras=5:{{ docker_version }}-1~{{ ansible_distribution | lower }}.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release }}"
+  - "docker-ce=5:{{ docker_version }}-1~{{ ansible_facts['distribution'] | lower }}.{{ ansible_facts['distribution_major_version'] }}~{{ ansible_facts['distribution_release'] }}"
+  - "docker-ce-cli=5:{{ docker_version }}-1~{{ ansible_facts['distribution'] | lower }}.{{ ansible_facts['distribution_major_version'] }}~{{ ansible_facts['distribution_release'] }}"
+  - "docker-ce-rootless-extras=5:{{ docker_version }}-1~{{ ansible_facts['distribution'] | lower }}.{{ ansible_facts['distribution_major_version'] }}~{{ ansible_facts['distribution_release'] }}"
   - "containerd.io"
   - "docker-buildx-plugin"
   - "docker-compose-plugin"

--- a/ansible/host_vars/flux.yaml
+++ b/ansible/host_vars/flux.yaml
@@ -12,4 +12,4 @@ restic_host_config:
   default:
     # Use a dedicated repo via REST server over Tailscale. This host has limited
     # disk and memory, so pulling the index for all other machines is not practical.
-    repository: "rest:https://{{ '{{' }} $repo_username {{ '}}' }}:{{ '{{' }} $repo_password {{ '}}' }}@restic.cow-banjo.ts.net/{{ ansible_hostname }}"
+    repository: "rest:https://{{ '{{' }} $repo_username {{ '}}' }}:{{ '{{' }} $repo_password {{ '}}' }}@restic.cow-banjo.ts.net/{{ ansible_facts['hostname'] }}"

--- a/ansible/roles/kubeadm/tasks/master.yaml
+++ b/ansible/roles/kubeadm/tasks/master.yaml
@@ -27,14 +27,14 @@
     path: "/etc/kubernetes/admin.conf"
     regexp: "^(\\s+)server:\\s+"
     backrefs: true
-    line: "\\1server: https://{{ ansible_fqdn }}:6443"
+    line: "\\1server: https://{{ ansible_facts['fqdn'] }}:6443"
 
 - name: "Fixup super-admin.conf to use fqdn"
   ansible.builtin.lineinfile:
     path: "/etc/kubernetes/super-admin.conf"
     regexp: "^(\\s+)server:\\s+"
     backrefs: true
-    line: "\\1server: https://{{ ansible_fqdn }}:6443"
+    line: "\\1server: https://{{ ansible_facts['fqdn'] }}:6443"
 
 - name: "Fetch admin.conf for local use"
   ansible.builtin.fetch:

--- a/ansible/roles/kubeadm/templates/kubeadm.conf.j2
+++ b/ansible/roles/kubeadm/templates/kubeadm.conf.j2
@@ -17,10 +17,10 @@ kind: ClusterConfiguration
 apiVersion: kubeadm.k8s.io/v1beta3
 apiServer:
   certSANs:
-  - {{ ansible_fqdn }}
+  - {{ ansible_facts['fqdn'] }}
   - k1.oneill.net
 clusterName: kubernetes
-controlPlaneEndpoint: "{{ ansible_fqdn }}:6443"
+controlPlaneEndpoint: "{{ ansible_facts['fqdn'] }}:6443"
 controllerManager:
   extraArgs:
     allocate-node-cidrs: "true"


### PR DESCRIPTION
Change ansible_* variables to ansible_facts['*'] syntax to fix
deprecation warnings that will become errors in ansible-core 2.24.

Files fixed:
- group_vars/all/docker.yaml
- host_vars/flux.yaml
- roles/kubeadm/tasks/master.yaml
- roles/kubeadm/templates/kubeadm.conf.j2

Also adds documentation for semaphore-deploy script usage.
