### PR TITLE
Enable smartmontools on Pi hosts

### DIFF
--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -46,13 +46,24 @@
     - ansible_facts['virtualization_role'] == 'guest'
     - qemu_guest_agent_enabled | default(true) | bool
 
-- name: "Install smartmontools on non-VM amd64 hosts"
+- name: "Install smartmontools on physical hosts"
   ansible.builtin.apt:
     name: smartmontools
     state: present
   when:
-    - ansible_facts['architecture'] == 'x86_64'
     - ansible_facts['virtualization_role'] != 'guest'
+
+- name: "Deploy custom smartmontools drivedb for USB bridges"
+  ansible.builtin.copy:
+    dest: /etc/smart_drivedb.h
+    content: |
+      /* Custom USB bridge entries for SMART passthrough */
+      /* Transcend ESD310 (garagepi, pantrypi) */
+      { "USB: Transcend ESD310; ", "0x2174:0x2100", "", "", "-d sat" },
+    mode: "0644"
+  when:
+    - ansible_facts['virtualization_role'] != 'guest'
+  notify: Restart smartd
 
 - name: "Configure smartd for disk monitoring"
   ansible.builtin.template:
@@ -62,7 +73,6 @@
     owner: root
     group: root
   when:
-    - ansible_facts['architecture'] == 'x86_64'
     - ansible_facts['virtualization_role'] != 'guest'
   notify: Restart smartd
 
@@ -72,7 +82,6 @@
     state: started
     enabled: true
   when:
-    - ansible_facts['architecture'] == 'x86_64'
     - ansible_facts['virtualization_role'] != 'guest'
 
 - name: "Disable and stop dhcpcd"

--- a/ansible/roles/common/templates/smartd.conf.j2
+++ b/ansible/roles/common/templates/smartd.conf.j2
@@ -2,9 +2,6 @@
 # smartd configuration for disk health monitoring
 # See smartd.conf(5) man page for details
 
-# Scan SATA/ATA devices only (excludes iSCSI and other SCSI devices):
-#
-# -d sat: Only monitor SATA/ATA devices (physical SSDs/HDDs)
 # -a: Monitor all SMART attributes
 # -o on: Enable automatic offline tests
 # -S on: Enable attribute autosave
@@ -21,4 +18,4 @@
 # - Temperature excursions (if supported)
 # - Changes in SMART attributes beyond thresholds
 
-DEVICESCAN -d sat -a -o on -S on -s (S/../.././02|L/../../6/03) -m root -M exec /usr/share/smartmontools/smartd-runner
+DEVICESCAN -a -o on -S on -s (S/../.././02|L/../../6/03) -m root -M exec /usr/share/smartmontools/smartd-runner


### PR DESCRIPTION
- Remove architecture restriction (was x86_64 only)
- Add custom drivedb entry for Transcend ESD310 USB bridges
- Remove -d sat from DEVICESCAN (auto-detection works with drivedb)

Deployed and verified on pantrypi and garagepi.
