### PR TITLE
Force local flake builds for logging

### DIFF
--- a/.github/workflows/flake-builds.yaml
+++ b/.github/workflows/flake-builds.yaml
@@ -46,4 +46,5 @@ jobs:
         authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
     - name: Build dev shell
-      run: nix build --print-build-logs --log-format raw --verbose ${{ matrix.flake-output }}
+      run: nix build --print-build-logs --log-format raw --verbose --show-trace --option
+        log-lines 0 --option substitute false ${{ matrix.flake-output }}


### PR DESCRIPTION
Build devShells without substitutes so logs stream during compilation and Cachix uploads outputs.