### PR TITLE
Reduce k3/k4 CPU steal time

### DIFF
--- a/ansible/roles/proxmox/tasks/main.yaml
+++ b/ansible/roles/proxmox/tasks/main.yaml
@@ -18,6 +18,18 @@
       - proxmox_admin_password is defined
     fail_msg: "Missing required Proxmox API token or password variables. Check group_vars/proxmox.yaml"
 
+- name: "Disable KSM memory deduplication"
+  ansible.builtin.systemd:
+    name: ksmtuned
+    state: stopped
+    enabled: false
+  failed_when: false
+
+- name: "Disable KSM page scanning"
+  ansible.builtin.shell:
+    cmd: echo 0 > /sys/kernel/mm/ksm/run
+  changed_when: false
+
 - name: "Configure network interfaces"
   ansible.builtin.import_tasks: network.yaml
   when: proxmox_manage_network | default(false)

--- a/kubernetes/restic/cronjob-nfs.yaml.j2
+++ b/kubernetes/restic/cronjob-nfs.yaml.j2
@@ -23,6 +23,14 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: resticprofile
+                    operator: Exists
+                topologyKey: kubernetes.io/hostname
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-b2-check.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-b2-check.yaml
@@ -23,6 +23,14 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: resticprofile
+                    operator: Exists
+                topologyKey: kubernetes.io/hostname
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-b2-forget.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-b2-forget.yaml
@@ -23,6 +23,14 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: resticprofile
+                    operator: Exists
+                topologyKey: kubernetes.io/hostname
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-b2.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-b2.yaml
@@ -23,6 +23,14 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: resticprofile
+                    operator: Exists
+                topologyKey: kubernetes.io/hostname
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-flux-check.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-flux-check.yaml
@@ -23,6 +23,14 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: resticprofile
+                    operator: Exists
+                topologyKey: kubernetes.io/hostname
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-flux-forget.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-flux-forget.yaml
@@ -23,6 +23,14 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: resticprofile
+                    operator: Exists
+                topologyKey: kubernetes.io/hostname
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-main-check.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-main-check.yaml
@@ -23,6 +23,14 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: resticprofile
+                    operator: Exists
+                topologyKey: kubernetes.io/hostname
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-main-copy.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-main-copy.yaml
@@ -23,6 +23,14 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: resticprofile
+                    operator: Exists
+                topologyKey: kubernetes.io/hostname
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-main-forget.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-main-forget.yaml
@@ -23,6 +23,14 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: resticprofile
+                    operator: Exists
+                topologyKey: kubernetes.io/hostname
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-xtal-b2-check.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-xtal-b2-check.yaml
@@ -23,6 +23,14 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: resticprofile
+                    operator: Exists
+                topologyKey: kubernetes.io/hostname
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-xtal-b2-forget.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-xtal-b2-forget.yaml
@@ -23,6 +23,14 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: resticprofile
+                    operator: Exists
+                topologyKey: kubernetes.io/hostname
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-xtal-check.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-xtal-check.yaml
@@ -23,6 +23,14 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: resticprofile
+                    operator: Exists
+                topologyKey: kubernetes.io/hostname
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-xtal-copy.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-xtal-copy.yaml
@@ -23,6 +23,14 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: resticprofile
+                    operator: Exists
+                topologyKey: kubernetes.io/hostname
           containers:
           - name: resticprofile
             command:

--- a/kubernetes/restic/cronjobs/cronjob-xtal-forget.yaml
+++ b/kubernetes/restic/cronjobs/cronjob-xtal-forget.yaml
@@ -23,6 +23,14 @@ spec:
         spec:
           hostname: rp-kube
           restartPolicy: OnFailure
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: resticprofile
+                    operator: Exists
+                topologyKey: kubernetes.io/hostname
           containers:
           - name: resticprofile
             command:


### PR DESCRIPTION
- Disable KSM (ksmtuned) on all Proxmox hosts. KSM was consuming 6-7%
  CPU on p3/p4 for minimal benefit on single-VM hosts with free RAM.
- Add required pod anti-affinity to all resticprofile cronjobs so no two
  backup pods run on the same node. Prevents CPU spike compounding when
  overlapping jobs co-locate (e.g., b2-forget + xtal-b2-forget on k4
  pushing host CPU to 80%+ and steal to 9%+).
