### PR TITLE
Add pollonly to NUT UPS drivers to fix CPU spin

### DIFF
--- a/ansible/group_vars/nut.yaml
+++ b/ansible/group_vars/nut.yaml
@@ -12,18 +12,21 @@ nut_ups:
     description: "UPS for Synology"
     extra: |
       serial = "CXXPV7000091"
+      pollonly
   - name: "ups2"
     driver: "usbhid-ups"
     device: auto
     description: "UPS for p1, p2, p3, p4"
     extra: |
       serial = "CXXPV7000092"
+      pollonly
   - name: "ups3"
     driver: "usbhid-ups"
     device: auto
     description: "UPS for network gear & infra1"
     extra: |
       serial = "CXXPX7007632"
+      pollonly
 
 nut_upsmon_extra: |
   SHUTDOWNCMD "/sbin/shutdown -h +0"


### PR DESCRIPTION
Two of three usbhid-ups driver processes on infra1 were stuck in a CPU
spin loop (~96% each) due to broken USB interrupt transfers. The pollonly
directive disables interrupt transfers and forces polling-only mode.
