### PR TITLE
Move image pins into manifests

### DIFF
--- a/kubernetes/acme-sh/cronjob-renew.yaml
+++ b/kubernetes/acme-sh/cronjob-renew.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
           - name: acme-sh
-            image: neilpang/acme.sh@sha256:c4dfbb35feddff3145ed417cf5179b25faa89bd32551d1104ce28d50bd190920
+            image: neilpang/acme.sh:3.1.2@sha256:3c6b40e30e2c0c79863ba6ef5545d93350a040371213058099066ccd85b46aad
             command: [/bin/sh, /scripts/acme-renew.sh]
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/acme-sh/cronjob-synology.yaml
+++ b/kubernetes/acme-sh/cronjob-synology.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
           - name: acme-sh
-            image: neilpang/acme.sh@sha256:c4dfbb35feddff3145ed417cf5179b25faa89bd32551d1104ce28d50bd190920
+            image: neilpang/acme.sh:3.1.2@sha256:3c6b40e30e2c0c79863ba6ef5545d93350a040371213058099066ccd85b46aad
             command: [/bin/sh, /scripts/acme-synology.sh]
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/acme-sh/cronjob-udmp.yaml
+++ b/kubernetes/acme-sh/cronjob-udmp.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
           - name: acme-sh
-            image: neilpang/acme.sh@sha256:c4dfbb35feddff3145ed417cf5179b25faa89bd32551d1104ce28d50bd190920
+            image: neilpang/acme.sh:3.1.2@sha256:3c6b40e30e2c0c79863ba6ef5545d93350a040371213058099066ccd85b46aad
             command: [/bin/sh, /scripts/acme-udmp.sh]
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/acme-sh/kustomization.yaml
+++ b/kubernetes/acme-sh/kustomization.yaml
@@ -28,7 +28,3 @@ configMapGenerator:
   - ssh-config
   options:
     disableNameSuffixHash: true
-
-images:
-- name: neilpang/acme.sh
-  newTag: 3.1.2@sha256:3c6b40e30e2c0c79863ba6ef5545d93350a040371213058099066ccd85b46aad

--- a/kubernetes/alertmanager/deploy.yaml
+++ b/kubernetes/alertmanager/deploy.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       initContainers:
       - name: gomplate-config
-        image: hairyhenderson/gomplate@sha256:55db623a1e3d620501fbf3ff01753cfde101d9b49fa5ff0132b4a8d0c246c16c
+        image: hairyhenderson/gomplate:v4.3.3@sha256:55db623a1e3d620501fbf3ff01753cfde101d9b49fa5ff0132b4a8d0c246c16c
         args:
         - --file
         - /etc/alertmanager/config.template.yaml
@@ -46,7 +46,7 @@ spec:
           mountPath: /config
       containers:
       - name: alertmanager
-        image: prom/alertmanager@sha256:286ad8838533a5a01d89bd09643f43d2b68b65203123b5700e54a8f80ff9c1f4
+        image: prom/alertmanager:v0.30.0@sha256:abb750ac7b63116761c16dd481ae92496fbe04721686c0920f0fa4d0728cd4a6
         args:
         - --config.file=/config/config.yaml
         - --storage.path=/alertmanager

--- a/kubernetes/alertmanager/kustomization.yaml
+++ b/kubernetes/alertmanager/kustomization.yaml
@@ -17,12 +17,6 @@ resources:
 - pvc.yaml
 - externalsecret.yaml
 
-images:
-- name: hairyhenderson/gomplate
-  newTag: v4.3.3@sha256:55db623a1e3d620501fbf3ff01753cfde101d9b49fa5ff0132b4a8d0c246c16c
-- name: prom/alertmanager
-  newTag: v0.30.0@sha256:abb750ac7b63116761c16dd481ae92496fbe04721686c0920f0fa4d0728cd4a6
-
 labels:
 
 - pairs:

--- a/kubernetes/autobrr/deploy.yaml
+++ b/kubernetes/autobrr/deploy.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: autobrr
-        image: ghcr.io/autobrr/autobrr@sha256:db9794958a0f9db93059c1e9f06193a063ce3846d346d7a7c9eca607c6617c51
+        image: ghcr.io/autobrr/autobrr:v1.71.0@sha256:db9794958a0f9db93059c1e9f06193a063ce3846d346d7a7c9eca607c6617c51
         ports:
         - containerPort: 7474
         envFrom:

--- a/kubernetes/autobrr/kustomization.yaml
+++ b/kubernetes/autobrr/kustomization.yaml
@@ -22,10 +22,6 @@ configMapGenerator:
   - AUTOBRR__OIDC_ISSUER=https://auth.k.oneill.net/application/o/autobrr/
   - AUTOBRR__OIDC_REDIRECT_URL=https://autobrr.k.oneill.net/api/auth/oidc/callback
 
-images:
-- name: ghcr.io/autobrr/autobrr
-  newTag: v1.71.0@sha256:db9794958a0f9db93059c1e9f06193a063ce3846d346d7a7c9eca607c6617c51
-
 labels:
 
 - pairs:

