### PR TITLE
Run git commit inside nix develop for pre-commit hooks

### DIFF
--- a/.github/workflows/render-helm.yaml
+++ b/.github/workflows/render-helm.yaml
@@ -108,7 +108,7 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add .
         if ! git diff --cached --quiet; then
-          git commit -m "chore: regenerate Helm manifests"
+          nix develop --command git commit -m "chore: regenerate Helm manifests"
         fi
 
     - name: Push changes via PAT


### PR DESCRIPTION
Pre-commit hooks use language:system and require nix-provided tools
(ruamel-yaml, pyyaml, kyverno). Running the commit inside nix develop
ensures these tools are available in PATH.
