### PR TITLE
Clear gyb config dir before copying on restart

### DIFF
--- a/kubernetes/got-your-back/run
+++ b/kubernetes/got-your-back/run
@@ -15,6 +15,10 @@ rm -rf gyb gyb.tar.xz
 
 cd /data
 
+# Clear config dir in case of container restart (emptyDir persists, and
+# the renamed .cfg file from a previous run would cause find to return
+# two results, breaking the mv below).
+rm -rf /config/*
 cp -aL /config-source/* /config
 
 old_filename=$(find /config -name "*.cfg")


### PR DESCRIPTION
The run script copies config from a read-only secret mount to an
emptyDir, then renames the .cfg file (replacing _ with @). With
restartPolicy: OnFailure, the emptyDir persists across container
restarts, so both the original and renamed files exist, causing
find to return two results and the mv to fail.