--- a/kubernetes/awair-exporter/deploy.yaml
+++ b/kubernetes/awair-exporter/deploy.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: awair-exporter
-        image: dvorak/awair_exporter@sha256:5c0cae7ff6b699eec82c28ad1b54b22142ab09aeb99688cd397948167f8cca91
+        image: dvorak/awair_exporter:latest@sha256:5c0cae7ff6b699eec82c28ad1b54b22142ab09aeb99688cd397948167f8cca91
         imagePullPolicy: Always
         envFrom:
         - secretRef:

--- a/kubernetes/awair-exporter/kustomization.yaml
+++ b/kubernetes/awair-exporter/kustomization.yaml
@@ -12,10 +12,6 @@ resources:
 - service.yaml
 - externalsecret.yaml
 
-images:
-- name: dvorak/awair_exporter
-  newTag: latest@sha256:5c0cae7ff6b699eec82c28ad1b54b22142ab09aeb99688cd397948167f8cca91
-
 labels:
 
 - pairs:

--- a/kubernetes/bazarr/deploy.yaml
+++ b/kubernetes/bazarr/deploy.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: bazarr
-        image: linuxserver/bazarr@sha256:5af962ae633e97c8e008e4b6e638798de1420e8a9e8e6189beb108a52c6e942a
+        image: linuxserver/bazarr:1.5.3@sha256:001875e61839c8a50743f0bc0fa4da2a55ed8a038b9b5ed0dd2c663dd3d0bfc7
         ports:
         - containerPort: 6767
         volumeMounts:

--- a/kubernetes/bazarr/kustomization.yaml
+++ b/kubernetes/bazarr/kustomization.yaml
@@ -16,10 +16,6 @@ resources:
 - service.yaml
 - ingress.yaml
 
-images:
-- name: linuxserver/bazarr
-  newTag: 1.5.3@sha256:001875e61839c8a50743f0bc0fa4da2a55ed8a038b9b5ed0dd2c663dd3d0bfc7
-
 labels:
 
 - pairs:

--- a/kubernetes/blackbox-exporter/deploy.yaml
+++ b/kubernetes/blackbox-exporter/deploy.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: blackbox-exporter
-        image: prom/blackbox-exporter@sha256:e753ff9f3fc458d02cca5eddab5a77e1c175eee484a8925ac7d524f04366c2fc
+        image: prom/blackbox-exporter:v0.28.0@sha256:e753ff9f3fc458d02cca5eddab5a77e1c175eee484a8925ac7d524f04366c2fc
         imagePullPolicy: Always
         args: [--config.file=/config/config.yaml]
         volumeMounts:

--- a/kubernetes/blackbox-exporter/kustomization.yaml
+++ b/kubernetes/blackbox-exporter/kustomization.yaml
@@ -13,10 +13,6 @@ resources:
 - deploy.yaml
 - service.yaml
 
-images:
-- name: prom/blackbox-exporter
-  newTag: v0.28.0@sha256:e753ff9f3fc458d02cca5eddab5a77e1c175eee484a8925ac7d524f04366c2fc
-
 labels:
 
 - pairs:

--- a/kubernetes/bookshelf/deploy.yaml
+++ b/kubernetes/bookshelf/deploy.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: bookshelf
-        image: ghcr.io/pennydreadful/bookshelf
+        image: ghcr.io/pennydreadful/bookshelf:hardcover-v0.4.20.91@sha256:fd6183d0eacf1cac6ce3a0c8ff2b0d5af9ddf2101141f6c86c928a136c9b2d95
         ports:
         - containerPort: 8787
         volumeMounts:

--- a/kubernetes/bookshelf/kustomization.yaml
+++ b/kubernetes/bookshelf/kustomization.yaml
@@ -23,10 +23,6 @@ configMapGenerator:
   files:
   - copy-to-booklore.sh
 
-images:
-- name: ghcr.io/pennydreadful/bookshelf
-  newTag: hardcover-v0.4.20.91@sha256:fd6183d0eacf1cac6ce3a0c8ff2b0d5af9ddf2101141f6c86c928a136c9b2d95
-
 labels:
 
 - pairs:

--- a/kubernetes/changedetection/deploy.yaml
+++ b/kubernetes/changedetection/deploy.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: changedetection
-        image: dgtlmoon/changedetection.io@sha256:e95931043d68da46e90498ce74ad317b392caade07186dc06bdfa1710901bf90
+        image: dgtlmoon/changedetection.io:0.51.4@sha256:99cf11f04b5d1f1300b5b68f17dc22e76bdb5d6695d7e6590d2df92eca8fb339
         ports:
         - name: changedetection
           containerPort: 5000
@@ -35,7 +35,7 @@ spec:
         - name: PLAYWRIGHT_DRIVER_URL
           value: ws://localhost:3000/
       - name: browserless
-        image: dgtlmoon/sockpuppetbrowser@sha256:7116c61ef9cfce3d48a7efd9355d2fbe19f593ea3cfb52a5ded40ecbcb0a3f9d
+        image: dgtlmoon/sockpuppetbrowser:0.0.3@sha256:23a7be698216407648b6c78fc55de0411bde550635edc30347373c86a5176fad
         resources:
           limits:
             memory: 2Gi

--- a/kubernetes/changedetection/kustomization.yaml
+++ b/kubernetes/changedetection/kustomization.yaml
@@ -16,12 +16,6 @@ resources:
 commonAnnotations:
   argoManaged: 'true'
 
