### PR TITLE
Add basement humidifier water level alerts

### DIFF
--- a/kubernetes/hass/config/kustomization.yaml
+++ b/kubernetes/hass/config/kustomization.yaml
@@ -13,6 +13,7 @@ configMapGenerator:
   - configuration.yaml=configuration.yaml
   - input_boolean.yaml=input_boolean.yaml
   - input_select.yaml=input_select.yaml
+  - packages__basement_humidifier_alert.yaml=packages/basement_humidifier_alert.yaml
   - packages__ego_charger_maintenance.yaml=packages/ego_charger_maintenance.yaml
   - packages__office_thermostat_gaming.yaml=packages/office_thermostat_gaming.yaml
   - packages__temperature_alerts.yaml=packages/temperature_alerts.yaml

--- a/kubernetes/hass/config/packages/basement_humidifier_alert.yaml
+++ b/kubernetes/hass/config/packages/basement_humidifier_alert.yaml
@@ -1,0 +1,47 @@
+---
+template:
+
+- binary_sensor:
+  - name: Rec Room Humidifier Not Running
+    unique_id: rec_room_humidifier_not_running
+    device_class: problem
+    delay_on:
+      minutes: 25
+    state: >
+      {% set switch_on = is_state('switch.rec_room_humidifier', 'on') %}
+      {% set power = states('sensor.rec_room_humidifier_power') | float(0) %}
+      {{ switch_on and power < 2 }}
+    availability: >
+      {{ states('sensor.rec_room_humidifier_power') | is_number }}
+
+  - name: Basement Hallway Humidifier Not Running
+    unique_id: basement_hallway_humidifier_not_running
+    device_class: problem
+    delay_on:
+      minutes: 25
+    state: >
+      {% set switch_on = is_state('switch.basement_hallway_humidifier', 'on') %}
+      {% set power = states('sensor.basement_hallway_humidifier_power') | float(0)
+      %}
+      {{ switch_on and power < 2 }}
+    availability: >
+      {{ states('sensor.basement_hallway_humidifier_power') | is_number }}
+
+alert:
+  rec_room_humidifier_not_running:
+    name: 🚰 Rec room humidifier is on but not drawing power. Check water level.
+    done_message: ✅ Rec room humidifier is running again.
+    entity_id: binary_sensor.rec_room_humidifier_not_running
+    state: 'on'
+    repeat: 240
+    notifiers:
+    - future_planning_committee
+
+  basement_hallway_humidifier_not_running:
+    name: 🚰 Basement hallway humidifier is on but not drawing power. Check water level.
+    done_message: ✅ Basement hallway humidifier is running again.
+    entity_id: binary_sensor.basement_hallway_humidifier_not_running
+    state: 'on'
+    repeat: 240
+    notifiers:
+    - future_planning_committee


### PR DESCRIPTION
Alert via notify.future_planning_committee every 4 hours when a
basement humidifier switch is on but power draw is below 2W for
25+ minutes, indicating the tank is likely empty.

Separate binary sensors and alerts for rec room and basement
hallway humidifiers.
