### PR TITLE
Expose Netdata streaming to flux VPS via Tailscale

### DIFF
--- a/ansible/host_vars/flux/netdata.yaml
+++ b/ansible/host_vars/flux/netdata.yaml
@@ -1,0 +1,3 @@
+---
+netdata_parent: netdata.cow-banjo.ts.net
+netdata_streaming_skip_tls_verify: true

--- a/ansible/roles/netdata/templates/stream.conf.j2
+++ b/ansible/roles/netdata/templates/stream.conf.j2
@@ -3,3 +3,10 @@
     enabled = yes
     destination = {{ netdata_parent }}:{{ netdata_parent_port }}:SSL
     api key = {{ netdata_stream_api_key }}
+{% if netdata_streaming_skip_tls_verify | default(false) %}
+    # Parent cert is issued for netdata-stream.k.oneill.net but this host
+    # connects via Tailscale (netdata.cow-banjo.ts.net), causing a hostname
+    # mismatch. TLS still encrypts the connection; WireGuard provides
+    # additional transport encryption; the API key authenticates the stream.
+    ssl skip certificate verification = yes
+{% endif %}

--- a/kubernetes/netdata/kustomization.yaml
+++ b/kubernetes/netdata/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
 - helm/netdata/k8s-state/persistentvolumeclaim.yaml
 - helm/netdata/k8s-state/deployment.yaml
 - netdata-streaming-lb.yaml
+- tailscale-service.yaml
 - certificate-streaming.yaml
 
 patches:

--- a/kubernetes/netdata/tailscale-service.yaml
+++ b/kubernetes/netdata/tailscale-service.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: netdata-tailscale
+  annotations:
+    tailscale.com/hostname: netdata
+    tailscale.com/tags: tag:netdata
+
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  ports:
+  - port: 19999
+    targetPort: http
+    protocol: TCP
+    name: streaming
+  selector:
+    app: netdata
+    release: netdata
+    role: parent

--- a/opentofu/tailscale.tf
+++ b/opentofu/tailscale.tf
@@ -18,6 +18,7 @@ resource "tailscale_acl" "main" {
             "tag:flux": ["autogroup:admin"],
             "tag:restic": ["tag:k8s-operator"],
             "tag:healthchecks": ["tag:k8s-operator"],
+            "tag:netdata": ["tag:k8s-operator"],
         },
 
         // Define access control lists for users, groups, autogroups, tags,
@@ -52,6 +53,14 @@ resource "tailscale_acl" "main" {
                 "src":    ["tag:flux"],
                 "proto":  "tcp",
                 "dst":    ["tag:healthchecks:443"],
+            },
+
+            // Allow flux to reach netdata parent for metrics streaming
+            {
+                "action": "accept",
+                "src":    ["tag:flux"],
+                "proto":  "tcp",
+                "dst":    ["tag:netdata:19999"],
             },
 
             // Allow GitHub Actions to reach ArgoCD and Semaphore


### PR DESCRIPTION
- Add L4 Tailscale Service for Netdata parent streaming port (19999)
- Add tag:netdata and ACL rule allowing flux to reach it
- Add flux host vars to stream via netdata.cow-banjo.ts.net
- Skip TLS cert verification for flux (hostname mismatch with
  parent cert, but TLS + WireGuard still encrypt the connection)