-images:
-- name: dgtlmoon/changedetection.io
-  newTag: 0.51.4@sha256:99cf11f04b5d1f1300b5b68f17dc22e76bdb5d6695d7e6590d2df92eca8fb339
-- name: dgtlmoon/sockpuppetbrowser
-  newTag: 0.0.3@sha256:23a7be698216407648b6c78fc55de0411bde550635edc30347373c86a5176fad
-
 labels:
 
 - pairs:

--- a/kubernetes/cluster-backup/cronjob.yaml
+++ b/kubernetes/cluster-backup/cronjob.yaml
@@ -20,7 +20,7 @@ spec:
           hostNetwork: true
           containers:
           - name: cluster-backup
-            image: alpine@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
+            image: alpine:3.23@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
             imagePullPolicy: Always
             command:
             - /script/backup

--- a/kubernetes/cluster-backup/kustomization.yaml
+++ b/kubernetes/cluster-backup/kustomization.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 namespace: kube-system
 
 resources:
@@ -8,10 +9,6 @@ resources:
 
 commonAnnotations:
   argoManaged: 'true'
-
-images:
-- name: alpine
-  newTag: 3.23@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
 
 labels:
 

--- a/kubernetes/cross-seed/deploy.yaml
+++ b/kubernetes/cross-seed/deploy.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: cross-seed
-        image: ghcr.io/cross-seed/cross-seed@sha256:e2bf5b593e4e7d699e6242423ad7966190cd52ba8eefafdfdbb0cb5b0b609b96
+        image: ghcr.io/cross-seed/cross-seed:6.13.6@sha256:e2bf5b593e4e7d699e6242423ad7966190cd52ba8eefafdfdbb0cb5b0b609b96
         command: [cross-seed, daemon]
         ports:
         - containerPort: 2468

--- a/kubernetes/cross-seed/kustomization.yaml
+++ b/kubernetes/cross-seed/kustomization.yaml
@@ -15,10 +15,6 @@ resources:
 - externalsecret.yaml
 - pvc-config.yaml
 
-images:
-- name: ghcr.io/cross-seed/cross-seed
-  newTag: 6.13.6@sha256:e2bf5b593e4e7d699e6242423ad7966190cd52ba8eefafdfdbb0cb5b0b609b96
-
 configMapGenerator:
 - name: cross-seed-config
   files:

--- a/kubernetes/ddns-route53/deploy.yaml
+++ b/kubernetes/ddns-route53/deploy.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: oneill
-        image: ghcr.io/crazy-max/ddns-route53@sha256:59b1f3d51530f8e1a8331ad9c63c4be414f72503b306eea7f3b3abf532ce2ae5
+        image: ghcr.io/crazy-max/ddns-route53:2.13.0@sha256:d10e583abf0f5665217d557d8cafb9806e6fb079b7d255b516fe1f5dbf90a1b3
         args:
         - --schedule=*/5 * * * *
         securityContext:
@@ -54,15 +54,15 @@ spec:
         - name: DDNSR53_ROUTE53_RECORDSSET_0_TYPE
           value: A
         - name: DDNSR53_ROUTE53_RECORDSSET_0_TTL
-          value: "300"
+          value: '300'
         - name: DDNSR53_ROUTE53_RECORDSSET_1_NAME
           value: luser.oneill.net.
         - name: DDNSR53_ROUTE53_RECORDSSET_1_TYPE
           value: AAAA
         - name: DDNSR53_ROUTE53_RECORDSSET_1_TTL
-          value: "300"
+          value: '300'
       - name: fnord
-        image: ghcr.io/crazy-max/ddns-route53@sha256:59b1f3d51530f8e1a8331ad9c63c4be414f72503b306eea7f3b3abf532ce2ae5
+        image: ghcr.io/crazy-max/ddns-route53:2.13.0@sha256:d10e583abf0f5665217d557d8cafb9806e6fb079b7d255b516fe1f5dbf90a1b3
         args:
         - --schedule=*/5 * * * *
         securityContext:
@@ -92,10 +92,10 @@ spec:
         - name: DDNSR53_ROUTE53_RECORDSSET_0_TYPE
           value: A
         - name: DDNSR53_ROUTE53_RECORDSSET_0_TTL
-          value: "300"
+          value: '300'
         - name: DDNSR53_ROUTE53_RECORDSSET_1_NAME
           value: luser.fnord.net.
         - name: DDNSR53_ROUTE53_RECORDSSET_1_TYPE
           value: AAAA
         - name: DDNSR53_ROUTE53_RECORDSSET_1_TTL
-          value: "300"
+          value: '300'

--- a/kubernetes/ddns-route53/kustomization.yaml
+++ b/kubernetes/ddns-route53/kustomization.yaml
@@ -17,7 +17,3 @@ labels:
     app.kubernetes.io/name: ddns-route53
     app.kubernetes.io/instance: ddns-route53
   includeSelectors: true
-
-images:
-- name: ghcr.io/crazy-max/ddns-route53
-  newTag: 2.13.0@sha256:d10e583abf0f5665217d557d8cafb9806e6fb079b7d255b516fe1f5dbf90a1b3

--- a/kubernetes/got-your-back/cronjob-full.yaml
+++ b/kubernetes/got-your-back/cronjob-full.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
           - name: got-your-back
