### PR TITLE
Disable dhcpcd to fix pantrypi idempotency failure

### DIFF
--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -74,6 +74,15 @@
     - ansible_facts['architecture'] == 'x86_64'
     - ansible_facts['virtualization_role'] != 'guest'
 
+- name: "Disable and stop dhcpcd"
+  ansible.builtin.systemd:
+    name: dhcpcd
+    state: stopped
+    enabled: false
+    masked: true
+  when: disable_dhcpcd | default(true) | bool
+  failed_when: false
+
 - name: "Turn on passwordless sudo for sudo group"
   ansible.builtin.lineinfile:
     dest: /etc/sudoers


### PR DESCRIPTION
dhcpcd has its own RA/SLAAC stack that ignores the kernel accept_ra=0
sysctl, installing RA-learned IPv6 default routes that break the
ansible idempotency check. Stop, disable, and mask dhcpcd in the
common role so ifupdown is the sole network manager.
