### PR TITLE
Add apt cache warmup to idempotency test

### DIFF
--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -3,6 +3,7 @@
   ansible.builtin.apt:
     update_cache: true
     cache_valid_time: 3600
+  tags: apt-cache
 
 - name: "Remove unwanted packages"
   ansible.builtin.apt:

--- a/kubernetes/semaphore/scripts/ansible-idempotency-test
+++ b/kubernetes/semaphore/scripts/ansible-idempotency-test
@@ -184,7 +184,9 @@ def report_healthcheck(
     max_host_len = 0
     for a in attempts:
         if a.get("host_results"):
-            max_host_len = max(max_host_len, max(len(h) for h in a["host_results"].keys()))
+            max_host_len = max(
+                max_host_len, max(len(h) for h in a["host_results"].keys())
+            )
 
     lines = ["--- Idempotency Test Summary ---"]
     lines.append(f"Status: {'✅ PASS' if success else '❌ FAIL'}")
@@ -201,7 +203,9 @@ def report_healthcheck(
         if a.get("host_results"):
             lines.append("    Hosts:")
             for host, counts in sorted(a["host_results"].items()):
-                host_icon = "✅" if counts["changed"] == 0 and counts["failed"] == 0 else "❌"
+                host_icon = (
+                    "✅" if counts["changed"] == 0 and counts["failed"] == 0 else "❌"
+                )
                 changed = str(counts["changed"]).rjust(2)
                 failed = str(counts["failed"]).rjust(2)
                 ok = str(counts["ok"]).rjust(3)
@@ -227,6 +231,7 @@ class IdempotencyTester:
         project: str,
         template: str,
         tags: Optional[str] = None,
+        warmup_tags: Optional[str] = None,
         ara_username: Optional[str] = None,
         ara_password: Optional[str] = None,
         healthcheck_key: Optional[str] = None,
@@ -247,6 +252,7 @@ class IdempotencyTester:
             password=ara_password,
         )
         self.healthcheck_key = healthcheck_key
+        self.warmup_tags = warmup_tags
         self.min_attempts = min_attempts
         self.max_attempts = max_attempts
         self.attempts: list[dict] = []
@@ -285,6 +291,27 @@ class IdempotencyTester:
 
         return idempotent, ara_url, task_url, host_results
 
+    def run_warmup(self) -> None:
+        """Run a warmup deploy to prime caches before testing"""
+        print(f"\n--- Warmup deploy (tags: {self.warmup_tags}) ---")
+
+        if self.deployer.project_id is None:
+            self.deployer.resolve_ids()
+
+        # Temporarily swap tags for the warmup run
+        original_tags = self.deployer.tags
+        self.deployer.tags = self.warmup_tags
+
+        try:
+            success, ara_url, task_url, task_id = self.deployer.deploy_single_attempt()
+        finally:
+            self.deployer.tags = original_tags
+
+        if not success:
+            raise DeploymentError(f"Warmup deploy failed (task: {task_url})")
+
+        print("Warmup deploy completed successfully")
+
     def run(self) -> bool:
         """Run idempotency test with retries"""
         print("Starting Ansible idempotency test")
@@ -293,12 +320,17 @@ class IdempotencyTester:
         print(f"  Template: {self.deployer.template_name}")
         if self.deployer.tags:
             print(f"  Tags: {self.deployer.tags}")
+        if self.warmup_tags:
+            print(f"  Warmup tags: {self.warmup_tags}")
         print(f"  Min attempts: {self.min_attempts}")
         print(f"  Max attempts: {self.max_attempts}")
 
         # Send start notification
         if self.healthcheck_key:
             ping_healthcheck(self.healthcheck_key, "ansible-idempotency-test/start")
+
+        if self.warmup_tags:
+            self.run_warmup()
 
         final_success = False
 
@@ -388,6 +420,11 @@ def main():
         help="Ansible tags to run (comma-separated, for testing)",
     )
     parser.add_argument(
+        "--warmup-tags",
+        default="apt-cache",
+        help="Run a warmup deploy with these tags before testing (default: apt-cache, empty string to disable)",
+    )
+    parser.add_argument(
         "--min-attempts",
         type=int,
         default=2,
@@ -418,6 +455,7 @@ def main():
         project=args.project,
         template=args.template,
         tags=args.tags,
+        warmup_tags=args.warmup_tags,
         ara_username=ara_username,
         ara_password=ara_password,
         healthcheck_key=healthcheck_key,

--- a/scripts/ansible-idempotency-test
+++ b/scripts/ansible-idempotency-test
@@ -183,7 +183,9 @@ def report_healthcheck(
     max_host_len = 0
     for a in attempts:
         if a.get("host_results"):
-            max_host_len = max(max_host_len, max(len(h) for h in a["host_results"].keys()))
+            max_host_len = max(
+                max_host_len, max(len(h) for h in a["host_results"].keys())
+            )
 
     lines = ["--- Idempotency Test Summary ---"]
     lines.append(f"Status: {'✅ PASS' if success else '❌ FAIL'}")
@@ -200,7 +202,9 @@ def report_healthcheck(
         if a.get("host_results"):
             lines.append("    Hosts:")
             for host, counts in sorted(a["host_results"].items()):
-                host_icon = "✅" if counts["changed"] == 0 and counts["failed"] == 0 else "❌"
+                host_icon = (
+                    "✅" if counts["changed"] == 0 and counts["failed"] == 0 else "❌"
+                )
                 changed = str(counts["changed"]).rjust(2)
                 failed = str(counts["failed"]).rjust(2)
                 ok = str(counts["ok"]).rjust(3)
@@ -226,6 +230,7 @@ class IdempotencyTester:
         project: str,
         template: str,
         tags: Optional[str] = None,
+        warmup_tags: Optional[str] = None,
         ara_username: Optional[str] = None,
         ara_password: Optional[str] = None,
         healthcheck_key: Optional[str] = None,
@@ -246,6 +251,7 @@ class IdempotencyTester:
             password=ara_password,
         )
         self.healthcheck_key = healthcheck_key
+        self.warmup_tags = warmup_tags
         self.min_attempts = min_attempts
         self.max_attempts = max_attempts
         self.attempts: list[dict] = []
@@ -284,6 +290,27 @@ class IdempotencyTester:
 
         return idempotent, ara_url, task_url, host_results
 
+    def run_warmup(self) -> None:
+        """Run a warmup deploy to prime caches before testing"""
+        print(f"\n--- Warmup deploy (tags: {self.warmup_tags}) ---")
+
+        if self.deployer.project_id is None:
+            self.deployer.resolve_ids()
+
+        # Temporarily swap tags for the warmup run
+        original_tags = self.deployer.tags
+        self.deployer.tags = self.warmup_tags
+
+        try:
+            success, ara_url, task_url, task_id = self.deployer.deploy_single_attempt()
+        finally:
+            self.deployer.tags = original_tags
+
+        if not success:
+            raise DeploymentError(f"Warmup deploy failed (task: {task_url})")
+
+        print("Warmup deploy completed successfully")
+
     def run(self) -> bool:
         """Run idempotency test with retries"""
         print("Starting Ansible idempotency test")
@@ -292,12 +319,17 @@ class IdempotencyTester:
         print(f"  Template: {self.deployer.template_name}")
         if self.deployer.tags:
             print(f"  Tags: {self.deployer.tags}")
+        if self.warmup_tags:
+            print(f"  Warmup tags: {self.warmup_tags}")
         print(f"  Min attempts: {self.min_attempts}")
         print(f"  Max attempts: {self.max_attempts}")
 
         # Send start notification
         if self.healthcheck_key:
             ping_healthcheck(self.healthcheck_key, "ansible-idempotency-test/start")
+
+        if self.warmup_tags:
+            self.run_warmup()
 
         final_success = False
 
@@ -387,6 +419,11 @@ def main():
         help="Ansible tags to run (comma-separated, for testing)",
     )
     parser.add_argument(
+        "--warmup-tags",
+        default="apt-cache",
+        help="Run a warmup deploy with these tags before testing (default: apt-cache, empty string to disable)",
+    )
+    parser.add_argument(
         "--min-attempts",
         type=int,
         default=2,
@@ -417,6 +454,7 @@ def main():
         project=args.project,
         template=args.template,
         tags=args.tags,
+        warmup_tags=args.warmup_tags,
         ara_username=ara_username,
         ara_password=ara_password,
         healthcheck_key=healthcheck_key,


### PR DESCRIPTION
Tag the apt-update task in the common role with `apt-cache` so it can
be run independently. Add `--warmup-tags` to the idempotency test
script (defaulting to `apt-cache`) that runs a Semaphore deploy with
only those tags before the test loop begins. This primes all hosts'
apt caches so subsequent test attempts aren't thrown off by cache
expiry between runs.
