### PR TITLE
Add UPS power and energy sensors for Home Assistant

### DIFF
--- a/.claude/rules/kubernetes/deployment-pattern.md
+++ b/.claude/rules/kubernetes/deployment-pattern.md
@@ -44,6 +44,20 @@ Do NOT use `kubectl apply -f <file>` directly.
 - ArgoCD manages deployments from main branch, but apply locally first to verify changes work before committing
 - For cronjobs, trigger a manual run with: `kubectl create job --from=cronjob/<name> <test-name>`
 
+## ConfigMap and Secret Reload
+
+Most workloads have [Reloader](https://github.com/stakater/Reloader) configured
+via the `reloader.stakater.com/auto: "true"` pod annotation. This automatically
+triggers a rolling restart when referenced ConfigMaps or Secrets change.
+
+**Implications:**
+
+- After `kubectl apply`, pods restart automatically—no manual deletion needed
+- Changes propagate within ~30 seconds of ConfigMap update
+- Not all workloads have this; check pod annotations if restart doesn't occur
+- If a workload is missing Reloader and would benefit from it, ask about adding
+  the annotation
+
 ## Rendering Helm Charts
 
 Render scripts for Kubernetes applications are standardized across this repository. Refer to [helm-rendering.md](./helm-rendering.md) for the canonical render script pattern, helper usage, and best practices that apply to all applications.

--- a/kubernetes/hass/config/kustomization.yaml
+++ b/kubernetes/hass/config/kustomization.yaml
@@ -13,3 +13,4 @@ configMapGenerator:
   - input_select.yaml=input_select.yaml
   - packages__office_thermostat_gaming.yaml=packages/office_thermostat_gaming.yaml
   - packages__temperature_alerts.yaml=packages/temperature_alerts.yaml
+  - packages__ups_power.yaml=packages/ups_power.yaml

--- a/kubernetes/hass/config/packages/ups_power.yaml
+++ b/kubernetes/hass/config/packages/ups_power.yaml
@@ -1,0 +1,73 @@
+---
+template:
+
+- sensor:
+  - name: UPS Synology Power
+    unique_id: ups_synology_power_watts
+    unit_of_measurement: W
+    device_class: power
+    state_class: measurement
+    state: >
+      {% set load = states('sensor.ups_synology_load') | float(0) %}
+      {% set nominal = states('sensor.ups_nominal_real_power') | float(0) %}
+      {{ (load / 100 * nominal) | round(0) }}
+    availability: >
+      {{ states('sensor.ups_synology_load') | is_number and
+         states('sensor.ups_nominal_real_power') | is_number }}
+
+  - name: UPS2 Servers Power
+    unique_id: ups2_servers_power_watts
+    unit_of_measurement: W
+    device_class: power
+    state_class: measurement
+    state: >
+      {% set load = states('sensor.ups2_servers_10g_switch_load') | float(0) %}
+      {% set nominal = states('sensor.ups2_nominal_real_power') | float(0) %}
+      {{ (load / 100 * nominal) | round(0) }}
+    availability: >
+      {{ states('sensor.ups2_servers_10g_switch_load') | is_number and
+         states('sensor.ups2_nominal_real_power') | is_number }}
+
+  - name: UPS3 Network Power
+    unique_id: ups3_network_power_watts
+    unit_of_measurement: W
+    device_class: power
+    state_class: measurement
+    state: >
+      {% set load = states('sensor.ups3_network_gear_load') | float(0) %}
+      {% set nominal = states('sensor.ups3_nominal_real_power') | float(0) %}
+      {{ (load / 100 * nominal) | round(0) }}
+    availability: >
+      {{ states('sensor.ups3_network_gear_load') | is_number and
+         states('sensor.ups3_nominal_real_power') | is_number }}
+
+sensor:
+- platform: integration
+  source: sensor.ups_synology_power
+  name: UPS Synology Energy
+  unique_id: ups_synology_energy_kwh
+  unit_prefix: k
+  round: 2
+  method: left
+  max_sub_interval:
+    minutes: 5
+
+- platform: integration
+  source: sensor.ups2_servers_power
+  name: UPS2 Servers Energy
+  unique_id: ups2_servers_energy_kwh
+  unit_prefix: k
+  round: 2
+  method: left
+  max_sub_interval:
+    minutes: 5
+
+- platform: integration
+  source: sensor.ups3_network_power
+  name: UPS3 Network Energy
+  unique_id: ups3_network_energy_kwh
+  unit_prefix: k
+  round: 2
+  method: left
+  max_sub_interval:
+    minutes: 5


### PR DESCRIPTION
- Template sensors to calculate watts from UPS load percentage
- Integration sensors for kWh energy tracking (Energy Dashboard)
- Document Reloader behavior in deployment rules
