### PR TITLE
Add go-unifi-mcp to dev environment

### DIFF
--- a/.claude/rules/integrations/unifi.md
+++ b/.claude/rules/integrations/unifi.md
@@ -1,0 +1,62 @@
+# UniFi Integration
+
+Query and manage the UniFi controller via `mcp-cli` using `go-unifi-mcp`.
+
+## Configuration
+
+Running in **eager mode** - all 242 tools are registered directly as MCP tools.
+
+## Usage
+
+```bash
+# List all servers
+mcp-cli
+
+# Show unifi server tools
+mcp-cli unifi
+
+# Show tool schema
+mcp-cli unifi/list_firewall_rule
+
+# Call tool
+mcp-cli unifi/list_device '{}'
+
+# Get firewall rule details
+mcp-cli unifi/get_firewall_rule '{"id": "rule-id-here"}'
+```
+
+## Available Tool Categories
+
+Tools follow the pattern `{operation}_{resource}` where operation is one of:
+list, get, create, update, delete.
+
+- **Devices**: list_device, get_device, create_device, update_device,
+  delete_device
+- **Firewall Rules**: list_firewall_rule, get_firewall_rule,
+  create_firewall_rule, update_firewall_rule, delete_firewall_rule
+- **Firewall Groups**: list_firewall_group, get_firewall_group,
+  create_firewall_group, update_firewall_group, delete_firewall_group
+- **Firewall Zones**: list_firewall_zone, get_firewall_zone,
+  create_firewall_zone, update_firewall_zone, delete_firewall_zone
+- **Firewall Zone Policies**: list_firewall_zone_policy,
+  get_firewall_zone_policy, create_firewall_zone_policy,
+  update_firewall_zone_policy, delete_firewall_zone_policy
+- **Networks**: list_network, get_network, create_network, update_network,
+  delete_network
+- **Port Forwarding**: list_port_forward, get_port_forward, create_port_forward,
+  update_port_forward, delete_port_forward
+- **Users**: list_user, get_user, create_user, update_user, delete_user
+- **WLANs**: list_wlan, get_wlan, create_wlan, update_wlan, delete_wlan
+- **Settings**: `get_setting_*`, `update_setting_*` (46+ setting types)
+- **DNS Records**: list_dns_record, get_dns_record, create_dns_record,
+  update_dns_record, delete_dns_record
+- **DHCP Options**: list_dhcp_option, get_dhcp_option, create_dhcp_option,
+  update_dhcp_option, delete_dhcp_option
+
+## Firewall IPv6 Support
+
+Full IPv6 support via filipowm/go-unifi:
+
+- IPv6 rulesets: WANv6_IN, WANv6_OUT, WANv6_LOCAL, LANv6_IN, etc.
+- Fields: src_address_ipv6, dst_address_ipv6, protocol_v6, icmpv6_typename
+- Zone-based policies with ip_version (ipv4/ipv6/both)

--- a/.mcp_servers.json
+++ b/.mcp_servers.json
@@ -7,6 +7,16 @@
         "HA_URL": "https://hass.k.oneill.net",
         "HA_TOKEN": "${HASS_BEARER_TOKEN}"
       }
+    },
+    "unifi": {
+      "command": "go-unifi-mcp",
+      "env": {
+        "UNIFI_HOST": "https://udmp.oneill.net",
+        "UNIFI_API_KEY": "${UNIFI_API_KEY}",
+        "UNIFI_SITE": "default",
+        "UNIFI_VERIFY_SSL": "false",
+        "UNIFI_TOOL_MODE": "eager"
+      }
     }
   }
 }

--- a/.secrets.tmpl
+++ b/.secrets.tmpl
@@ -14,6 +14,9 @@ export ARA_API_PASSWORD="{{ op://infra/ara-api-basic-auth/password }}"
 # Home Assistant (used by: kubernetes/hass/get-prom-metrics)
 export HASS_BEARER_TOKEN="{{ op://infra/prometheus/hass-bearer-token }}"
 
+# UniFi Network (used by: go-unifi-mcp server)
+export UNIFI_API_KEY="{{ op://infra/unifi-mcp/api-key }}"
+
 # Restic/Rclone (used by: kubernetes/restic/scripts/run, run-rclone)
 export RESTIC_PASSWORD="{{ op://infra/resticprofile/RESTIC_PASSWORD }}"
 export RCLONE_CONFIG_B2C_PASSWORD="{{ op://infra/resticprofile-rclone/RCLONE_CONFIG_CRYPT_PASSWORD }}"

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,40 @@
 {
   "nodes": {
+    "go-unifi-mcp": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1769539352,
+        "narHash": "sha256-wPJ/YbnWWcXiGUFzkarneCPmV1I0AiN9ubeUBpcs8Lk=",
+        "owner": "claytono",
+        "repo": "go-unifi-mcp",
+        "rev": "4649100b1026f5f3618fe3b71715324ad92435ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "claytono",
+        "repo": "go-unifi-mcp",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1769018530,
+        "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "88d3861acdd3d2f0e361767018218e51810df8a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1769018530,
         "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
@@ -18,7 +52,8 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "go-unifi-mcp": "go-unifi-mcp",
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,11 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    go-unifi-mcp.url = "github:claytono/go-unifi-mcp";
   };
 
   # Flake outputs that other flakes can use
-  outputs = { self, nixpkgs }:
+  outputs = { self, nixpkgs, go-unifi-mcp }:
     let
       # Helpers for producing system-specific outputs
       supportedSystems = [ "x86_64-linux" "aarch64-darwin" "x86_64-darwin" "aarch64-linux" ];
@@ -141,6 +142,7 @@
               velero
               yamlfix
               yq-go
+              go-unifi-mcp.packages.${pkgs.stdenv.hostPlatform.system}.default
             ] ++ lib.optional (builtins.elem stdenv.hostPlatform.system [ "aarch64-darwin" "x86_64-linux" ]) (mkMcpCli pkgs);
 
             shellHook = ''


### PR DESCRIPTION
- Add go-unifi-mcp flake input and devShell package
- Configure MCP server in eager mode (242 tools)
- Add UNIFI_API_KEY to secrets template
- Add integration docs for UniFi MCP usage
