### PR TITLE
Add Netdata Kubernetes manifests

### DIFF
--- a/kubernetes/netdata/Chart.yaml
+++ b/kubernetes/netdata/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: netdata
+version: 1.0.0
+dependencies:
+- name: netdata
+  version: 3.7.158
+  repository: https://netdata.github.io/helmchart/

--- a/kubernetes/netdata/dbengine-pvc.yaml
+++ b/kubernetes/netdata/dbengine-pvc.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+
+metadata:
+  name: netdata-parent-dbengine
+
+spec:
+  accessModes:
+  - ReadWriteOncePod
+  storageClassName: nfs
+  resources:
+    requests:
+      storage: 20Gi

--- a/kubernetes/netdata/externalsecret.yaml
+++ b/kubernetes/netdata/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+  name: netdata-streaming
+
+spec:
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  data:
+  - secretKey: NETDATA_STREAM_API_KEY
+    remoteRef:
+      key: netdata-streaming
+      property: api-key
+  target:
+    name: netdata-streaming

--- a/kubernetes/netdata/helm/netdata/child/configmap.yaml
+++ b/kubernetes/netdata/helm/netdata/child/configmap.yaml
@@ -1,0 +1,307 @@
+---
+# Source: netdata/templates/child/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: netdata-conf-child
+  namespace: netdata
+  labels:
+    app: netdata
+    chart: netdata-3.7.158
+    release: netdata
+    heritage: Helm
+data:
+    
+  go.d: |
+        modules:
+          pulsar: no
+          prometheus: yes
+  kubelet: |
+        update_every: 1
+        autodetection_retry: 0
+        jobs:
+          - name: local
+            url: http://127.0.0.1:10255/metrics
+          - name: local
+            url: https://localhost:10250/metrics
+            tls_skip_verify: yes
+  kubeproxy: |
+        update_every: 1
+        autodetection_retry: 0
+        jobs:
+          - name: local
+            url: http://127.0.0.1:10249/metrics
+  netdata: |
+        [db]
+          mode = ram
+        [web]
+          bind to = localhost:19999
+        [health]
+          enabled = no
+        [ml]
+          enabled = no
+  stream: |
+        [stream]
+          enabled = yes
+          destination = netdata:19999
+          api key = 11111111-2222-3333-4444-555555555555
+          timeout seconds = 60
+          buffer size bytes = 1048576
+          reconnect delay seconds = 5
+          initial clock resync iterations = 60
+---
+# Source: netdata/templates/child/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: netdata-child-sd-config-map
+  namespace: netdata
+  labels:
+    app: netdata
+    chart: netdata-3.7.158
+    release: netdata
+    heritage: Helm
+data:
+  config.yml: |
+    disabled: no
+    
+    name: 'kubernetes'
+    
+    discover:
+      - discoverer: k8s
+        k8s:
+          - tags: unknown
+            role: pod
+            pod:
+              local_mode: yes
+    classify:
+      - name: "Control-Plane"
+        selector: unknown
+        tags: -unknown control_plane
+        match:
+          - tags: kube_scheduler
+            expr: '{{ glob .Image "k8s.gcr.io/kube-scheduler:*" }}'
+          - tags: kube_controller_manager
+            expr: '{{ glob .Image "k8s.gcr.io/kube-controller-manager:*" }}'
+      - name: "Applications"
+        selector: unknown
+        tags: -unknown applications
+        match:
+          - tags: activemq
+            expr: '{{ and (eq .Port "8161") (glob .Image "*/activemq*") }}'
+          - tags: apache
+            expr: '{{ and (eq .Port "80" "8080") (glob .Image "httpd*" "*/httpd*") }}'
+          - tags: bind
+            expr: '{{ and (eq .Port "8653") (glob .Image "*/bind*") }}'
+          - tags: cockroachdb
+            expr: '{{ and (eq .Port "8080") (glob .Image "*/cockroach*") }}'
+          - tags: consul
+            expr: '{{ and (eq .Port "8500") (glob .Image "consul*" "*/consul*") }}'
+          - tags: coredns
+            expr: '{{ and (eq .Port "9153") (glob .Image "*/coredns*") }}'
+          - tags: elasticsearch
+            expr: '{{ and (eq .Port "9200") (glob .Image "elasticsearch:*" "*/elasticsearch:*") }}'
+          - tags: fluentd
+            expr: '{{ and (eq .Port "24220") (glob .Image "fluentd*" "*/fluentd*") }}'
+          - tags: freeradius
+            expr: '{{ and (eq .Port "18121") (glob .Image "*/freeradius*") }}'
+          - tags: hdfs
+            expr: '{{ and (eq .Port "50070") (glob .Image "*/hdfs*") }}'
+          - tags: lighttpd
+            expr: '{{ and (eq .Port "80" "8080") (glob .Image "*/lighttpd*") }}'
+          - tags: logstash
+            expr: '{{ and (eq .Port "9600") (glob .Image "logstash*" "*/logstash*") }}'
+          - tags: mysql
+            expr: '{{ and (eq .Port "3306") (glob .Image "mysql*" "*/mysql*" "mariadb*" "*/mariadb*") }}'
+          - tags: nginx
+            expr: '{{ and (eq .Port "80" "8080") (glob .Image "nginx*" "*/nginx*") }}'
+          - tags: openvpn
+            expr: '{{ and (eq .Port "7505") (glob .Image "*/openvpn") }}'
+          - tags: phpfpm
+            expr: '{{ and (eq .Port "80" "8080") (glob .Image "*/phpfpm*" "*/php-fpm*") }}'
+          - tags: rabbitmq
+            expr: '{{ and (eq .Port "15672") (glob .Image "rabbitmq*" "*/rabbitmq*") }}'
+          - tags: solr
+            expr: '{{ and (eq .Port "8983") (glob .Image "solr*" "*/solr*") }}'
+          - tags: tengine
+            expr: '{{ and (eq .Port "80" "8080") (glob .Image "*/tengine*") }}'
+          - tags: unbound
+            expr: '{{ and (eq .Port "8953") (glob .Image "*/unbound*") }}'
+          - tags: vernemq
+            expr: '{{ and (eq .Port "8888") (glob .Image "*/vernemq*") }}'
+          - tags: zookeeper
+            expr: '{{ and (eq .Port "2181") (glob .Image "zookeeper*" "*/zookeeper*") }}'
+          - tags: consul_envoy
+            expr: |
+              {{ $imageOK := glob .Image "*/consul-dataplane*" -}}
+              {{ $scrapeOK := eq (get .Annotations "prometheus.io/scrape") "true" -}}
+              {{ $promPort := get .Annotations "prometheus.io/port" -}}
+              {{ $portOK1 := and (eq .Port $promPort) (not (empty .Port)) -}}
+              {{ $portOK2 := and (empty .Port) (not (empty $promPort)) -}}
+              {{ and $imageOK $scrapeOK (or $portOK1 $portOK2) }}
+      - name: "Prometheus Generic Applications"
+        selector: unknown
+        tags: -unknown prometheus_generic
+        match:
+          - tags: prometheus_generic
+            expr: |
+              {{ $scrapeOK := eq (get .Annotations "prometheus.io/scrape") "true" -}}
+              {{ $portOK := eq (default .Port (get .Annotations "prometheus.io/port")) .Port -}}
+              {{ $imageOK := not (glob .Image "netdata/netdata*" "*pulsar*" "*telegraf*") -}}
+              {{ and $scrapeOK $portOK $imageOK }}
+    compose:
+      - name: "Control-Plane"
+        selector: '!unknown control_plane'
+        config:
+          - selector: kube_scheduler
+            template: |
+              - module: prometheus
+                name: prometheus-{{.TUID}}
+                url: http://{{.PodIP}}:{{default "10251" .Port}}/metrics
+                app: '{{.ContName}}'
+                update_every: 10
+                max_time_series: 1000
+          - selector: kube_controller_manager
+            template: |
+              - module: prometheus
+                name: prometheus-{{.TUID}}
+                url: http://{{.PodIP}}:{{default "10252" .Port}}/metrics
+                app: '{{.ContName}}'
+                update_every: 10
+                max_time_series: 2000
+      - name: "Prometheus Generic Applications"
+        selector: '!unknown prometheus_generic'
+        config:
+          - selector: prometheus_generic
+            template: |
+              {{ $path := default "/metrics" (get .Annotations "prometheus.io/path") -}}
+              - module: prometheus
+                name: prometheus-{{.TUID}}
+                url: http://{{.Address}}{{$path}}
+                app: '{{.ContName}}'
+                update_every: 10
+                max_time_series: 4000
+      - name: "Applications"
+        selector: '!unknown applications'
+        tags: file
+        config:
+          - selector: activemq
+            template: |
+              - module: activemq
+                name: activemq-{{.TUID}}
+                url: http://{{.Address}}
+          - selector: apache
+            template: |
+              - module: apache
+                name: apache-{{.TUID}}
+                url: http://{{.Address}}/server-status?auto
+          - selector: bind
+            template: |
+              - module: bind
+                name: bind-{{.TUID}}
+                url: http://{{.Address}}/json/v1
+          - selector: cockroachdb
+            template: |
+              - module: cockroachdb
+                name: cockroachdb-{{.TUID}}
+                url: http://{{.Address}}/_status/vars
+          - selector: consul
+            template: |
+              - module: consul
+                name: consul-{{.TUID}}
+                url: http://{{.Address}}
+          - selector: coredns
+            template: |
+              - module: coredns
+                name: coredns-{{.TUID}}
+                url: http://{{.Address}}/metrics
+          - selector: elasticsearch
+            template: |
+              - module: elasticsearch
+                name: elasticsearch-{{.TUID}}
+                url: http://{{.Address}}
+          - selector: consul_envoy
+            template: |
+              {{ $path := default "/metrics" (get .Annotations "prometheus.io/path") -}}
+              {{ $promPort := get .Annotations "prometheus.io/port" -}}
+              {{ $port := ternary .Port $promPort (not (empty .Port)) -}}
+              - module: envoy
+                name: {{.TUID}}
+                url: http://{{ .PodIP }}:{{ $port }}{{ $path }}
+          - selector: fluentd
+            template: |
+              - module: fluentd
+                name: fluentd-{{.TUID}}
+                url: http://{{.Address}}
+          - selector: freeradius
+            template: |
+              - module: freeradius
+                name: freeradius-{{.TUID}}
+                address: {{.PodIP}}
+                port: {{.Port}}
+          - selector: hdfs
+            template: |
+              - module: hdfs
+                name: hdfs-{{.TUID}}
+                url: http://{{.Address}}/jmx
+          - selector: lighttpd
+            template: |
+              - module: lighttpd
+                name: lighttpd-{{.TUID}}
+                url: http://{{.Address}}/server-status?auto
+          - selector: logstash
+            template: |
+              - module: logstash
+                name: logstash-{{.TUID}}
+                url: http://{{.Address}}
+          - selector: mysql
+            template: |
+              - module: mysql
+                name: mysql-{{.TUID}}
+                dsn: 'netdata@tcp({{.Address}})/'
+          - selector: nginx
+            template: |
+              - module: nginx
+                name: nginx-{{.TUID}}
+                url: http://{{.Address}}/stub_status
+          - selector: openvpn
+            template: |
+              - module: openvpn
+                name: openvpn-{{.TUID}}
+                address: {{.Address}}
+          - selector: phpfpm
+            template: |
+              - module: phpfpm
+                name: phpfpm-{{.TUID}}
+                url: http://{{.Address}}/status?full&json
+          - selector: rabbitmq
+            template: |
+              - module: rabbitmq
+                name: rabbitmq-{{.TUID}}
+                url: http://{{.Address}}
+          - selector: solr
+            template: |
+              - module: solr
+                name: solr-{{.TUID}}
+                url: http://{{.Address}}
+          - selector: tengine
+            template: |
+              - module: tengine
+                name: tengine-{{.TUID}}
+                url: http://{{.Address}}/us
+          - selector: unbound
+            template: |
+              - module: unbound
+                name: unbound-{{.TUID}}
+                address: {{.Address}}
+                use_tls: false
+          - selector: vernemq
+            template: |
+              - module: vernemq
+                name: vernemq-{{.TUID}}
+                url: http://{{.Address}}/metrics
+          - selector: zookeeper
+            template: |
+              - module: zookeeper
+                name: zookeeper-{{.TUID}}
+                address: {{.Address}}