-            image: debian@sha256:5cf544fad978371b3df255b61e209b373583cb88b733475c86e49faa15ac2104
+            image: debian:stable-slim@sha256:ed542b2d269ff08139fc5ab8c762efe8c8986b564a423d5241a5ce9fb09b6c08
             command: [/usr/local/bin/run]
             imagePullPolicy: Always
             env:

--- a/kubernetes/got-your-back/cronjob-incremental.yaml
+++ b/kubernetes/got-your-back/cronjob-incremental.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
           - name: got-your-back
-            image: debian@sha256:5cf544fad978371b3df255b61e209b373583cb88b733475c86e49faa15ac2104
+            image: debian:stable-slim@sha256:ed542b2d269ff08139fc5ab8c762efe8c8986b564a423d5241a5ce9fb09b6c08
             command: [/usr/local/bin/run, --fast-incremental]
             imagePullPolicy: Always
             env:

--- a/kubernetes/got-your-back/kustomization.yaml
+++ b/kubernetes/got-your-back/kustomization.yaml
@@ -13,10 +13,6 @@ resources:
 commonAnnotations:
   argoManaged: 'true'
 
-images:
-- name: debian
-  newTag: stable-slim@sha256:ed542b2d269ff08139fc5ab8c762efe8c8986b564a423d5241a5ce9fb09b6c08
-
 labels:
 
 - pairs:

--- a/kubernetes/huntarr/deploy.yaml
+++ b/kubernetes/huntarr/deploy.yaml
@@ -22,7 +22,7 @@ spec:
       enableServiceLinks: false
       containers:
       - name: huntarr
-        image: ghcr.io/plexguide/huntarr@sha256:f84ea30ce0a358e6be628925f8e45cdcafcdff1d4bed59e4e64f493011415822
+        image: ghcr.io/plexguide/huntarr:8.2.10@sha256:b5a47c2b43806165f433d308d69a21e74a687ce59f4fcccb612d6a7acb3af6d7
         ports:
         - containerPort: 9705
         volumeMounts:

--- a/kubernetes/huntarr/kustomization.yaml
+++ b/kubernetes/huntarr/kustomization.yaml
@@ -16,10 +16,6 @@ resources:
 - ingress.yaml
 - pvc-config.yaml
 
-images:
-- name: ghcr.io/plexguide/huntarr
-  newTag: 8.2.10@sha256:b5a47c2b43806165f433d308d69a21e74a687ce59f4fcccb612d6a7acb3af6d7
-
 labels:
 
 - pairs:

--- a/kubernetes/meshcentral/deploy.yaml
+++ b/kubernetes/meshcentral/deploy.yaml
@@ -31,7 +31,7 @@ spec:
                 operator: Exists
       containers:
       - name: meshcentral
-        image: typhonragewind/meshcentral@sha256:9ea262ff902fa18fcca8688af4c7fe62988254f5cf08f273193bec6b4cf626be
+        image: typhonragewind/meshcentral:1.1.53@sha256:9ea262ff902fa18fcca8688af4c7fe62988254f5cf08f273193bec6b4cf626be
         imagePullPolicy: Always
         env:
         - name: TZ

--- a/kubernetes/meshcentral/kustomization.yaml
+++ b/kubernetes/meshcentral/kustomization.yaml
@@ -13,10 +13,6 @@ resources:
 commonAnnotations:
   argoManaged: 'true'
 
-images:
-- name: typhonragewind/meshcentral
-  newTag: 1.1.53@sha256:9ea262ff902fa18fcca8688af4c7fe62988254f5cf08f273193bec6b4cf626be
-
 labels:
 
 - pairs:

--- a/kubernetes/mosquitto/deploy.yaml
+++ b/kubernetes/mosquitto/deploy.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       initContainers:
       - name: init-password-file
-        image: alpine@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
+        image: alpine:3.23@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
         command: [/bin/sh, -c, /scripts/create-password-file > /generated/passwd]
         volumeMounts:
         - name: script
@@ -32,7 +32,7 @@ spec:
           mountPath: /generated
       containers:
       - name: mosquitto
-        image: eclipse-mosquitto@sha256:077fe4ff4c49df1e860c98335c77dda08360629e0e2a718147027e4db3eace9d
+        image: eclipse-mosquitto:2.0@sha256:077fe4ff4c49df1e860c98335c77dda08360629e0e2a718147027e4db3eace9d
         imagePullPolicy: Always
         resources:
           limits:

--- a/kubernetes/mosquitto/kustomization.yaml
+++ b/kubernetes/mosquitto/kustomization.yaml
@@ -14,12 +14,6 @@ resources:
 - pvc.yaml
 - service.yaml
 
-images:
-- name: alpine
-  newTag: 3.23@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
-- name: eclipse-mosquitto
-  newTag: 2.0@sha256:077fe4ff4c49df1e860c98335c77dda08360629e0e2a718147027e4db3eace9d
-
 labels:
 
 - pairs:

