### PR TITLE
Sync semaphore nix-flake.lock when updating root flake.lock

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -51,6 +51,16 @@ jobs:
           nix
           automerge
 
+    - name: Sync flake.lock to semaphore
+      if: steps.update-flake-lock.outputs.pull-request-number != ''
+      run: |
+        cp flake.lock kubernetes/semaphore/nix-flake.lock
+        git add kubernetes/semaphore/nix-flake.lock
+        if ! git diff --cached --quiet; then
+          git commit --amend --no-edit
+          git push --force-with-lease
+        fi
+
     - name: Enable automerge
       if: steps.update-flake-lock.outputs.pull-request-number != ''
       run: gh pr merge --auto --rebase "${{ steps.update-flake-lock.outputs.pull-request-number }}"

--- a/kubernetes/semaphore/nix-flake.lock
+++ b/kubernetes/semaphore/nix-flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1770156057,
-        "narHash": "sha256-YgyI188AjhSTV+3q4yyw26c/Pd3k+rz+OfDvQlA1w2Y=",
+        "lastModified": 1770753000,
+        "narHash": "sha256-Won84PmYKUU4ZdwsMTJ6ZQjyyecMA34lk1JwqzrA5m4=",
         "owner": "claytono",
         "repo": "go-unifi-mcp",
-        "rev": "c569645235a425a3a8618643d1a0fa0ce1b46fc5",
+        "rev": "789c5db7673da88bc2df5a0d12e0e5bd15f1e513",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1770562336,
-        "narHash": "sha256-ub1gpAONMFsT/GU2hV6ZWJjur8rJ6kKxdm9IlCT0j84=",
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d6c71932130818840fc8fe9509cf50be8c64634f",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The update-flake-lock workflow updates the root flake.lock but never
copies it to kubernetes/semaphore/nix-flake.lock, causing them to
drift out of sync.
