### PR TITLE
Add daily frank pod restart via descheduler PodLifeTime

### DIFF
--- a/kubernetes/descheduler/helm/templates/configmap.yaml
+++ b/kubernetes/descheduler/helm/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
     apiVersion: "descheduler/v1alpha2"
     kind: "DeschedulerPolicy"
     evictLocalStoragePods: true
-    maxNoOfPodsToEvictPerNode: 2
+    maxNoOfPodsToEvictPerNamespace: 1
     profiles:
     - name: default
       pluginConfig:
@@ -40,3 +40,20 @@ data:
           enabled:
           - PodLifeTime
           - RemovePodsHavingTooManyRestarts
+    - name: frank-daily-restart
+      pluginConfig:
+      - args:
+          evictLocalStoragePods: true
+          namespaces:
+            include:
+            - frank
+        name: DefaultEvictor
+      - args:
+          maxPodLifeTimeSeconds: 86400
+          states:
+          - Running
+        name: PodLifeTime
+      plugins:
+        deschedule:
+          enabled:
+          - PodLifeTime

--- a/kubernetes/descheduler/helm/templates/cronjob.yaml
+++ b/kubernetes/descheduler/helm/templates/cronjob.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/version: "0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
-  schedule: "17 7 * * *"
+  schedule: "0 9 * * *"
   concurrencyPolicy: "Forbid"
   jobTemplate:
     spec:
@@ -19,7 +19,7 @@ spec:
         metadata:
           name: descheduler
           annotations:
-            checksum/config: ecdd1e55cbcb53ea8105a820f039d35375891832aa64aeefb25231867aec2494
+            checksum/config: 71233b66231600d89a7770bad865a8e753de3b456441e96fb95dab0216ddafa1
           labels:
             app.kubernetes.io/name: descheduler
             app.kubernetes.io/instance: descheduler

--- a/kubernetes/descheduler/values.yaml
+++ b/kubernetes/descheduler/values.yaml
@@ -1,9 +1,8 @@
 ---
-schedule: 17 7 * * *
-deschedulerPolicyAPIVersion: descheduler/v1alpha2
+schedule: 0 9 * * *  # 09:00 UTC = 4:00 AM EST / 5:00 AM EDT
 
 deschedulerPolicy:
-  maxNoOfPodsToEvictPerNode: 2
+  maxNoOfPodsToEvictPerNamespace: 1
   evictLocalStoragePods: true
   profiles:
   - name: default
@@ -17,28 +16,32 @@ deschedulerPolicy:
             operator: DoesNotExist
     - name: PodLifeTime
       args:
-        maxPodLifeTimeSeconds: 1209600
+        maxPodLifeTimeSeconds: 1209600  # 14 days
         states:
         - Running
-        # - name: LowNodeUtilization
-        #   args:
-        #     thresholds:
-        #       cpu: 20
-        #       memory: 20
-        #       pods: 20
-        #     targetThresholds:
-        #       cpu: 50
-        #       memory: 50
-        #       pods: 50
     - name: RemovePodsHavingTooManyRestarts
       args:
         podRestartThreshold: 10
         includingInitContainers: true
     plugins:
-        # balance:
-        #   enabled:
-        #     - LowNodeUtilization
       deschedule:
         enabled:
         - PodLifeTime
         - RemovePodsHavingTooManyRestarts
+  - name: frank-daily-restart
+    pluginConfig:
+    - name: DefaultEvictor
+      args:
+        evictLocalStoragePods: true
+        namespaces:
+          include:
+          - frank
+    - name: PodLifeTime
+      args:
+        maxPodLifeTimeSeconds: 86400  # 24 hours
+        states:
+        - Running
+    plugins:
+      deschedule:
+        enabled:
+        - PodLifeTime


### PR DESCRIPTION
The frank (OpenClaw) headless Chrome sidecar can get stuck on
Cloudflare challenge pages, burning ~60% CPU indefinitely.

- Add frank-daily-restart profile with 24h PodLifeTime
- Change schedule to 09:00 UTC (4am EST)
- Replace maxNoOfPodsToEvictPerNode with maxNoOfPodsToEvictPerNamespace
- Remove redundant deschedulerPolicyAPIVersion (chart default)
