### PR TITLE
Fix Proxmox SDN idempotency by using template files

### DIFF
--- a/ansible/roles/proxmox/handlers/main.yaml
+++ b/ansible/roles/proxmox/handlers/main.yaml
@@ -8,3 +8,7 @@
   ansible.builtin.command:
     cmd: update-initramfs -u -k all
   listen: Update initramfs
+
+- name: Apply SDN configuration
+  ansible.builtin.command:
+    cmd: pvesh set /cluster/sdn

--- a/ansible/roles/proxmox/tasks/sdn.yaml
+++ b/ansible/roles/proxmox/tasks/sdn.yaml
@@ -1,32 +1,20 @@
 ---
-- name: "Create SDN VLAN zone"
-  community.proxmox.proxmox_zone:
-    api_host: "{{ ansible_host }}"
-    api_user: "root@pam"
-    api_token_id: "{{ proxmox_api_token_id }}"
-    api_token_secret: "{{ proxmox_api_token_secret }}"
-    state: present
-    zone: "{{ proxmox_sdn_zone.name }}"
-    type: "{{ proxmox_sdn_zone.type }}"
-    bridge: "{{ proxmox_sdn_zone.bridge }}"
-  delegate_to: localhost
-  become: false
+- name: "Deploy SDN zones config"
+  ansible.builtin.template:
+    src: sdn-zones.cfg.j2
+    dest: /etc/pve/sdn/zones.cfg
+    owner: root
+    group: www-data
+    mode: "0640"
   run_once: true
+  notify: Apply SDN configuration
 
-- name: "Create SDN VNets"
-  community.proxmox.proxmox_vnet:
-    api_host: "{{ ansible_host }}"
-    api_user: "root@pam"
-    api_token_id: "{{ proxmox_api_token_id }}"
-    api_token_secret: "{{ proxmox_api_token_secret }}"
-    state: present
-    vnet: "{{ item.name }}"
-    zone: "{{ proxmox_sdn_zone.name }}"
-    tag: "{{ item.tag }}"
-    alias: "{{ item.alias | default(omit) }}"
-  delegate_to: localhost
-  become: false
+- name: "Deploy SDN vnets config"
+  ansible.builtin.template:
+    src: sdn-vnets.cfg.j2
+    dest: /etc/pve/sdn/vnets.cfg
+    owner: root
+    group: www-data
+    mode: "0640"
   run_once: true
-  loop: "{{ proxmox_sdn_vnets }}"
-  loop_control:
-    label: "{{ item.name }} (VLAN {{ item.tag }})"
+  notify: Apply SDN configuration

--- a/ansible/roles/proxmox/templates/sdn-vnets.cfg.j2
+++ b/ansible/roles/proxmox/templates/sdn-vnets.cfg.j2
@@ -1,0 +1,10 @@
+{% for vnet in proxmox_sdn_vnets %}
+vnet: {{ vnet.name }}
+	zone {{ proxmox_sdn_zone.name }}
+{% if vnet.alias is defined %}
+	alias {{ vnet.alias }}
+{% endif %}
+	isolate-ports 0
+	tag {{ vnet.tag }}
+
+{% endfor %}

--- a/ansible/roles/proxmox/templates/sdn-zones.cfg.j2
+++ b/ansible/roles/proxmox/templates/sdn-zones.cfg.j2
@@ -1,0 +1,2 @@
+{{ proxmox_sdn_zone.type }}: {{ proxmox_sdn_zone.name }}
+	bridge {{ proxmox_sdn_zone.bridge }}

--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -124,6 +124,13 @@ locals {
       hostname = "pantrypi.oneill.net"
       note     = "Raspberry Pi in pantry - zwavejs, zigbee2mqtt, rtl433"
     }
+    # Test VMs
+    testvm = {
+      mac      = "BC:24:11:59:85:90"
+      ip       = "172.19.74.60"
+      hostname = "testvm.oneill.net"
+      note     = "Test VM"
+    }
     # Desktop PCs
     szamar = {
       mac         = "9c:6b:00:9b:16:ef"


### PR DESCRIPTION
The community.proxmox.proxmox_zone module always reports changed=True
due to a bug - it doesn't compare before/after state. Replace the buggy
API module with direct file management using Ansible's template module.

Proxmox SDN config lives at /etc/pve/sdn/ (cluster filesystem - syncs
automatically). The template module has proper idempotency.

Also adds DHCP reservation for testvm.
