### PR TITLE
Fix resticprofile INJECT_FACTS_AS_VARS deprecation

### DIFF
--- a/ansible/deprecation-allowlist.yaml
+++ b/ansible/deprecation-allowlist.yaml
@@ -10,8 +10,6 @@
   - "TASK [oefenweb.postfix : configure mailname]"
   - "TASK [oefenweb.postfix : facts | set | is_docker_guest]"
   - "TASK [oefenweb.postfix : update configuration file]"
-  - "TASK [resticprofile : Download restic]"
-  - "TASK [resticprofile : Download resticprofile]"
 
 "Importing 'to_native' from 'ansible.module_utils._":
   - "TASK [common : Configure sysctl for inotify]"

--- a/ansible/roles/resticprofile/tasks/install.yaml
+++ b/ansible/roles/resticprofile/tasks/install.yaml
@@ -69,7 +69,7 @@
     dest: "{{ resticprofile_tmp_dir }}/restic.bz2"
     mode: "0640"
   vars:
-    resticprofile_os: "{{ ansible_system | lower }}"
+    resticprofile_os: "{{ ansible_facts['system'] | lower }}"
   when: resticprofile_install_restic
 
 - name: Extract restic
@@ -94,7 +94,7 @@
     dest: "{{ resticprofile_tmp_dir }}/resticprofile.tar.gz"
     mode: "0640"
   vars:
-    resticprofile_os: "{{ ansible_system | lower }}"
+    resticprofile_os: "{{ ansible_facts['system'] | lower }}"
   when: resticprofile_install_resticprofile
 
 - name: Extract resticprofile.tgz

--- a/ansible/scripts/check-deprecations
+++ b/ansible/scripts/check-deprecations
@@ -70,7 +70,8 @@ def check_deprecations(
     print(f"Total warnings found: {total}")
     print()
 
-    has_errors = False
+    has_new = False
+    needs_update = False
     print("Deprecation status:")
 
     # Check each found deprecation
@@ -90,27 +91,34 @@ def check_deprecations(
                 print(f"    Found ({len(found_set)}):")
                 for ctx in sorted(found_set):
                     print(f"      {ctx}")
-                has_errors = True
+                needs_update = True
+                # New contexts appeared - this is a real issue
+                if found_set - expected_set:
+                    has_new = True
         else:
             print(f"  ✗ {pattern}... (NEW - {count} occurrences)")
             print("    Contexts:")
             for ctx in sorted(found_set):
                 print(f"      {ctx}")
-            has_errors = True
+            has_new = True
 
     # Check for removed deprecations
     for pattern in expected:
         if pattern not in found:
             print(f"  ⬇ {pattern}... (REMOVED - update allowlist)")
-            has_errors = True
+            needs_update = True
 
     print()
 
-    if has_errors:
+    if has_new or needs_update:
         print("To fix:")
-        print("  1. Address the deprecation in the code, OR")
+        if has_new:
+            print("  1. Address the new deprecation in the code, OR")
+            print("  2. Add to allowlist if it cannot be fixed")
+        else:
+            print("  Deprecations were fixed! Regenerate the allowlist:")
         print(
-            "  2. Regenerate: check-deprecations --generate <log> > "
+            "     check-deprecations --generate <logfile> > "
             "ansible/deprecation-allowlist.yaml"
         )
         print()


### PR DESCRIPTION
- Change ansible_system to ansible_facts['system'] in resticprofile role
- Update allowlist to reflect fixed deprecations
- Improve check-deprecations messaging to distinguish new vs fixed deprecations
