### PR TITLE
Add IPv6 AAAA records for ddns-route53

### DIFF
--- a/kubernetes/ddns-route53/deploy.yaml
+++ b/kubernetes/ddns-route53/deploy.yaml
@@ -23,17 +23,79 @@ spec:
         app.kubernetes.io/instance: ddns-route53
     spec:
       containers:
-      - name: ddns-route53
+      - name: oneill
         image: ghcr.io/crazy-max/ddns-route53@sha256:59b1f3d51530f8e1a8331ad9c63c4be414f72503b306eea7f3b3abf532ce2ae5
         args:
         - --schedule=*/5 * * * *
-        envFrom:
-        - secretRef:
-            name: ddns-route53-oneill
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        env:
+        - name: DDNSR53_CREDENTIALS_ACCESSKEYID
+          valueFrom:
+            secretKeyRef:
+              name: ddns-route53-aws
+              key: DDNSR53_CREDENTIALS_ACCESSKEYID
+        - name: DDNSR53_CREDENTIALS_SECRETACCESSKEY
+          valueFrom:
+            secretKeyRef:
+              name: ddns-route53-aws
+              key: DDNSR53_CREDENTIALS_SECRETACCESSKEY
+        - name: DDNSR53_ROUTE53_HOSTEDZONEID
+          valueFrom:
+            secretKeyRef:
+              name: ddns-route53-aws
+              key: ONEILL_NET_ZONE_ID
+        - name: DDNSR53_ROUTE53_RECORDSSET_0_NAME
+          value: luser.oneill.net.
+        - name: DDNSR53_ROUTE53_RECORDSSET_0_TYPE
+          value: A
+        - name: DDNSR53_ROUTE53_RECORDSSET_0_TTL
+          value: "300"
+        - name: DDNSR53_ROUTE53_RECORDSSET_1_NAME
+          value: luser.oneill.net.
+        - name: DDNSR53_ROUTE53_RECORDSSET_1_TYPE
+          value: AAAA
+        - name: DDNSR53_ROUTE53_RECORDSSET_1_TTL
+          value: "300"
       - name: fnord
         image: ghcr.io/crazy-max/ddns-route53@sha256:59b1f3d51530f8e1a8331ad9c63c4be414f72503b306eea7f3b3abf532ce2ae5
         args:
         - --schedule=*/5 * * * *
-        envFrom:
-        - secretRef:
-            name: ddns-route53-fnord
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        env:
+        - name: DDNSR53_CREDENTIALS_ACCESSKEYID
+          valueFrom:
+            secretKeyRef:
+              name: ddns-route53-aws
+              key: DDNSR53_CREDENTIALS_ACCESSKEYID
+        - name: DDNSR53_CREDENTIALS_SECRETACCESSKEY
+          valueFrom:
+            secretKeyRef:
+              name: ddns-route53-aws
+              key: DDNSR53_CREDENTIALS_SECRETACCESSKEY
+        - name: DDNSR53_ROUTE53_HOSTEDZONEID
+          valueFrom:
+            secretKeyRef:
+              name: ddns-route53-aws
+              key: FNORD_NET_ZONE_ID
+        - name: DDNSR53_ROUTE53_RECORDSSET_0_NAME
+          value: luser.fnord.net.
+        - name: DDNSR53_ROUTE53_RECORDSSET_0_TYPE
+          value: A
+        - name: DDNSR53_ROUTE53_RECORDSSET_0_TTL
+          value: "300"
+        - name: DDNSR53_ROUTE53_RECORDSSET_1_NAME
+          value: luser.fnord.net.
+        - name: DDNSR53_ROUTE53_RECORDSSET_1_TYPE
+          value: AAAA
+        - name: DDNSR53_ROUTE53_RECORDSSET_1_TTL
+          value: "300"

--- a/kubernetes/ddns-route53/externalsecret.yaml
+++ b/kubernetes/ddns-route53/externalsecret.yaml
@@ -3,27 +3,26 @@ apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 
 metadata:
-  name: ddns-route53-fnord
+  name: ddns-route53-aws
 
 spec:
   secretStoreRef:
     name: production
     kind: ClusterSecretStore
