### PR TITLE
Add NUT client shutdown coordination for Proxmox hosts

### DIFF
--- a/ansible/group_vars/nut.yaml
+++ b/ansible/group_vars/nut.yaml
@@ -15,13 +15,13 @@ nut_ups:
   - name: "ups2"
     driver: "usbhid-ups"
     device: auto
-    description: "UPS for luser, p2, p3, p4"
+    description: "UPS for p1, p2, p3, p4"
     extra: |
       serial = "CXXPV7000092"
   - name: "ups3"
     driver: "usbhid-ups"
     device: auto
-    description: "UPS for network gear"
+    description: "UPS for network gear & infra1"
     extra: |
       serial = "CXXPX7007632"
 

--- a/ansible/group_vars/nut_client.yaml
+++ b/ansible/group_vars/nut_client.yaml
@@ -1,0 +1,27 @@
+---
+nut_mode: netclient
+nut_enabled: true
+
+# Empty - clients don't need ups.conf (no local drivers)
+nut_ups: []
+nut_packages:
+  - nut-client
+
+nut_services:
+  - nut-monitor
+
+# Shutdown after 5 minutes on battery (ups2 has ~12 min runtime)
+nut_shutdown_delay: 300
+
+nut_upsmon_extra: |
+  MONITOR ups2@nut.oneill.net 1 monuser secret secondary
+  MINSUPPLIES 1
+  SHUTDOWNCMD "/sbin/shutdown -h +0"
+  HOSTSYNC 60
+  FINALDELAY 5
+  RUN_AS_USER root
+  NOTIFYCMD /usr/sbin/upssched
+  NOTIFYFLAG ONBATT SYSLOG+EXEC
+  NOTIFYFLAG ONLINE SYSLOG+EXEC
+  NOTIFYFLAG LOWBATT SYSLOG+EXEC
+  NOTIFYFLAG FSD SYSLOG+EXEC

--- a/ansible/inventory/default
+++ b/ansible/inventory/default
@@ -31,6 +31,7 @@ k3
 infra1
 
 [nut_client]
+p1
 p2
 p3
 p4

--- a/ansible/roles/nut/tasks/main.yaml
+++ b/ansible/roles/nut/tasks/main.yaml
@@ -50,7 +50,17 @@
     owner: "root"
     group: "nut"
     mode: "0640"
-  when: "nut_onbatt_timer is defined"
+  when: nut_shutdown_delay is defined or nut_notify_email is defined
+  tags: nut
+
+- name: Install upssched-cmd.sh script (for client shutdown)
+  ansible.builtin.template:
+    src: upssched-cmd.sh.j2
+    dest: /etc/nut/upssched-cmd.sh
+    owner: root
+    group: nut
+    mode: "0750"
+  when: nut_shutdown_delay is defined
   tags: nut
 
 - name: Include webgui tasks if enabled

--- a/ansible/roles/nut/templates/upssched-cmd.sh.j2
+++ b/ansible/roles/nut/templates/upssched-cmd.sh.j2
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Handle upssched timer events (client shutdown)
+
+case "$1" in
+    shutdown)
+        logger -t upssched "Initiating UPS-triggered shutdown"
+        /sbin/shutdown -h +0 "UPS battery timeout - shutting down"
+        ;;
+    *)
+        logger -t upssched "Unknown event: $1"
+        ;;
+esac

--- a/ansible/site.yaml
+++ b/ansible/site.yaml
@@ -138,6 +138,12 @@
     - role: nut
       tags: nut
 
+- name: NUT clients
+  hosts: nut_client
+  roles:
+    - role: nut
+      tags: nut
+
 - name: OS install server
   hosts: infra1
   roles:

--- a/ansible/templates/nut/upssched.conf.j2
+++ b/ansible/templates/nut/upssched.conf.j2
@@ -1,23 +1,29 @@
-CMDSCRIPT /etc/nut/notify-email.sh
 PIPEFN /run/nut/upssched.pipe
 LOCKFN /run/nut/upssched.lock
+
+{% if nut_shutdown_delay is defined %}
+# Client: shutdown after battery timeout
+CMDSCRIPT /etc/nut/upssched-cmd.sh
+
+AT ONBATT * START-TIMER shutdown {{ nut_shutdown_delay }}
+AT ONLINE * CANCEL-TIMER shutdown
+AT LOWBATT * START-TIMER shutdown 30
+AT FSD * EXECUTE shutdown
+
+{% elif nut_notify_email is defined %}
+# Server: email notifications
+CMDSCRIPT /etc/nut/notify-email.sh
 
 AT ONBATT * START-TIMER onbatt_timer 15
 AT ONLINE * START-TIMER online_timer 15
 AT LOWBATT * START-TIMER lowbatt_timer 15
-AT FSD * START-TIMER fsd_timer 15
 AT COMMBAD * START-TIMER commbad_timer 15
 AT COMMOK * START-TIMER commok_timer 15
-AT REPLBATT * START-TIMER replbatt_timer 15
-AT NOCOMM * START-TIMER nocomm_timer 15
-AT SHUTDOWN * START-TIMER shutdown_timer 15
 
 AT onbatt_timer * EXECUTE onbatt_timer
 AT online_timer * EXECUTE online_timer
 AT lowbatt_timer * EXECUTE lowbatt_timer
-AT fsd_timer * EXECUTE fsd_timer
 AT commbad_timer * EXECUTE commbad_timer
 AT commok_timer * EXECUTE commok_timer
-AT replbatt_timer * EXECUTE replbatt_timer
-AT nocomm_timer * EXECUTE nocomm_timer
-AT shutdown_timer * EXECUTE shutdown_timer
+
+{% endif %}


### PR DESCRIPTION
Configure p1-p4 to shutdown gracefully 5 minutes after power loss,
ensuring clean unmount of Synology storage before it enters Safe Mode.

- Add nut_client group with p1-p4
- Add group_vars for NUT client config (5-min shutdown delay)
- Add upssched-cmd.sh script for handling shutdown events
- Update upssched.conf template for client shutdown logic
- LOWBATT uses 30-second timer (prevents boot loop when UPS LB flag persists)
- FSD triggers immediate shutdown
