### PR TITLE
replace relaymail with postfix

### DIFF
--- a/ansible/site.yaml
+++ b/ansible/site.yaml
@@ -124,7 +124,6 @@
       tags: chrony
     - role: oefenweb.postfix
       tags: postfix
-      when: is_vagrant is undefined or not is_vagrant
     - role: resticprofile
       tags: [restic, resticprofile]
 


### PR DESCRIPTION
Remove the `is_vagrant` conditional from the postfix role - Vagrant support is no longer needed.