--- a/kubernetes/mqtt-log/deploy.yaml
+++ b/kubernetes/mqtt-log/deploy.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: mqtt-log
-        image: eclipse-mosquitto@sha256:077fe4ff4c49df1e860c98335c77dda08360629e0e2a718147027e4db3eace9d
+        image: eclipse-mosquitto:2.0@sha256:077fe4ff4c49df1e860c98335c77dda08360629e0e2a718147027e4db3eace9d
         env:
         - name: MQTT_USERNAME
           valueFrom:

--- a/kubernetes/mqtt-log/kustomization.yaml
+++ b/kubernetes/mqtt-log/kustomization.yaml
@@ -11,10 +11,6 @@ resources:
 - deploy.yaml
 - externalsecret.yaml
 
-images:
-- name: eclipse-mosquitto
-  newTag: 2.0@sha256:077fe4ff4c49df1e860c98335c77dda08360629e0e2a718147027e4db3eace9d
-
 labels:
 
 - pairs:

--- a/kubernetes/netatmo-exporter/deploy.yaml
+++ b/kubernetes/netatmo-exporter/deploy.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: netatmo-exporter
-        image: ghcr.io/xperimental/netatmo-exporter@sha256:db0f94e68faa98bde52b597a5085a0ca46ec50615fedd6f187080f18ac43344c
+        image: ghcr.io/xperimental/netatmo-exporter:2.1.2@sha256:db0f94e68faa98bde52b597a5085a0ca46ec50615fedd6f187080f18ac43344c
         env:
         - name: NETATMO_EXPORTER_TOKEN_FILE
           value: /data/token.json

--- a/kubernetes/netatmo-exporter/kustomization.yaml
+++ b/kubernetes/netatmo-exporter/kustomization.yaml
@@ -14,10 +14,6 @@ resources:
 - pvc.yaml
 - externalsecret.yaml
 
-images:
-- name: ghcr.io/xperimental/netatmo-exporter
-  newTag: 2.1.2@sha256:db0f94e68faa98bde52b597a5085a0ca46ec50615fedd6f187080f18ac43344c
-
 labels:
 
 - pairs:

--- a/kubernetes/netatmo-wunderground-agent/deploy.yaml
+++ b/kubernetes/netatmo-wunderground-agent/deploy.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: netatmo-wunderground-agent
-        image: brbeaird/netatmo-wunderground-agent@sha256:9762b8722cb99722fa7f0669d389b4298f8b8599c8f06d745683ae1d89f319fe
+        image: brbeaird/netatmo-wunderground-agent:latest@sha256:9762b8722cb99722fa7f0669d389b4298f8b8599c8f06d745683ae1d89f319fe
         env:
         - name: netatmo_tokenFileDirectory
           value: /data

--- a/kubernetes/netatmo-wunderground-agent/kustomization.yaml
+++ b/kubernetes/netatmo-wunderground-agent/kustomization.yaml
@@ -12,10 +12,6 @@ resources:
 - pvc.yaml
 - externalsecret.yaml
 
-images:
-- name: brbeaird/netatmo-wunderground-agent
-  newTag: latest@sha256:9762b8722cb99722fa7f0669d389b4298f8b8599c8f06d745683ae1d89f319fe
-
 labels:
 
 - pairs:

--- a/kubernetes/network-storage-benchmark/kustomization.yaml
+++ b/kubernetes/network-storage-benchmark/kustomization.yaml
@@ -4,10 +4,6 @@ kind: Kustomization
 
 namespace: network-storage-benchmark
 
-images:
-- name: alpine
-  newTag: "3.23@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62"
-
 resources:
 - namespace.yaml
 - pvc-iscsi.yaml

--- a/kubernetes/network-storage-benchmark/network-benchmark-server.yaml
+++ b/kubernetes/network-storage-benchmark/network-benchmark-server.yaml
@@ -43,7 +43,7 @@ spec:
 
       containers:
       - name: iperf-server
-        image: alpine@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
+        image: alpine:3.23@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
         command: [/bin/sh, -c]
         args:
         - |

--- a/kubernetes/openarchiver/deploy.yaml
+++ b/kubernetes/openarchiver/deploy.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: openarchiver
-        image: logiclabshq/open-archiver@sha256:ce5dadae4f1a0be84479718d7cc546cdcb821ea8c39e341f6ee3482c8a1e9796
+        image: docker.io/logiclabshq/open-archiver:v0.4.0@sha256:8b580260ae82d9f4656912a8d7dd57fbdaaca7b993c82a42f7f0514d8908597b
         imagePullPolicy: IfNotPresent
         envFrom:
         - configMapRef:

--- a/kubernetes/openarchiver/kustomization.yaml
+++ b/kubernetes/openarchiver/kustomization.yaml
@@ -19,16 +19,5 @@ resources:
 - deploy.yaml
 - ingress.yaml
 
-images:
-- name: logiclabshq/open-archiver
-  newName: docker.io/logiclabshq/open-archiver
-  newTag: v0.4.0@sha256:8b580260ae82d9f4656912a8d7dd57fbdaaca7b993c82a42f7f0514d8908597b
-- name: valkey/valkey
-  newName: docker.io/valkey/valkey
-  newTag: 8.1.4-alpine3.22@sha256:e706d1213aaba6896c162bb6a3a9e1894e1a435f28f8f856d14fab2e10aa098b
-- name: getmeili/meilisearch
-  newName: docker.io/getmeili/meilisearch
-  newTag: v1.31.0@sha256:1af40ecce0b3a21f9a4ff14defaa80da602af3d456ef40a81e83e20043e97485
-
 commonAnnotations:
   argoManaged: 'true'