--- a/kubernetes/netdata/helm/netdata/child/daemonset.yaml
+++ b/kubernetes/netdata/helm/netdata/child/daemonset.yaml
@@ -1,0 +1,173 @@
+---
+# Source: netdata/templates/child/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: netdata-child
+  namespace: netdata
+  labels:
+    app: netdata
+    chart: netdata-3.7.158
+    release: netdata
+    heritage: Helm
+    role: child
+spec:
+  selector:
+    matchLabels:
+      app: netdata
+      release: netdata
+      role: child
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/netdata: unconfined
+        checksum/config: da298d4e234854f41c853996da6b1f51b5fbdadc445031c5539305700f27ad5e
+        reloader.stakater.com/auto: "true"
+      labels:
+        app: netdata
+        release: netdata
+        role: child
+    spec:
+      serviceAccountName: netdata
+      restartPolicy: Always
+      hostPID: true
+      hostIPC: true
+      hostNetwork: true
+      initContainers:
+        - name: init-persistence
+          image: "alpine:latest"
+          resources:
+            requests:
+              cpu: 10m
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: persistencevarlibdir
+              mountPath: "/persistencevarlibdir"
+          command:
+            - "/bin/sh"
+          args:
+            - "-c"
+            - '
+            chmod 777 /persistencevarlibdir;
+            '
+      containers:
+        - name: netdata
+          image: "netdata/netdata:v2.8.5"
+          imagePullPolicy: Always
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NETDATA_LISTENER_PORT
+              value: '19999'
+            - name: DO_NOT_TRACK
+              value: "1"
+          ports:
+            - name: http
+              containerPort: 19999
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - /usr/sbin/netdatacli
+              - ping
+            initialDelaySeconds: 0
+            failureThreshold: 3
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            exec:
+              command:
+              - /usr/sbin/netdatacli
+              - ping
+            initialDelaySeconds: 0
+            failureThreshold: 3
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: proc
+              readOnly: true
+              mountPath: /host/proc
+            - name: sys
+              mountPath: /host/sys
+            - name: os-release
+              mountPath: /host/etc/os-release
+            - name: varlog
+              mountPath: /host/var/log
+            - name: configmap
+              mountPath: /etc/netdata/go.d.conf
+              subPath: go.d
+            - name: configmap
+              mountPath: /etc/netdata/go.d/k8s_kubelet.conf
+              subPath: kubelet
+            - name: configmap
+              mountPath: /etc/netdata/go.d/k8s_kubeproxy.conf
+              subPath: kubeproxy
+            - name: configmap
+              mountPath: /etc/netdata/netdata.conf
+              subPath: netdata
+            - name: configmap
+              mountPath: /etc/netdata/stream.conf.tmpl
+              subPath: stream
+            - name: persistencevarlibdir
+              mountPath: /var/lib/netdata
+            - name: sdconfigmap
+              mountPath: "/etc/netdata/go.d/sd/k8s.conf"
+              subPath: config.yml
+            - mountPath: /etc/netdata/stream.conf
+              name: stream-conf
+              subPath: stream.conf
+          securityContext:
+            capabilities:
+              add:
+                - SYS_PTRACE
+                - SYS_ADMIN
+          resources:
+            {}
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: os-release
+          hostPath:
+            path: /etc/os-release
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: configmap
+          configMap:
+            name: netdata-conf-child
+            optional: true
+        - name: configsecret
+          secret:
+            secretName: netdata-conf-child
+            optional: true
+        - name: persistencevarlibdir
+          hostPath:
+            path: /var/lib/netdata-k8s-child/var/lib/netdata
+            type: DirectoryOrCreate
+        - name: sdconfigmap
+          configMap:
+            name: netdata-child-sd-config-map
+            optional: true
+        - emptyDir: {}
+          name: stream-conf
+      dnsPolicy: ClusterFirstWithHostNet

