### PR TITLE
Expose OTBR web UI through Traefik

### DIFF
--- a/ansible/group_vars/pi.yaml
+++ b/ansible/group_vars/pi.yaml
@@ -1,5 +1,22 @@
 ---
 node_exporter_enabled: true
 
-restic_arch: arm64
-resticprofile_arch: arm64
+# Map Ansible architecture to restic release names (arm covers armv6/armv7)
+restic_arch: >-
+  {{
+    {
+      'aarch64': 'arm64',
+      'armv7l': 'arm',
+      'armv6l': 'arm'
+    }.get(ansible_facts['architecture'], ansible_facts['architecture'])
+  }}
+
+# Map Ansible architecture to resticprofile release names
+resticprofile_arch: >-
+  {{
+    {
+      'aarch64': 'arm64',
+      'armv7l': 'armv7',
+      'armv6l': 'armv6'
+    }.get(ansible_facts['architecture'], ansible_facts['architecture'])
+  }}

--- a/ansible/host_vars/pantrypi.yaml
+++ b/ansible/host_vars/pantrypi.yaml
@@ -21,7 +21,7 @@ interfaces_ether_interfaces:
 matter_device: /dev/serial/by-id/usb-Nabu_Casa_ZBT-2_DCB4D9122BA8-if00
 matter_backbone_interface: eth0
 matter_server_hostname: matter.oneill.net
-matter_otbr_hostname: otbr.oneill.net
+matter_otbr_hostname: thread.oneill.net
 
 # Traefik file provider configs
 traefik_config_files:

--- a/ansible/roles/matter/templates/docker-compose.yaml.j2
+++ b/ansible/roles/matter/templates/docker-compose.yaml.j2
@@ -15,8 +15,10 @@ services:
     environment:
       OT_RCP_DEVICE: "spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=460800&uart-flow-control"
       OT_INFRA_IF: {{ matter_backbone_interface }}
-      OT_REST_LISTEN_ADDR: "0.0.0.0"
+      OT_REST_LISTEN_ADDR: "{{ ansible_docker0.ipv4.address }}"
       OT_REST_LISTEN_PORT: "8081"
+      OT_WEB_LISTEN_ADDR: "{{ ansible_docker0.ipv4.address }}"
+      OT_WEB_LISTEN_PORT: "8080"
       TZ: America/New_York
     healthcheck:
       test: ["CMD", "test", "-S", "/run/openthread-wpan0.sock"]

--- a/ansible/roles/traefik/templates/conf.d/matter.yml.j2
+++ b/ansible/roles/traefik/templates/conf.d/matter.yml.j2
@@ -13,7 +13,16 @@ http:
       rule: "Host(`{{ matter_otbr_hostname }}`)"
       entryPoints:
         - websecure
-      service: otbr
+      service: otbr-web
+      tls:
+        certResolver: letsencrypt
+
+    otbr-api:
+      rule: "Host(`{{ matter_otbr_hostname }}`) && (PathPrefix(`/node`) || PathPrefix(`/diagnostics`) || PathPrefix(`/v1`))"
+      entryPoints:
+        - websecure
+      service: otbr-api
+      priority: 100
       tls:
         certResolver: letsencrypt
 
@@ -23,7 +32,12 @@ http:
         servers:
           - url: "http://{{ ansible_host }}:5580"
 
-    otbr:
+    otbr-web:
       loadBalancer:
         servers:
-          - url: "http://{{ ansible_host }}:8081"
+          - url: "http://{{ ansible_docker0.ipv4.address }}:8080"
+
+    otbr-api:
+      loadBalancer:
+        servers:
+          - url: "http://{{ ansible_docker0.ipv4.address }}:8081"

--- a/opentofu/modules/dns/oneill.tf
+++ b/opentofu/modules/dns/oneill.tf
@@ -211,9 +211,9 @@ resource "aws_route53_record" "matter" {
   records = ["pantrypi.oneill.net"]
 }
 
-resource "aws_route53_record" "otbr" {
+resource "aws_route53_record" "thread" {
   zone_id = aws_route53_zone.oneill_net.zone_id
-  name    = "otbr.oneill.net"
+  name    = "thread.oneill.net"
   type    = "CNAME"
   ttl     = 300
   records = ["pantrypi.oneill.net"]


### PR DESCRIPTION
- Bind otbr-web to 0.0.0.0:8080 (defaults to localhost only)
- Split Traefik routing: web UI at root, REST API at /node /diagnostics /v1