--- a/kubernetes/openarchiver/meilisearch-statefulset.yaml
+++ b/kubernetes/openarchiver/meilisearch-statefulset.yaml
@@ -24,11 +24,11 @@ spec:
         runAsUser: 1000
       containers:
       - name: meilisearch
-        image: getmeili/meilisearch@sha256:8d29e977478bb1a1a12f08f4e5a1d83bbe9edb66e66ad5f4c16627c4b9f1e2db
+        image: docker.io/getmeili/meilisearch:v1.31.0@sha256:1af40ecce0b3a21f9a4ff14defaa80da602af3d456ef40a81e83e20043e97485
         imagePullPolicy: IfNotPresent
         env:
         - name: MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE
-          value: "true"
+          value: 'true'
         - name: MEILI_MASTER_KEY
           valueFrom:
             secretKeyRef:

--- a/kubernetes/openarchiver/valkey-statefulset.yaml
+++ b/kubernetes/openarchiver/valkey-statefulset.yaml
@@ -24,7 +24,7 @@ spec:
         runAsUser: 999
       containers:
       - name: valkey
-        image: valkey/valkey@sha256:546304417feac0874c3dd576e0952c6bb8f06bb4093ea0c9ca303c73cf458f63
+        image: docker.io/valkey/valkey:8.1.4-alpine3.22@sha256:e706d1213aaba6896c162bb6a3a9e1894e1a435f28f8f856d14fab2e10aa098b
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh

--- a/kubernetes/overseerr/deploy.yaml
+++ b/kubernetes/overseerr/deploy.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: overseerr
-        image: linuxserver/overseerr@sha256:f6a782e44742a02bdb6032d32ebb4e9615e261140f879be897b28cdb40ff800e
+        image: linuxserver/overseerr:1.34.0@sha256:f6a782e44742a02bdb6032d32ebb4e9615e261140f879be897b28cdb40ff800e
         ports:
         - containerPort: 5055
         volumeMounts:

--- a/kubernetes/overseerr/kustomization.yaml
+++ b/kubernetes/overseerr/kustomization.yaml
@@ -13,10 +13,6 @@ resources:
 - ingress.yaml
 - pvc-config.yaml
 
-images:
-- name: linuxserver/overseerr
-  newTag: 1.34.0@sha256:f6a782e44742a02bdb6032d32ebb4e9615e261140f879be897b28cdb40ff800e
-
 labels:
 
 - pairs:

--- a/kubernetes/plexmediaserver/deploy.yaml
+++ b/kubernetes/plexmediaserver/deploy.yaml
@@ -28,7 +28,7 @@ spec:
       priorityClassName: gpu-priority
       containers:
       - name: plexmediaserver
-        image: lscr.io/linuxserver/plex@sha256:b19a5e34c6f8dd42abf88556b8aa5c8987c0c34820aaeaa320a02d8c17fdaab3
+        image: lscr.io/linuxserver/plex:1.42.2.10156-f737b826c-ls288@sha256:1720efa8e919a724ff3003cce7c1c0ae91a54e097ca3c8f6713a780c6fd73432
         imagePullPolicy: Always
         livenessProbe:
           exec:

--- a/kubernetes/plexmediaserver/kustomization.yaml
+++ b/kubernetes/plexmediaserver/kustomization.yaml
@@ -14,10 +14,6 @@ resources:
 - externalsecret.yaml
 - pvc-config.yaml
 
-images:
-- name: lscr.io/linuxserver/plex
-  newTag: 1.42.2.10156-f737b826c-ls288@sha256:1720efa8e919a724ff3003cce7c1c0ae91a54e097ca3c8f6713a780c6fd73432
-
 labels:
 
 - pairs:

--- a/kubernetes/prometheus/deploy.yaml
+++ b/kubernetes/prometheus/deploy.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: prometheus
       containers:
       - name: prometheus
-        image: prom/prometheus@sha256:1f0f50f06acaceb0f5670d2c8a658a599affe7b0d8e78b898c1035653849a702
+        image: prom/prometheus:v3.8.1@sha256:2b6f734e372c1b4717008f7d0a0152316aedd4d13ae17ef1e3268dbfaf68041b
         args:
         - --config.file=/etc/prometheus/prometheus.yml
         - --web.external-url=https://prometheus.k.oneill.net

--- a/kubernetes/prometheus/kustomization.yaml
+++ b/kubernetes/prometheus/kustomization.yaml
@@ -18,10 +18,6 @@ resources:
 - service.yaml
 - externalsecret.yaml
 
-images:
-- name: prom/prometheus
-  newTag: v3.8.1@sha256:2b6f734e372c1b4717008f7d0a0152316aedd4d13ae17ef1e3268dbfaf68041b
-
 labels:
 
 - pairs:

--- a/kubernetes/prowlarr/deploy.yaml
+++ b/kubernetes/prowlarr/deploy.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: prowlarr
-        image: linuxserver/prowlarr@sha256:d3e9307b320b6772749a2cf8fc2712e9e824c4930b034680ad4d08a9e2f25884
+        image: linuxserver/prowlarr:2.3.0@sha256:d3e9307b320b6772749a2cf8fc2712e9e824c4930b034680ad4d08a9e2f25884
         ports:
         - containerPort: 9696
         volumeMounts:

