### PR TITLE
Deploy Proxmox PVE exporter for cluster monitoring

### DIFF
--- a/kubernetes/netdata/helm/netdata/parent/configmap.yaml
+++ b/kubernetes/netdata/helm/netdata/parent/configmap.yaml
@@ -12,6 +12,22 @@ metadata:
     heritage: Helm
 data:
     
+  go.d: |
+        default_run: false
+        modules:
+          prometheus: true
+  go.d-prometheus: |
+        jobs:
+          - name: proxmox-cluster
+            url: http://prometheus-pve-exporter.o11y.svc:9221/pve?target=p1.oneill.net&cluster=1&node=0
+          - name: proxmox-p1
+            url: http://prometheus-pve-exporter.o11y.svc:9221/pve?target=p1.oneill.net&cluster=0&node=1
+          - name: proxmox-p2
+            url: http://prometheus-pve-exporter.o11y.svc:9221/pve?target=p2.oneill.net&cluster=0&node=1
+          - name: proxmox-p3
+            url: http://prometheus-pve-exporter.o11y.svc:9221/pve?target=p3.oneill.net&cluster=0&node=1
+          - name: proxmox-p4
+            url: http://prometheus-pve-exporter.o11y.svc:9221/pve?target=p4.oneill.net&cluster=0&node=1
   health: |
         SEND_EMAIL="NO"
         SEND_SLACK="YES"

--- a/kubernetes/netdata/helm/netdata/parent/deployment.yaml
+++ b/kubernetes/netdata/helm/netdata/parent/deployment.yaml
@@ -40,6 +40,7 @@ spec:
             sed "s/11111111-2222-3333-4444-555555555555/$NETDATA_STREAM_API_KEY/g" \
               /etc/netdata-tmpl/stream > /out/stream/stream.conf
             cp /etc/netdata-tmpl/netdata /out/netdata/netdata.conf
+            sed -i 's/go.d = no/go.d = yes/' /out/netdata/netdata.conf
             cat >> /out/netdata/netdata.conf <<'EOF'
             [web]
               ssl key = /etc/netdata/ssl/tls.key
@@ -104,6 +105,12 @@ spec:
           volumeMounts:
             - name: os-release
               mountPath: /host/etc/os-release
+            - name: configmap
+              mountPath: /etc/netdata/go.d.conf
+              subPath: go.d
+            - name: configmap
+              mountPath: /etc/netdata/go.d/prometheus.conf
+              subPath: go.d-prometheus
             - name: configmap
               mountPath: /etc/netdata/health_alarm_notify.conf
               subPath: health

--- a/kubernetes/netdata/values.yaml
+++ b/kubernetes/netdata/values.yaml
@@ -49,6 +49,7 @@ parent:
       sed "s/11111111-2222-3333-4444-555555555555/$NETDATA_STREAM_API_KEY/g" \
         /etc/netdata-tmpl/stream > /out/stream/stream.conf
       cp /etc/netdata-tmpl/netdata /out/netdata/netdata.conf
+      sed -i 's/go.d = no/go.d = yes/' /out/netdata/netdata.conf
       cat >> /out/netdata/netdata.conf <<'EOF'
       [web]
         ssl key = /etc/netdata/ssl/tls.key
@@ -74,6 +75,28 @@ parent:
       path: /etc/netdata/stream.conf.tmpl
     netdata:
       path: /etc/netdata/netdata.conf.tmpl
+    go.d:
+      enabled: true
+      path: /etc/netdata/go.d.conf
+      data: |
+        default_run: false
+        modules:
+          prometheus: true
+    go.d-prometheus:
+      enabled: true
+      path: /etc/netdata/go.d/prometheus.conf
+      data: |
+        jobs:
+          - name: proxmox-cluster
+            url: http://prometheus-pve-exporter.o11y.svc:9221/pve?target=p1.oneill.net&cluster=1&node=0
+          - name: proxmox-p1
+            url: http://prometheus-pve-exporter.o11y.svc:9221/pve?target=p1.oneill.net&cluster=0&node=1
+          - name: proxmox-p2
+            url: http://prometheus-pve-exporter.o11y.svc:9221/pve?target=p2.oneill.net&cluster=0&node=1
+          - name: proxmox-p3
+            url: http://prometheus-pve-exporter.o11y.svc:9221/pve?target=p3.oneill.net&cluster=0&node=1
+          - name: proxmox-p4
+            url: http://prometheus-pve-exporter.o11y.svc:9221/pve?target=p4.oneill.net&cluster=0&node=1
 
   # Upstream defaults to `Default` but parent doesn't use hostNetwork
   dnsPolicy: ClusterFirst

