### PR TITLE
Fix INJECT_FACTS_AS_VARS deprecations and add CI tracking

### DIFF
--- a/ansible/deprecation-allowlist.yaml
+++ b/ansible/deprecation-allowlist.yaml
@@ -1,0 +1,17 @@
+---
+# Ansible Deprecation Allowlist
+#
+# Format: deprecation pattern -> list of task contexts
+# Auto-generated from: /tmp/docker-test-output.log
+#
+# Regenerate with: check-deprecations --generate <logfile>
+
+"INJECT_FACTS_AS_VARS default to `True` is deprecat":
+  - "TASK [oefenweb.postfix : configure mailname]"
+  - "TASK [oefenweb.postfix : facts | set | is_docker_guest]"
+  - "TASK [oefenweb.postfix : update configuration file]"
+  - "TASK [resticprofile : Download restic]"
+  - "TASK [resticprofile : Download resticprofile]"
+
+"Importing 'to_native' from 'ansible.module_utils._":
+  - "TASK [common : Configure sysctl for inotify]"

--- a/ansible/group_vars/all/main.yaml
+++ b/ansible/group_vars/all/main.yaml
@@ -1,3 +1,3 @@
 ---
-# Used by chrony role (tbaczynski.chrony) to conditionally configure UFW firewall rules
+# Used by chrony role to conditionally configure UFW firewall rules
 enable_ufw: false

--- a/ansible/group_vars/all/node_exporter.yaml
+++ b/ansible/group_vars/all/node_exporter.yaml
@@ -11,5 +11,5 @@ node_exporter_arch: >-
       'x86_64': 'amd64',
       'aarch64': 'arm64',
       'armv7l': 'armv7'
-    }.get(ansible_architecture, ansible_architecture)
+    }.get(ansible_facts['architecture'], ansible_facts['architecture'])
   }}

--- a/ansible/roles/setup_upgrade/handlers/main.yaml
+++ b/ansible/roles/setup_upgrade/handlers/main.yaml
@@ -2,6 +2,6 @@
 - name: "Update grub"
   ansible.builtin.command: "update-grub"
   when:
-    - ansible_architecture == "x86_64"
+    - ansible_facts['architecture'] == "x86_64"
     - setup_upgrade_update_grub | default(true)
   failed_when: false

