### PR TITLE
Add mcp-cli for Home Assistant entity queries

### DIFF
--- a/.claude/rules/integrations/home-assistant.md
+++ b/.claude/rules/integrations/home-assistant.md
@@ -1,12 +1,66 @@
 ---
-paths: ["kubernetes/hass/**/*"]
+paths: ["kubernetes/hass/**/*", "esphome/**/*"]
 ---
 
-# Home Assistant Metrics and Entity Discovery
+# Home Assistant
+
+## Entity Discovery & Troubleshooting
+
+Use the **mcp-cli** skill to query Home Assistant. The `hass` server is
+configured in `.mcp_servers.json`.
+
+### Common Tasks
+
+**Find entities:**
+
+```bash
+mcp-cli hass/search_entities_tool '{"query":"temperature"}'
+mcp-cli hass/list_entities '{"domain":"light"}'
+```
+
+**Get entity state:**
+
+```bash
+mcp-cli hass/get_entity '{"entity_id":"sensor.office_temperature"}'
+mcp-cli hass/get_entity '{"entity_id":"light.kitchen", "detailed":true}'
+```
+
+**Check history:**
+
+```bash
+mcp-cli hass/get_history '{"entity_id":"climate.office", "hours":24}'
+```
+
+**Debug issues:**
+
+```bash
+mcp-cli hass/get_error_log '{}'
+mcp-cli hass/list_automations '{}'
+```
+
+**System overview:**
+
+```bash
+mcp-cli hass/system_overview '{}'
+```
+
+### Available Tools
+
+| Tool                   | Purpose                      |
+| ---------------------- | ---------------------------- |
+| `get_entity`           | Get state of specific entity |
+| `search_entities_tool` | Search entities by query     |
+| `list_entities`        | List entities by domain      |
+| `domain_summary_tool`  | Summary of domain's entities |
+| `system_overview`      | Full HA system overview      |
+| `list_automations`     | List all automations         |
+| `get_history`          | Entity state history         |
+| `get_error_log`        | HA error log                 |
+| `call_service_tool`    | Call any HA service          |
+
+## Prometheus Metrics (Alternative)
 
 Script: `kubernetes/hass/get-prom-metrics`
-
-## Usage Pattern
 
 Cache output to avoid repeated API calls:
 
@@ -15,11 +69,4 @@ Cache output to avoid repeated API calls:
 grep -i "keyword" /tmp/hass-metrics.txt
 ```
 
-Only re-fetch if data has changed (e.g., new devices added).
-
-## Common Discovery Patterns
-
-- Entity names: `grep 'entity="sensor\.'`
-- Binary sensors: `grep 'entity="binary_sensor\.'`
-- Sensor values: `grep 'hass_sensor_temperature_celsius'`
-- By friendly name: `grep -i 'friendly_name=".*keyword"'`
+Use for numeric metrics; use mcp-cli for entity state and troubleshooting.

--- a/.claude/skills/mcp-cli/SKILL.md
+++ b/.claude/skills/mcp-cli/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: mcp-cli
+description:
+  Interface for MCP (Model Context Protocol) servers via CLI. Use when you need
+  to interact with external tools, APIs, or data sources through MCP servers.
+---
+
+# MCP-CLI
+
+Access MCP servers through the command line. MCP enables interaction with
+external systems like GitHub, filesystems, databases, and APIs.
+
+## Commands
+
+| Command                            | Output                          |
+| ---------------------------------- | ------------------------------- |
+| `mcp-cli`                          | List all servers and tool names |
+| `mcp-cli <server>`                 | Show tools with parameters      |
+| `mcp-cli <server>/<tool>`          | Get tool JSON schema            |
+| `mcp-cli <server>/<tool> '<json>'` | Call tool with arguments        |
+| `mcp-cli grep "<glob>"`            | Search tools by name            |
+
+**Add `-d` to include descriptions** (e.g., `mcp-cli filesystem -d`)
+
+## Workflow
+
+1. **Discover**: `mcp-cli` → see available servers and tools
+2. **Explore**: `mcp-cli <server>` → see tools with parameters
+3. **Inspect**: `mcp-cli <server>/<tool>` → get full JSON input schema
+4. **Execute**: `mcp-cli <server>/<tool> '<json>'` → run with arguments
+
+## Examples
+
+```bash
+# List all servers and tool names
+mcp-cli
+
+# See all tools with parameters
+mcp-cli filesystem
+
+# With descriptions (more verbose)
+mcp-cli filesystem -d
+
+# Get JSON schema for specific tool
+mcp-cli filesystem/read_file
+
+# Call the tool
+mcp-cli filesystem/read_file '{"path": "./README.md"}'
+
+# Search for tools
+mcp-cli grep "*file*"
+
+# JSON output for parsing
+mcp-cli filesystem/read_file '{"path": "./README.md"}' --json
+
+# Complex JSON with quotes (use '-' for stdin input)
+mcp-cli server/tool - <<EOF
+{"content": "Text with 'quotes' inside"}
+EOF
+
+# Or pipe from a file/command
+cat args.json | mcp-cli server/tool -
+
+# Complex Command chaining with xargs and jq
+mcp-cli filesystem/search_files '{"path": "src/", "pattern": "*.ts"}' --json | jq -r '.content[0].text' | head -1 | xargs -I {} sh -c 'mcp-cli filesystem/read_file "{\"path\": \"{}\"}"'
+```
+
+## Options
+
+| Flag         | Purpose                   |
+| ------------ | ------------------------- |
+| `-j, --json` | JSON output for scripting |
+| `-r, --raw`  | Raw text content          |
+| `-d`         | Include descriptions      |
+
+## Exit Codes
+
+- `0`: Success
+- `1`: Client error (bad args, missing config)
+- `2`: Server error (tool failed)
+- `3`: Network error

--- a/.envrc
+++ b/.envrc
@@ -61,6 +61,9 @@ if [[ -f .secrets.age ]]; then
   fi
 fi
 
+# MCP CLI config (used by: mcp-cli for hass-mcp)
+export MCP_CONFIG_PATH=".mcp_servers.json"
+
 # ARA (Ansible Run Analysis) configuration
 # Sends playbook run data to centralized ARA server at ara.k.oneill.net
 export ARA_API_CLIENT=http

--- a/.mcp_servers.json
+++ b/.mcp_servers.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "hass": {
+      "command": "uvx",
+      "args": ["hass-mcp"],
+      "env": {
+        "HA_URL": "https://hass.k.oneill.net",
+        "HA_TOKEN": "${HASS_BEARER_TOKEN}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Add mcp-cli to flake.nix (fetches pre-built binary)
- Configure hass-mcp server in .mcp_servers.json
- Add MCP_CONFIG_PATH to .envrc
- Add generic mcp-cli skill to .claude/skills/
- Update home-assistant.md rules with mcp-cli examples

Enables Claude to query HA entities, state, history, and error logs
on-demand without loading MCP tools into context.