--- a/kubernetes/prowlarr/kustomization.yaml
+++ b/kubernetes/prowlarr/kustomization.yaml
@@ -16,10 +16,6 @@ resources:
 - service.yaml
 - pvc-config.yaml
 
-images:
-- name: linuxserver/prowlarr
-  newTag: 2.3.0@sha256:d3e9307b320b6772749a2cf8fc2712e9e824c4930b034680ad4d08a9e2f25884
-
 labels:
 
 - pairs:

--- a/kubernetes/pushgateway/deploy.yaml
+++ b/kubernetes/pushgateway/deploy.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: pushgateway
-        image: prom/pushgateway@sha256:c835998819105d84d484918908df132807c78c05f3e0e649df0c0479c6780d98
+        image: prom/pushgateway:v1.11.2@sha256:c835998819105d84d484918908df132807c78c05f3e0e649df0c0479c6780d98
         ports:
         - name: web
           containerPort: 9091

--- a/kubernetes/pushgateway/kustomization.yaml
+++ b/kubernetes/pushgateway/kustomization.yaml
@@ -12,10 +12,6 @@ resources:
 - ingress.yaml
 - service.yaml
 
-images:
-- name: prom/pushgateway
-  newTag: v1.11.2@sha256:c835998819105d84d484918908df132807c78c05f3e0e649df0c0479c6780d98
-
 labels:
 
 - pairs:

--- a/kubernetes/qbit-manage/deploy.yaml
+++ b/kubernetes/qbit-manage/deploy.yaml
@@ -20,7 +20,7 @@ spec:
 
       containers:
       - name: qbit-manage
-        image: qbit-manage
+        image: ghcr.io/stuffanthings/qbit_manage:v4.6.5@sha256:4f36632a138b4e5aeab3b765b7f389087bfb140c80dbbec1343eca74dc351245
         ports:
         - containerPort: 8080
           name: web-api

--- a/kubernetes/qbit-manage/kustomization.yaml
+++ b/kubernetes/qbit-manage/kustomization.yaml
@@ -9,10 +9,6 @@ commonAnnotations:
 
 components:
 - ../components/authentik
-images:
-- name: qbit-manage
-  newName: ghcr.io/stuffanthings/qbit_manage
-  newTag: v4.6.5@sha256:4f36632a138b4e5aeab3b765b7f389087bfb140c80dbbec1343eca74dc351245
 
 resources:
 - deploy.yaml

--- a/kubernetes/qbittorrent/deploy.yaml
+++ b/kubernetes/qbittorrent/deploy.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: qbittorrent
-        image: qbittorrent
+        image: ghcr.io/linuxserver/qbittorrent:5.1.4@sha256:f430d70c70d1547fded30fbc3181c4750cef354212a5138ab754eba9ba8bd9e1
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/kubernetes/qbittorrent/kustomization.yaml
+++ b/kubernetes/qbittorrent/kustomization.yaml
@@ -13,11 +13,6 @@ resources:
 - service.yaml
 - ingress.yaml
 
-images:
-- name: qbittorrent
-  newName: ghcr.io/linuxserver/qbittorrent
-  newTag: 5.1.4@sha256:f430d70c70d1547fded30fbc3181c4750cef354212a5138ab754eba9ba8bd9e1
-
 labels:
 
 - pairs:

--- a/kubernetes/qui/deploy.yaml
+++ b/kubernetes/qui/deploy.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: qui
-        image: ghcr.io/autobrr/qui@sha256:b3b18f82f340642fc19ffb8935c112673008e7e6ae0ead5b6e8bb39c9b4462a3
+        image: ghcr.io/autobrr/qui:v1.12.0@sha256:b3b18f82f340642fc19ffb8935c112673008e7e6ae0ead5b6e8bb39c9b4462a3
         ports:
         - containerPort: 7476
         envFrom:

--- a/kubernetes/qui/kustomization.yaml
+++ b/kubernetes/qui/kustomization.yaml
@@ -14,10 +14,6 @@ resources:
 - externalsecret.yaml
 - pvc-config.yaml
 
-images:
-- name: ghcr.io/autobrr/qui
-  newTag: v1.12.0@sha256:b3b18f82f340642fc19ffb8935c112673008e7e6ae0ead5b6e8bb39c9b4462a3
-
 labels:
 
 - pairs:

--- a/kubernetes/radarr/deploy.yaml
+++ b/kubernetes/radarr/deploy.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: radarr
-        image: linuxserver/radarr@sha256:270f25698624b57b86ca119cc95399d7ff15be8297095b4e1223fd5b549b732c
+        image: linuxserver/radarr:5.28.0@sha256:c984533510abe0219a70e80d15bd0d212b7df21baa0913759c4ce6cc9092240b
         ports:
         - containerPort: 7878
         volumeMounts:

--- a/kubernetes/radarr/kustomization.yaml
+++ b/kubernetes/radarr/kustomization.yaml
@@ -16,10 +16,6 @@ resources:
 - ingress.yaml
 - pvc-config.yaml
 