--- a/ansible/scripts/check-deprecations
+++ b/ansible/scripts/check-deprecations
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Check ansible output for deprecation warnings against a YAML allowlist.
+
+Usage:
+    check-deprecations <logfile>             Check against allowlist
+    check-deprecations --generate <logfile>  Generate new allowlist
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+SCRIPT_DIR = Path(__file__).parent
+ALLOWLIST_FILE = SCRIPT_DIR.parent / "deprecation-allowlist.yaml"
+
+
+def extract_deprecations(logfile: Path) -> dict[str, list[str]]:
+    """Extract deprecations with their task context from ansible output."""
+    deprecations: dict[str, list[str]] = {}
+    current_task = ""
+
+    task_pattern = re.compile(r"^(TASK|PLAY|RUNNING HANDLER) \[(.+)\]")
+    deprecation_pattern = re.compile(r"\[DEPRECATION WARNING\]: (.+)")
+
+    with open(logfile, encoding="utf-8") as f:
+        for line in f:
+            # Track current task/play context
+            if match := task_pattern.match(line):
+                current_task = match.group(0).replace("*", "").strip()
+
+            # Capture deprecation with context
+            if match := deprecation_pattern.search(line):
+                msg = match.group(1)
+                # Use first 50 chars as pattern key
+                pattern = msg[:50]
+                if pattern not in deprecations:
+                    deprecations[pattern] = []
+                if current_task and current_task not in deprecations[pattern]:
+                    deprecations[pattern].append(current_task)
+
+    return deprecations
+
+
+def generate_allowlist(deprecations: dict[str, list[str]], logfile: Path) -> None:
+    """Output YAML allowlist to stdout."""
+    print("---")
+    print("# Ansible Deprecation Allowlist")
+    print("#")
+    print("# Format: deprecation pattern -> list of task contexts")
+    print(f"# Auto-generated from: {logfile}")
+    print("#")
+    print("# Regenerate with: check-deprecations --generate <logfile>")
+    print()
+    print(yaml.dump(deprecations, default_flow_style=False, sort_keys=True))
+
+
+def check_deprecations(
+    found: dict[str, list[str]], expected: dict[str, list[str]]
+) -> bool:
+    """Check found deprecations against expected. Returns True if all match."""
+    print("=" * 46)
+    print("DEPRECATION WARNING REPORT")
+    print("=" * 46)
+    print()
+
+    total = sum(len(contexts) for contexts in found.values())
+    print(f"Total warnings found: {total}")
+    print()
+
+    has_errors = False
+    print("Deprecation status:")
+
+    # Check each found deprecation
+    for pattern, found_contexts in sorted(found.items()):
+        found_set = set(found_contexts)
+        count = len(found_contexts)
+
+        if pattern in expected:
+            expected_set = set(expected[pattern])
+            if found_set == expected_set:
+                print(f"  ✓ {pattern}... ({count} occurrences)")
+            else:
+                print(f"  ✗ {pattern}... (CHANGED)")
+                print(f"    Expected ({len(expected_set)}):")
+                for ctx in sorted(expected_set):
+                    print(f"      {ctx}")
+                print(f"    Found ({len(found_set)}):")
+                for ctx in sorted(found_set):
+                    print(f"      {ctx}")
+                has_errors = True
+        else:
+            print(f"  ✗ {pattern}... (NEW - {count} occurrences)")
+            print("    Contexts:")
+            for ctx in sorted(found_set):
+                print(f"      {ctx}")
+            has_errors = True
+
+    # Check for removed deprecations
+    for pattern in expected:
+        if pattern not in found:
+            print(f"  ⬇ {pattern}... (REMOVED - update allowlist)")
+            has_errors = True
+
+    print()
+
+    if has_errors:
+        print("To fix:")
+        print("  1. Address the deprecation in the code, OR")
+        print(
+            "  2. Regenerate: check-deprecations --generate <log> > "
+            "ansible/deprecation-allowlist.yaml"
+        )
+        print()
+        print("Status: FAIL")
+        print("=" * 46)
+        return False
+
+    print("Status: PASS")
+    print("=" * 46)
+    return True
+
+
+def main() -> int:
+    args = sys.argv[1:]
+
+    generate_mode = False
+    if args and args[0] == "--generate":
+        generate_mode = True
+        args = args[1:]
+
+    if len(args) != 1:
+        print("Usage: check-deprecations [--generate] <logfile>", file=sys.stderr)
+        return 1
+
+    logfile = Path(args[0])
+    if not logfile.exists():
+        print(f"Error: Log file not found: {logfile}", file=sys.stderr)
+        return 1
+
+    deprecations = extract_deprecations(logfile)
+
+    if generate_mode:
+        generate_allowlist(deprecations, logfile)
+        return 0
+
+    if not ALLOWLIST_FILE.exists():
+        print(f"Error: Allowlist file not found: {ALLOWLIST_FILE}", file=sys.stderr)
+        return 1
+
+    with open(ALLOWLIST_FILE, encoding="utf-8") as f:
+        expected = yaml.safe_load(f) or {}
+
+    if check_deprecations(deprecations, expected):
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ansible/scripts/docker-integration-test
+++ b/ansible/scripts/docker-integration-test
@@ -67,10 +67,22 @@ if [[ $# -eq 0 ]]; then
     # Copy vault password to workspace and execute the playbook inside the running container
     # Note: Mount to /var/lib/ because systemd mounts tmpfs over /tmp and /run
     docker exec "$CONTAINER_ID" cp /var/lib/ansible-vault-password /workspace/ansible/ansible-vault-password
-    if docker exec "$CONTAINER_ID" bash -c "cd /workspace && nix develop --command bash -c 'cd ansible && ansible-playbook -i inventory/test_local site.yaml'"; then
+
+    # Run playbook and capture output for deprecation analysis
+    ANSIBLE_LOG="/var/lib/ansible-output.log"
+    if docker exec "$CONTAINER_ID" bash -c "set -o pipefail; cd /workspace && nix develop --command bash -c 'cd ansible && ansible-playbook -i inventory/test_local site.yaml' 2>&1 | tee $ANSIBLE_LOG"; then
         EXIT_CODE=0
     else
         EXIT_CODE=$?
+    fi
+
+    # Check for new deprecation warnings (only if playbook succeeded)
+    if [[ $EXIT_CODE -eq 0 ]]; then
+        echo ""
+        echo "Checking for new deprecation warnings..."
+        if ! docker exec "$CONTAINER_ID" bash -c "cd /workspace && nix develop --command ansible/scripts/check-deprecations $ANSIBLE_LOG"; then
+            EXIT_CODE=1
+        fi
     fi
 
     # Clean up container


### PR DESCRIPTION
- Fix ansible_architecture -> ansible_facts['architecture'] in:
  - roles/setup_upgrade/handlers/main.yaml
  - group_vars/all/node_exporter.yaml
- Update stale comment referencing removed tbaczynski.chrony role
- Add deprecation tracking to integration tests:
  - Python script parses playbook output for deprecations
  - YAML allowlist tracks deprecations with task context
  - Fails CI if deprecations change (new, removed, or different tasks)
  - Use --generate to regenerate allowlist from test output

cc: https://github.com/claytono/infra/issues/1258
