### PR TITLE
Add new external-secrets CRDs to kustomization

### DIFF
--- a/kubernetes/external-secrets/kustomization.yaml
+++ b/kubernetes/external-secrets/kustomization.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 namespace: external-secrets
 
 resources:
@@ -25,7 +26,9 @@ resources:
 - helm/templates/crds/vaultdynamicsecret.yaml
 - helm/templates/crds/webhook.yaml
 - helm/templates/crds/generatorstate.yaml
+- helm/templates/crds/cloudsmithaccesstoken.yaml
 - helm/templates/crds/clusterpushsecret.yaml
+- helm/templates/crds/sshkey.yaml
 - helm/templates/deployment.yaml
 - helm/templates/rbac.yaml
 - helm/templates/serviceaccount.yaml


### PR DESCRIPTION
Add cloudsmithaccesstoken and sshkey CRD references
introduced in external-secrets chart v1.3.x.