--- a/kubernetes/prometheus-pve-exporter/deployment.yaml
+++ b/kubernetes/prometheus-pve-exporter/deployment.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: exporter
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-pve-exporter
+      app.kubernetes.io/instance: prometheus-pve-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus-pve-exporter
+        app.kubernetes.io/instance: prometheus-pve-exporter
+      annotations:
+        reloader.stakater.com/auto: 'true'
+    spec:
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      containers:
+      - name: pve-exporter
+        image: ghcr.io/prometheus-pve/prometheus-pve-exporter:3.8.0@sha256:66e0c8558b23f06231ab55ab1afdef2d43ff24365bcf75d36adaef6d9f7497df
+        ports:
+        - containerPort: 9221
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        env:
+        - name: PVE_USER
+          value: pve-exporter@pve
+        - name: PVE_TOKEN_NAME
+          value: exporter
+        envFrom:
+        - secretRef:
+            name: prometheus-pve-exporter
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 101
+          capabilities:
+            drop: [ALL]

--- a/kubernetes/prometheus-pve-exporter/externalsecret.yaml
+++ b/kubernetes/prometheus-pve-exporter/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+  name: exporter
+
+spec:
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  data:
+  - secretKey: PVE_TOKEN_VALUE
+    remoteRef:
+      key: prometheus-pve-exporter
+      property: credential
+  target:
+    name: prometheus-pve-exporter

--- a/kubernetes/prometheus-pve-exporter/kustomization.yaml
+++ b/kubernetes/prometheus-pve-exporter/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: o11y
+
+namePrefix: prometheus-pve-
+
+commonAnnotations:
+  argoManaged: 'true'
+
+resources:
+- deployment.yaml
+- service.yaml
+- externalsecret.yaml
+
+labels:
+
+- pairs:
+    app.kubernetes.io/name: prometheus-pve-exporter
+    app.kubernetes.io/instance: prometheus-pve-exporter

--- a/kubernetes/prometheus-pve-exporter/service.yaml
+++ b/kubernetes/prometheus-pve-exporter/service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: exporter
+
+spec:
+  selector:
+    app.kubernetes.io/name: prometheus-pve-exporter
+    app.kubernetes.io/instance: prometheus-pve-exporter
+  ports:
+  - port: 9221
+    targetPort: 9221

--- a/kubernetes/prometheus/config/prometheus.yml
+++ b/kubernetes/prometheus/config/prometheus.yml
@@ -298,6 +298,43 @@ scrape_configs:
     action: replace
     target_label: kubernetes_pod_name
 
+- job_name: proxmox-cluster
+  scrape_interval: 60s
+  metrics_path: /pve
+  params:
+    cluster: ['1']
+    node: ['0']
+  static_configs:
+  - targets:
+    - p1.oneill.net
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: __param_target
+  - source_labels: [__param_target]
+    target_label: instance
+  - target_label: __address__
+    replacement: prometheus-pve-exporter.o11y.svc:9221
+
+- job_name: proxmox-nodes
+  scrape_interval: 60s
+  metrics_path: /pve
+  params:
+    cluster: ['0']
+    node: ['1']
+  static_configs:
+  - targets:
+    - p1.oneill.net
+    - p2.oneill.net
+    - p3.oneill.net
+    - p4.oneill.net
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: __param_target
+  - source_labels: [__param_target]
+    target_label: instance
+  - target_label: __address__
+    replacement: prometheus-pve-exporter.o11y.svc:9221
+
 - job_name: karakeep
   metrics_path: /api/metrics
   static_configs:

--- a/opentofu/proxmox-pve-exporter.tf
+++ b/opentofu/proxmox-pve-exporter.tf
@@ -1,0 +1,40 @@
+# Proxmox API user and token for prometheus-pve-exporter
+# Read-only access (PVEAuditor) for cluster, node, and VM metrics
+
+resource "proxmox_virtual_environment_user" "pve_exporter" {
+  user_id = "pve-exporter@pve"
+  comment = "Prometheus PVE exporter - managed by OpenTofu"
+  enabled = true
+}
+
+resource "proxmox_virtual_environment_acl" "pve_exporter" {
+  path      = "/"
+  role_id   = "PVEAuditor"
+  user_id   = proxmox_virtual_environment_user.pve_exporter.user_id
+  propagate = true
+}
+
+resource "proxmox_virtual_environment_user_token" "pve_exporter" {
+  user_id               = proxmox_virtual_environment_user.pve_exporter.user_id
+  token_name            = "exporter"
+  comment               = "Prometheus PVE exporter - managed by OpenTofu"
+  privileges_separation = false
+}
+
+resource "onepassword_item" "pve_exporter" {
+  vault    = data.onepassword_vault.infra.uuid
+  title    = "prometheus-pve-exporter"
+  category = "login"
+
+  section {
+    label = "Token"
+
+    field {
+      label = "credential"
+      type  = "CONCEALED"
+      value = split("=", proxmox_virtual_environment_user_token.pve_exporter.value)[1]
+    }
+  }
+
+  note_value = "Proxmox API token for prometheus-pve-exporter. Managed by OpenTofu."
+}


### PR DESCRIPTION
- OpenTofu: Create PVE API user (pve-exporter@pve) with PVEAuditor role,
  API token, and 1Password storage
- Kubernetes: Deploy prometheus-pve-exporter in o11y namespace with
  ExternalSecret for token credential
- Prometheus: Add scrape jobs for cluster metrics (via p1) and per-node
  metrics (p1-p4) using multi-target exporter pattern
- Netdata: Enable go.d prometheus collector on parent to scrape PVE
  metrics from all nodes
