### PR TITLE
Add timezone management to common Ansible role

### DIFF
--- a/ansible/group_vars/all/main.yaml
+++ b/ansible/group_vars/all/main.yaml
@@ -1,4 +1,6 @@
 ---
+timezone: America/New_York
+
 # Used by chrony role to conditionally configure UFW firewall rules
 enable_ufw: false
 

--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -16,6 +16,19 @@
     state: present
     autoremove: true
 
+- name: "Set system timezone"
+  ansible.builtin.file:
+    src: "/usr/share/zoneinfo/{{ timezone }}"
+    dest: /etc/localtime
+    state: link
+    force: true
+
+- name: "Write timezone to /etc/timezone"
+  ansible.builtin.copy:
+    content: "{{ timezone }}\n"
+    dest: /etc/timezone
+    mode: "0644"
+
 - name: "Check if Proxmox is installed"
   ansible.builtin.stat:
     path: /usr/bin/pvesh


### PR DESCRIPTION
Default all hosts to America/New_York via group_vars, overridable
per-host. Previously no hosts had timezone managed by Ansible.