--- a/kubernetes/netdata/helm/netdata/clusterrole.yaml
+++ b/kubernetes/netdata/helm/netdata/clusterrole.yaml
@@ -1,0 +1,45 @@
+---
+# Source: netdata/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: netdata
+  labels:
+    app: netdata
+    chart: netdata-3.7.158
+    release: netdata
+    heritage: Helm
+rules:
+  - apiGroups: [""]
+    resources:
+      - "pods"           # used by sd, go.d/k8s_state, netdata (cgroup-name.sh, get-kubernetes-labels.sh)
+      - "services"       # used by sd
+      - "configmaps"     # used by sd
+      - "secrets"        # used by sd
+      - "nodes"          # used by go.d/k8s_state
+      - "nodes/metrics"  # used by go.d/k8s_kubelet when querying Kubelet HTTPS endpoint
+      - "nodes/proxy"    # used by netdata (cgroup-name.sh) when querying Kubelet /pods endpoint
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups: ["apps"]
+    resources:
+      - "deployments"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups: ["batch"]
+    resources:
+      - "cronjobs"
+      - "jobs"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups: [""]
+    resources:
+      - "namespaces"  # used by go.d/k8s_state, netdata (cgroup-name.sh, get-kubernetes-labels.sh)
+    verbs:
+      - "get"

