### PR TITLE
Fix flux host_vars shadowed by directory

### DIFF
--- a/ansible/host_vars/flux.yaml
+++ b/ansible/host_vars/flux.yaml
@@ -13,3 +13,5 @@ restic_host_config:
     # Use a dedicated repo via REST server over Tailscale. This host has limited
     # disk and memory, so pulling the index for all other machines is not practical.
     repository: "rest:https://{{ '{{' }} $repo_username {{ '}}' }}:{{ '{{' }} $repo_password {{ '}}' }}@restic.cow-banjo.ts.net/{{ ansible_facts['hostname'] }}"
+netdata_parent: netdata.cow-banjo.ts.net
+netdata_streaming_skip_tls_verify: true

--- a/ansible/host_vars/flux/netdata.yaml
+++ b/ansible/host_vars/flux/netdata.yaml
@@ -1,3 +1,0 @@
----
-netdata_parent: netdata.cow-banjo.ts.net
-netdata_streaming_skip_tls_verify: true


### PR DESCRIPTION
Ansible ignores host_vars/flux.yaml when host_vars/flux/ directory
also exists, causing qemu_guest_agent_enabled to be undefined and
breaking the nightly idempotency test.

Move netdata config into flux.yaml and remove the directory.
