### PR TITLE
Fix RPi QEMU integration test disk space failure

### DIFF
--- a/tests/rpi/Dockerfile
+++ b/tests/rpi/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     e2fsprogs \
     kpartx \
     dosfstools \
+    fdisk \
     openssh-client \
     netcat-openbsd \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The root partition wasn't being grown after qemu-img resize, so
apt-get update ran out of space as the Trixie package index grew.

- Grow root partition with sfdisk + resize2fs before QEMU boot
- Add fdisk package to test container for sfdisk
- Dump cloud-init logs on test failure for easier debugging