-images:
-- name: linuxserver/radarr
-  newTag: 5.28.0@sha256:c984533510abe0219a70e80d15bd0d212b7df21baa0913759c4ce6cc9092240b
-
 labels:
 
 - pairs:

--- a/kubernetes/smokeping-prober/deploy.yaml
+++ b/kubernetes/smokeping-prober/deploy.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: smokeping-prober
-        image: quay.io/superq/smokeping-prober@sha256:614b8fca5cad698d254a77a61bda643fea867a87dbc17851c9332a2fef1b555f
+        image: quay.io/superq/smokeping-prober:v0.10.0@sha256:614b8fca5cad698d254a77a61bda643fea867a87dbc17851c9332a2fef1b555f
         imagePullPolicy: IfNotPresent
         args:
         - --config.file=/config/config.yaml

--- a/kubernetes/smokeping-prober/kustomization.yaml
+++ b/kubernetes/smokeping-prober/kustomization.yaml
@@ -18,10 +18,6 @@ configMapGenerator:
   files:
   - config.yaml
 
-images:
-- name: quay.io/superq/smokeping-prober
-  newTag: v0.10.0@sha256:614b8fca5cad698d254a77a61bda643fea867a87dbc17851c9332a2fef1b555f
-
 labels:
 
 - pairs:

--- a/kubernetes/smokeping/deploy.yaml
+++ b/kubernetes/smokeping/deploy.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: smokeping
-        image: dvorak/docker-smokeping@sha256:f458e95b8d4ae8499e6efff9bb891b937eff13bd65550cb59f5b7a246a0de352
+        image: dvorak/docker-smokeping:latest@sha256:f458e95b8d4ae8499e6efff9bb891b937eff13bd65550cb59f5b7a246a0de352
         imagePullPolicy: Always
         ports:
         - containerPort: 80

--- a/kubernetes/smokeping/kustomization.yaml
+++ b/kubernetes/smokeping/kustomization.yaml
@@ -16,10 +16,6 @@ resources:
 commonAnnotations:
   argoManaged: 'true'
 
-images:
-- name: dvorak/docker-smokeping
-  newTag: latest@sha256:f458e95b8d4ae8499e6efff9bb891b937eff13bd65550cb59f5b7a246a0de352
-
 labels:
 
 - pairs:

--- a/kubernetes/sonarr/deploy.yaml
+++ b/kubernetes/sonarr/deploy.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: sonarr
-        image: linuxserver/sonarr@sha256:02b4d538d351d6e35882a021c08e8600fe95d28860fb1dd724b597166e7221ca
+        image: linuxserver/sonarr:4.0.16@sha256:02b4d538d351d6e35882a021c08e8600fe95d28860fb1dd724b597166e7221ca
         ports:
         - containerPort: 8989
         volumeMounts:

--- a/kubernetes/sonarr/kustomization.yaml
+++ b/kubernetes/sonarr/kustomization.yaml
@@ -16,10 +16,6 @@ resources:
 - ingress.yaml
 - pvc-config.yaml
 
-images:
-- name: linuxserver/sonarr
-  newTag: 4.0.16@sha256:02b4d538d351d6e35882a021c08e8600fe95d28860fb1dd724b597166e7221ca
-
 labels:
 
 - pairs:

--- a/kubernetes/tautulli/deploy.yaml
+++ b/kubernetes/tautulli/deploy.yaml
@@ -23,7 +23,7 @@ spec:
       - name: tautulli
         securityContext:
           privileged: true
-        image: tautulli/tautulli@sha256:5fc33cf56fce13db1a73f91f7b1214950f9b96f72b69ae704e492e88b049c717
+        image: tautulli/tautulli:v2.16.0@sha256:7e6ede32f7923e01899db906aa6a96d978a4a8df8e2ef0dcf44c92b2d0206221
         imagePullPolicy: Always
         ports:
         - containerPort: 8181

--- a/kubernetes/tautulli/kustomization.yaml
+++ b/kubernetes/tautulli/kustomization.yaml
@@ -16,10 +16,6 @@ resources:
 - pvc.yaml
 - service.yaml
 
-images:
-- name: tautulli/tautulli
-  newTag: v2.16.0@sha256:7e6ede32f7923e01899db906aa6a96d978a4a8df8e2ef0dcf44c92b2d0206221
-
 labels:
 
 - pairs:

--- a/kubernetes/vrroom-daily-reboot/cronjob.yaml
+++ b/kubernetes/vrroom-daily-reboot/cronjob.yaml
@@ -14,6 +14,6 @@ spec:
         spec:
           containers:
           - name: vrroom-daily-reboot
-            image: alpine@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
+            image: alpine:3.23@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
             command: [/bin/sh, -c, echo "set reboot" | nc vrroom-37.oneill.net 2222]
           restartPolicy: Never

--- a/kubernetes/vrroom-daily-reboot/kustomization.yaml
+++ b/kubernetes/vrroom-daily-reboot/kustomization.yaml
@@ -10,10 +10,6 @@ resources:
 commonAnnotations:
   argoManaged: 'true'
 
-images:
-- name: alpine
-  newTag: 3.23.2@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
-
 labels:
 
 - pairs:


### PR DESCRIPTION
- Drop kustomize image overrides for non-helm apps
- Keep version+digest pins in base manifests