--- a/kubernetes/netdata/helm/netdata/clusterrolebinding.yaml
+++ b/kubernetes/netdata/helm/netdata/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+---
+# Source: netdata/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: netdata
+  labels:
+    app: netdata
+    chart: netdata-3.7.158
+    release: netdata
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: netdata
+subjects:
+- kind: ServiceAccount
+  name: netdata
+  namespace: netdata

--- a/kubernetes/netdata/helm/netdata/k8s-state/configmap.yaml
+++ b/kubernetes/netdata/helm/netdata/k8s-state/configmap.yaml
@@ -1,0 +1,60 @@
+---
+# Source: netdata/templates/k8s-state/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: netdata-conf-k8s-state
+  namespace: netdata
+  labels:
+    app: netdata
+    chart: netdata-3.7.158
+    release: netdata
+    heritage: Helm
+data:
+    
+  go.d: |
+        default_run: no
+        modules:
+          k8s_state: yes
+  go.d-k8s_state: |
+        jobs:
+          - name: k8s_state
+            update_every: 1
+  netdata: |
+        [global]
+          hostname = netdata-k8s-state
+        [db]
+          mode = ram
+        [web]
+          bind to = localhost:19999
+        [health]
+          enabled = no
+        [ml]
+          enabled = no
+        [plugins]
+          timex = no
+          checks = no
+          idlejitter = no
+          tc = no
+          diskspace = no
+          proc = no
+          cgroups = no
+          enable running new plugins = no
+          slabinfo = no
+          perf = no
+          go.d = yes
+          ioping = no
+          ebpf = no
+          charts.d = no
+          apps = no
+          python.d = no
+          fping = no
+  stream: |
+        [stream]
+          enabled = yes
+          destination = netdata:19999
+          api key = 11111111-2222-3333-4444-555555555555
+          timeout seconds = 60
+          buffer size bytes = 1048576
+          reconnect delay seconds = 5
+          initial clock resync iterations = 60

