### PR TITLE
Enable ansible-lint offline mode to fix manifest churn

### DIFF
--- a/ansible/.ansible-lint.yaml
+++ b/ansible/.ansible-lint.yaml
@@ -1,4 +1,5 @@
 ---
+offline: true
 exclude_paths:
   - galaxy/
 skip_list:


### PR DESCRIPTION
ansible-compat runs ansible-galaxy install during initialization,
regenerating collection FILES.json and MANIFEST.json with
non-deterministic file ordering. This caused pre-commit to always
report galaxy manifest modifications on ansible changes.

offline: true prevents the redundant install since collections are
already vendored.
