### PR TITLE
Add Netdata MCP server and upgrade mcp-cli to v0.3.0

### DIFF
--- a/.mcp_servers.json
+++ b/.mcp_servers.json
@@ -17,6 +17,9 @@
         "UNIFI_VERIFY_SSL": "false",
         "UNIFI_TOOL_MODE": "eager"
       }
+    },
+    "netdata": {
+      "url": "https://netdata-stream.k.oneill.net:19999/mcp"
     }
   }
 }


### PR DESCRIPTION
- Build mcp-cli from source (commit d77672a) instead of downloading
  pre-built v0.1.4 binaries. Adds HTTP transport support and
  subcommand architecture (info, call, grep).
- Add netdata server to .mcp_servers.json using HTTP URL transport
  pointing to the streaming parent at netdata-stream.k.oneill.net