--- a/kubernetes/netdata/helm/netdata/k8s-state/deployment.yaml
+++ b/kubernetes/netdata/helm/netdata/k8s-state/deployment.yaml
@@ -1,0 +1,119 @@
+---
+# Source: netdata/templates/k8s-state/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netdata-k8s-state
+  namespace: netdata
+  labels:
+    app: netdata
+    chart: netdata-3.7.158
+    release: netdata
+    heritage: Helm
+    role: k8sState
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: netdata
+      release: netdata
+      role: k8sState
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/netdata: unconfined
+        checksum/config: b0479dd3f8bfbdf689b7d6c77fd78022efb7603e76f1070e35836d15a6b68ab0
+        reloader.stakater.com/auto: "true"
+      labels:
+        app: netdata
+        release: netdata
+        role: k8sState
+    spec:
+      securityContext:
+        fsGroup: 201
+      serviceAccountName: netdata
+      restartPolicy: Always
+      initContainers:
+      containers:
+        - name: netdata
+          image: "netdata/netdata:v2.8.5"
+          imagePullPolicy: Always
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NETDATA_LISTENER_PORT
+              value: '19999'
+            - name: DO_NOT_TRACK
+              value: "1"
+          ports:
+            - name: http
+              containerPort: 19999
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - /usr/sbin/netdatacli
+                - ping
+            initialDelaySeconds: 0
+            failureThreshold: 3
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            exec:
+              command:
+                - /usr/sbin/netdatacli
+                - ping
+            initialDelaySeconds: 0
+            failureThreshold: 3
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: os-release
+              mountPath: /host/etc/os-release
+            - name: configmap
+              mountPath: /etc/netdata/go.d.conf
+              subPath: go.d
+            - name: configmap
+              mountPath: /etc/netdata/go.d/k8s_state.conf
+              subPath: go.d-k8s_state
+            - name: configmap
+              mountPath: /etc/netdata/netdata.conf
+              subPath: netdata
+            - name: configmap
+              mountPath: /etc/netdata/stream.conf.tmpl
+              subPath: stream
+            - name: varlib
+              mountPath: /var/lib/netdata
+            - mountPath: /etc/netdata/stream.conf
+              name: stream-conf
+              subPath: stream.conf
+          resources:
+            {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: os-release
+          hostPath:
+            path: /etc/os-release
+        - name: configmap
+          configMap:
+            name: netdata-conf-k8s-state
+            optional: true
+        - name: configsecret
+          secret:
+            secretName: netdata-conf-k8s-state
+            optional: true
+        - name: varlib
+          persistentVolumeClaim:
+            claimName: netdata-k8s-state-varlib
+        - emptyDir: {}
+          name: stream-conf
+      dnsPolicy: ClusterFirstWithHostNet

--- a/kubernetes/netdata/helm/netdata/k8s-state/persistentvolumeclaim.yaml
+++ b/kubernetes/netdata/helm/netdata/k8s-state/persistentvolumeclaim.yaml
@@ -1,0 +1,18 @@
+---
+# Source: netdata/templates/k8s-state/persistentvolumeclaim.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: netdata-k8s-state-varlib
+  namespace: netdata
+  labels:
+    app: netdata
+    chart: netdata-3.7.158
+    release: netdata
+    heritage: Helm
+    role: k8sState
+spec:
+  accessModes: [ "ReadWriteOnce" ]
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/netdata/helm/netdata/parent/configmap.yaml
+++ b/kubernetes/netdata/helm/netdata/parent/configmap.yaml
@@ -1,0 +1,45 @@
+---
+# Source: netdata/templates/parent/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: netdata-conf-parent
+  namespace: netdata
+  labels:
+    app: netdata
+    chart: netdata-3.7.158
+    release: netdata
+    heritage: Helm
+data:
+    
+  health: |
+        SEND_EMAIL="NO"
+        SEND_SLACK="YES"
+        SLACK_WEBHOOK_URL=""
+        DEFAULT_RECIPIENT_SLACK=""
+  netdata: |
+        [global]
+          hostname = netdata-parent
+        [db]
+          mode = dbengine
+      
+        [plugins]
+          cgroups = no
+          tc = no
+          enable running new plugins = no
+          check for new plugins every = 72000
+          python.d = no
+          charts.d = no
+          go.d = no
+          node.d = no
+          apps = no
+          proc = no
+          idlejitter = no
+          diskspace = no
+  stream: |
+        [11111111-2222-3333-4444-555555555555]
+          enabled = yes
+          history = 3600
+          default memory mode = dbengine
+          health enabled by default = auto
+          allow from = *

--- a/kubernetes/netdata/helm/netdata/parent/deployment.yaml
+++ b/kubernetes/netdata/helm/netdata/parent/deployment.yaml
@@ -1,0 +1,144 @@
+---
+# Source: netdata/templates/parent/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netdata-parent
+  namespace: netdata
+  labels:
+    app: netdata
+    chart: netdata-3.7.158
+    release: netdata
+    heritage: Helm
+    role: parent
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: netdata
+      release: netdata
+      role: parent
+  template:
+    metadata:
+      labels:
+        app: netdata
+        release: netdata
+        role: parent
+      annotations:
+        checksum/config: 3593a1a2512ae7890431f94cfdd5515e59386ef76ad3bab54910c99fddf06d90
+        reloader.stakater.com/auto: "true"
+    spec:
+      securityContext:
+        fsGroup: 201
+      serviceAccountName: netdata
+      initContainers:
+        - command:
+          - sh
+          - -c
+          - |
+            sed "s/11111111-2222-3333-4444-555555555555/$NETDATA_STREAM_API_KEY/g" \
+              /etc/netdata-tmpl/stream > /etc/netdata-out/stream.conf
+          envFrom:
+          - secretRef:
+              name: netdata-streaming
+          image: alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+          name: inject-stream-key
+          volumeMounts:
+          - mountPath: /etc/netdata-tmpl
+            name: configmap
+          - mountPath: /etc/netdata-out
+            name: stream-conf
+      containers:
+        - name: netdata
+          image: "netdata/netdata:v2.8.5"
+          imagePullPolicy: Always
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NETDATA_LISTENER_PORT
+              value: '19999'
+            - name: DO_NOT_TRACK
+              value: "1"
+          ports:
+            - name: http
+              containerPort: 19999
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - /usr/sbin/netdatacli
+              - ping
+            initialDelaySeconds: 0
+            failureThreshold: 3
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            exec:
+              command:
+              - /usr/sbin/netdatacli
+              - ping
+            initialDelaySeconds: 0
+            failureThreshold: 3
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 1
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts:
+            - name: os-release
+              mountPath: /host/etc/os-release
+            - name: configmap
+              mountPath: /etc/netdata/health_alarm_notify.conf
+              subPath: health
+            - name: configmap
+              mountPath: /etc/netdata/netdata.conf
+              subPath: netdata
+            - name: configmap
+              mountPath: /etc/netdata/stream.conf.tmpl
+              subPath: stream
+            - name: database
+              mountPath: /var/cache/netdata
+            - name: alarms
+              mountPath: /var/lib/netdata
+            - mountPath: /var/cache/netdata/dbengine
+              name: dbengine
+            - mountPath: /etc/netdata/stream.conf
+              name: stream-conf
+              subPath: stream.conf
+          resources:
+            {}
+      terminationGracePeriodSeconds: 300
+      volumes:
+        - name: os-release
+          hostPath:
+            path: /etc/os-release
+        - name: configmap
+          configMap:
+            name: netdata-conf-parent
+            optional: true
+        - name: configsecret
+          secret:
+            secretName: netdata-conf-parent
+            optional: true
+        - name: database
+          persistentVolumeClaim:
+            claimName: netdata-parent-database
+        - name: alarms
+          persistentVolumeClaim:
+            claimName: netdata-parent-alarms
+        - name: dbengine
+          persistentVolumeClaim:
+            claimName: netdata-parent-dbengine
+        - emptyDir: {}
+          name: stream-conf
+      dnsPolicy: ClusterFirst

--- a/kubernetes/netdata/helm/netdata/parent/ingress.yaml
+++ b/kubernetes/netdata/helm/netdata/parent/ingress.yaml
@@ -1,0 +1,37 @@
+---
+# Source: netdata/templates/parent/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: netdata
+  namespace: netdata
+  labels:
+    app: netdata
+    chart: netdata-3.7.158
+    release: netdata
+    heritage: Helm
+  annotations:
+    cert-manager.io/cluster-issuer: zerossl
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Monitoring
+    gethomepage.dev/icon: netdata.png
+    gethomepage.dev/name: Netdata
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+      - netdata.k.oneill.net
+      secretName: netdata-tls
+  rules:
+    - host: netdata.k.oneill.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: netdata
+                port:
+                  name: http

--- a/kubernetes/netdata/helm/netdata/parent/persistentvolumeclaim.yaml
+++ b/kubernetes/netdata/helm/netdata/parent/persistentvolumeclaim.yaml
@@ -1,0 +1,38 @@
+---
+# Source: netdata/templates/parent/persistentvolumeclaim.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: netdata-parent-database
+  namespace: netdata
+  labels:
+    app: netdata
+    chart: netdata-3.7.158
+    release: netdata
+    heritage: Helm
+    role: parent
+spec:
+  accessModes: [ "ReadWriteOnce" ]
+  storageClassName: "synology-iscsi"
+  resources:
+    requests:
+      storage: 10Gi
+---
+# Source: netdata/templates/parent/persistentvolumeclaim.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: netdata-parent-alarms
+  namespace: netdata
+  labels:
+    app: netdata
+    chart: netdata-3.7.158
+    release: netdata
+    heritage: Helm
+    role: parent
+spec:
+  accessModes: [ "ReadWriteOnce" ]
+  storageClassName: "synology-iscsi"
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/netdata/helm/netdata/parent/service.yaml
+++ b/kubernetes/netdata/helm/netdata/parent/service.yaml
@@ -1,0 +1,25 @@
+---
+# Source: netdata/templates/parent/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: netdata
+  namespace: netdata
+  labels:
+    app: netdata
+    chart: netdata-3.7.158
+    release: netdata
+    heritage: Helm
+    role: parent
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 19999
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: netdata
+    release: netdata
+    role: parent

--- a/kubernetes/netdata/helm/netdata/serviceaccount.yaml
+++ b/kubernetes/netdata/helm/netdata/serviceaccount.yaml
@@ -1,0 +1,12 @@
+---
+# Source: netdata/templates/serviceaccount.yaml
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  labels:
+    app: netdata
+    chart: netdata-3.7.158
+    release: netdata
+    heritage: Helm
+  name: netdata
+  namespace: netdata

--- a/kubernetes/netdata/kustomization.yaml
+++ b/kubernetes/netdata/kustomization.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: netdata
+
+commonAnnotations:
+  argoManaged: 'true'
+
+resources:
+- namespace.yaml
+- externalsecret.yaml
+- dbengine-pvc.yaml
+- helm/netdata/serviceaccount.yaml
+- helm/netdata/clusterrole.yaml
+- helm/netdata/clusterrolebinding.yaml
+- helm/netdata/parent/configmap.yaml
+- helm/netdata/parent/persistentvolumeclaim.yaml
+- helm/netdata/parent/service.yaml
+- helm/netdata/parent/deployment.yaml
+- helm/netdata/parent/ingress.yaml
+- helm/netdata/child/configmap.yaml
+- helm/netdata/child/daemonset.yaml
+- helm/netdata/k8s-state/configmap.yaml
+- helm/netdata/k8s-state/persistentvolumeclaim.yaml
+- helm/netdata/k8s-state/deployment.yaml
+
+patches:
+- path: patch-child-stream-init.yaml
+- path: patch-k8s-state-stream-init.yaml
+
+labels:
+
+- pairs:
+    app.kubernetes.io/name: netdata
+    app.kubernetes.io/instance: netdata
+  includeSelectors: true

--- a/kubernetes/netdata/namespace.yaml
+++ b/kubernetes/netdata/namespace.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: netdata
+  labels:
+    goldilocks.fairwinds.com/enabled: 'true'
+  annotations:
+    goldilocks.fairwinds.com/vpa-update-mode: InPlaceOrRecreate
+    goldilocks.fairwinds.com/vpa-resource-policy: >-
+      {"containerPolicies":[{"containerName":"*","controlledValues":"RequestsOnly"}]}

--- a/kubernetes/netdata/patch-child-stream-init.yaml
+++ b/kubernetes/netdata/patch-child-stream-init.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+
+metadata:
+  name: netdata-child
+  namespace: netdata
+
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: inject-stream-key
+        image: alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+        command:
+        - sh
+        - -c
+        - |
+          sed "s/11111111-2222-3333-4444-555555555555/$NETDATA_STREAM_API_KEY/g" \
+            /etc/netdata-tmpl/stream > /etc/netdata-out/stream.conf
+        envFrom:
+        - secretRef:
+            name: netdata-streaming
+        volumeMounts:
+        - name: configmap
+          mountPath: /etc/netdata-tmpl
+        - name: stream-conf
+          mountPath: /etc/netdata-out

--- a/kubernetes/netdata/patch-k8s-state-stream-init.yaml
+++ b/kubernetes/netdata/patch-k8s-state-stream-init.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: netdata-k8s-state
+  namespace: netdata
+
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: inject-stream-key
+        image: alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+        command:
+        - sh
+        - -c
+        - |
+          sed "s/11111111-2222-3333-4444-555555555555/$NETDATA_STREAM_API_KEY/g" \
+            /etc/netdata-tmpl/stream > /etc/netdata-out/stream.conf
+        envFrom:
+        - secretRef:
+            name: netdata-streaming
+        volumeMounts:
+        - name: configmap
+          mountPath: /etc/netdata-tmpl
+        - name: stream-conf
+          mountPath: /etc/netdata-out

--- a/kubernetes/netdata/render
+++ b/kubernetes/netdata/render
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$BASEDIR"
+
+source "$BASEDIR/../scripts/chart-version"
+
+rm -rf helm tmp
+mkdir -p tmp helm/netdata
+
+# Render the Netdata chart (direct from remote repo via chart-version helper)
+helm_template netdata netdata \
+  --namespace netdata \
+  --values values.yaml \
+  --output-dir tmp
+
+mv tmp/netdata/templates/* helm/netdata/
+
+rm -rf tmp
+rm -rf helm/*/tests

--- a/kubernetes/netdata/values.yaml
+++ b/kubernetes/netdata/values.yaml
@@ -1,0 +1,129 @@
+---
+parent:
+  # iSCSI for SQLite metadata (default storageclass is "-")
+  database:
+    storageclass: synology-iscsi
+    volumesize: 10Gi
+
+  # iSCSI for alarms (default storageclass is "-")
+  alarms:
+    storageclass: synology-iscsi
+
+  # NFS volume for dbengine time-series data (overlays dbengine subdir)
+  extraVolumes:
+  - name: dbengine
+    persistentVolumeClaim:
+      claimName: netdata-parent-dbengine
+  - name: stream-conf
+    emptyDir: {}
+
+  extraVolumeMounts:
+  - name: dbengine
+    mountPath: /var/cache/netdata/dbengine
+  - name: stream-conf
+    mountPath: /etc/netdata/stream.conf
+    subPath: stream.conf
+
+  # Init container to inject the streaming API key into stream.conf
+  # (only parent supports extraInitContainers; child/k8sState use kustomize patches)
+  extraInitContainers:
+  - name: inject-stream-key
+    image: alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+    command:
+    - sh
+    - -c
+    - |
+      sed "s/11111111-2222-3333-4444-555555555555/$NETDATA_STREAM_API_KEY/g" \
+        /etc/netdata-tmpl/stream > /etc/netdata-out/stream.conf
+    envFrom:
+    - secretRef:
+        name: netdata-streaming
+    volumeMounts:
+    - name: configmap
+      mountPath: /etc/netdata-tmpl
+    - name: stream-conf
+      mountPath: /etc/netdata-out
+
+  podAnnotations:
+    reloader.stakater.com/auto: 'true'
+
+  configs:
+    stream:
+      # .tmpl path avoids mount conflict with emptyDir at the real path
+      path: /etc/netdata/stream.conf.tmpl
+
+  # Upstream defaults to `Default` but parent doesn't use hostNetwork
+  dnsPolicy: ClusterFirst
+
+  # Chart defaults runAsUser: 201 but the entrypoint needs root for setup
+  # (group management, telemetry opt-out file). It drops privileges itself via
+  # `netdata -u netdata`.
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+
+  env:
+    DO_NOT_TRACK: 1
+
+child:
+  podAnnotations:
+    reloader.stakater.com/auto: 'true'
+
+  extraVolumes:
+  - name: stream-conf
+    emptyDir: {}
+
+  extraVolumeMounts:
+  - name: stream-conf
+    mountPath: /etc/netdata/stream.conf
+    subPath: stream.conf
+
+  # No extraInitContainers — chart doesn't support it for child.
+  # Init container added via kustomize patch (patch-child-stream-init.yaml)
+
+  configs:
+    stream:
+      path: /etc/netdata/stream.conf.tmpl
+
+  env:
+    DO_NOT_TRACK: 1
+
+k8sState:
+  podAnnotations:
+    reloader.stakater.com/auto: 'true'
+
+  extraVolumes:
+  - name: stream-conf
+    emptyDir: {}
+
+  extraVolumeMounts:
+  - name: stream-conf
+    mountPath: /etc/netdata/stream.conf
+    subPath: stream.conf
+
+  # No extraInitContainers — chart doesn't support it for k8sState.
+  # Init container added via kustomize patch (patch-k8s-state-stream-init.yaml)
+
+  configs:
+    stream:
+      path: /etc/netdata/stream.conf.tmpl
+
+  env:
+    DO_NOT_TRACK: 1
+
+ingress:
+  enabled: true
+  annotations:
+    cert-manager.io/cluster-issuer: zerossl
+    gethomepage.dev/enabled: 'true'
+    gethomepage.dev/name: Netdata
+    gethomepage.dev/group: Monitoring
+    gethomepage.dev/icon: netdata.png
+  spec:
+    ingressClassName: nginx
+  hosts:
+  - netdata.k.oneill.net
+  tls:
+  - secretName: netdata-tls
+    hosts:
+    - netdata.k.oneill.net


### PR DESCRIPTION
- Helm chart, kustomize overlay, ExternalSecret for streaming API key
- Fix upstream chart bug: parent securityContext needs root (runAsUser: 0)
  so Docker entrypoint can create opt-out file and manage groups before
  dropping privileges via `netdata -u netdata`
- Init containers inject streaming API key into stream.conf for all pods
- NFS + iSCSI persistent storage for parent dbengine and metadata
- Ingress at netdata.k.oneill.net with ZeroSSL TLS
