### PR TITLE
Fix cross-seed path mismatch with qBittorrent

### DIFF
--- a/kubernetes/cross-seed/config.js
+++ b/kubernetes/cross-seed/config.js
@@ -33,7 +33,7 @@ module.exports = {
      * 		dataDirs: ["C:\\My Data\\Downloads"]
      */
     dataDirs: [
-        "/shared/downloads/qbittorrent/completed",
+        "/downloads/qbittorrent/completed",
     ],
     /**
      * Determines flexibility of naming during matching. "safe" will allow only perfect name matches
@@ -57,7 +57,7 @@ module.exports = {
     /**
      * List of directories where cross-seed will create links to scanned files.
      */
-    linkDirs: ["/shared/downloads/qbittorrent/cross-seeds"],
+    linkDirs: ["/downloads/qbittorrent/cross-seeds"],
     /**
      * cross-seed will use links of this type to inject data-based matches into your client.
      * Only relevant if dataDirs is specified.

--- a/kubernetes/cross-seed/deploy.yaml
+++ b/kubernetes/cross-seed/deploy.yaml
@@ -37,8 +37,8 @@ spec:
           mountPath: /torrents
           subPath: qBittorrent/BT_backup
           readOnly: true
-        - name: shared
-          mountPath: /shared
+        - name: downloads
+          mountPath: /downloads
         - name: cross-seed-data
           mountPath: /cross-seeds
         env:
@@ -82,7 +82,7 @@ spec:
       - name: cross-seed-data
         persistentVolumeClaim:
           claimName: cross-seed-data
-      - name: shared
+      - name: downloads
         nfs:
           server: fs2.oneill.net
-          path: /volume2/shared
+          path: /volume2/shared/downloads


### PR DESCRIPTION
Cross-seed was mounting /volume2/shared at /shared, while qBittorrent
mounts /volume2/shared/downloads at /downloads. This caused cross-seed
to fail path verification since the paths reported by qBittorrent
didn't match the paths cross-seed saw.

Changed cross-seed to mount the downloads directory at /downloads to
match qBittorrent's view of the filesystem.