-  dataFrom:
-  - extract:
-      key: ddns-route53-fnord
-
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-
-metadata:
-  name: ddns-route53-oneill
-
-spec:
-  secretStoreRef:
-    name: production
-    kind: ClusterSecretStore
-  dataFrom:
-  - extract:
-      key: ddns-route53-oneill
+  data:
+  - secretKey: DDNSR53_CREDENTIALS_ACCESSKEYID
+    remoteRef:
+      key: ddns-route53-aws
+      property: DDNSR53_CREDENTIALS_ACCESSKEYID
+  - secretKey: DDNSR53_CREDENTIALS_SECRETACCESSKEY
+    remoteRef:
+      key: ddns-route53-aws
+      property: DDNSR53_CREDENTIALS_SECRETACCESSKEY
+  - secretKey: ONEILL_NET_ZONE_ID
+    remoteRef:
+      key: ddns-route53-aws
+      property: ONEILL_NET_ZONE_ID
+  - secretKey: FNORD_NET_ZONE_ID
+    remoteRef:
+      key: ddns-route53-aws
+      property: FNORD_NET_ZONE_ID

--- a/opentofu/ddns-route53.tf
+++ b/opentofu/ddns-route53.tf
@@ -1,0 +1,73 @@
+# IAM user for ddns-route53 dynamic DNS updates
+resource "aws_iam_user" "ddns_route53" {
+  name = "crazy-max-ddns-user"
+}
+
+resource "aws_iam_access_key" "ddns_route53" {
+  user = aws_iam_user.ddns_route53.name
+}
+
+# Policy allowing Route53 record updates for specific hosted zones
+resource "aws_iam_policy" "ddns_route53" {
+  name = "ddns-route53"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "VisualEditor0"
+        Effect = "Allow"
+        Action = [
+          "route53:ChangeResourceRecordSets",
+          "route53:ListResourceRecordSets"
+        ]
+        Resource = [
+          "arn:aws:route53:::hostedzone/${module.dns.oneill_net_zone_id}",
+          "arn:aws:route53:::hostedzone/${module.dns.fnord_net_zone_id}"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "ddns_route53" {
+  user       = aws_iam_user.ddns_route53.name
+  policy_arn = aws_iam_policy.ddns_route53.arn
+}
+
+# Store credentials and zone IDs in 1Password for Kubernetes ExternalSecret
+resource "onepassword_item" "ddns_route53_aws" {
+  vault    = data.onepassword_vault.infra.uuid
+  title    = "ddns-route53-aws"
+  category = "secure_note"
+
+  note_value = "AWS credentials and zone IDs for ddns-route53. Managed by OpenTofu - do not edit manually."
+
+  section {
+    label = "credentials"
+
+    field {
+      label = "DDNSR53_CREDENTIALS_ACCESSKEYID"
+      type  = "STRING"
+      value = aws_iam_access_key.ddns_route53.id
+    }
+
+    field {
+      label = "DDNSR53_CREDENTIALS_SECRETACCESSKEY"
+      type  = "CONCEALED"
+      value = aws_iam_access_key.ddns_route53.secret
+    }
+
+    field {
+      label = "ONEILL_NET_ZONE_ID"
+      type  = "STRING"
+      value = module.dns.oneill_net_zone_id
+    }
+
+    field {
+      label = "FNORD_NET_ZONE_ID"
+      type  = "STRING"
+      value = module.dns.fnord_net_zone_id
+    }
+  }
+}

--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -160,5 +160,12 @@ locals {
       hostname = "pantrypi-wifi.oneill.net"
       note     = "pantrypi wifi interface"
     }
+    # Desktop PCs
+    szamar = {
+      mac      = "9c:6b:00:9b:16:ef"
+      ip       = "172.19.74.50"
+      hostname = "szamar.oneill.net"
+      note     = "Gaming PC"
+    }
   }
 }

--- a/opentofu/modules/dns/outputs.tf
+++ b/opentofu/modules/dns/outputs.tf
@@ -3,3 +3,14 @@ output "k_oneill_net_nameservers" {
   description = "AWS Route53 nameservers for k.oneill.net zone"
   value       = aws_route53_zone.k_oneill_net.name_servers
 }
+
+# Export zone IDs for use in IAM policies
+output "oneill_net_zone_id" {
+  description = "AWS Route53 hosted zone ID for oneill.net"
+  value       = aws_route53_zone.oneill_net.zone_id
+}
+
+output "fnord_net_zone_id" {
+  description = "AWS Route53 hosted zone ID for fnord.net"
+  value       = aws_route53_zone.fnord_net.zone_id
+}


### PR DESCRIPTION
- Refactor ddns-route53 to use shared AWS credentials from 1Password
- Add AAAA record configuration alongside existing A records
- Manage IAM user/policy with OpenTofu (imported existing resources)
- Store zone IDs in 1Password to avoid hardcoding in manifests
- Add szamar host to infrastructure_hosts
