### PR TITLE
Fix descheduler frank-daily-restart namespace filter

### DIFF
--- a/kubernetes/descheduler/helm/templates/configmap.yaml
+++ b/kubernetes/descheduler/helm/templates/configmap.yaml
@@ -44,12 +44,12 @@ data:
       pluginConfig:
       - args:
           evictLocalStoragePods: true
-          namespaces:
-            include:
-            - frank
         name: DefaultEvictor
       - args:
           maxPodLifeTimeSeconds: 86400
+          namespaces:
+            include:
+            - frank
           states:
           - Running
         name: PodLifeTime

--- a/kubernetes/descheduler/helm/templates/cronjob.yaml
+++ b/kubernetes/descheduler/helm/templates/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
         metadata:
           name: descheduler
           annotations:
-            checksum/config: 71233b66231600d89a7770bad865a8e753de3b456441e96fb95dab0216ddafa1
+            checksum/config: 6958dc9d3b881ec2f90d2d19a251962b87bbb9b19a3f22fd5768cd04cda28291
           labels:
             app.kubernetes.io/name: descheduler
             app.kubernetes.io/instance: descheduler

--- a/kubernetes/descheduler/values.yaml
+++ b/kubernetes/descheduler/values.yaml
@@ -33,11 +33,11 @@ deschedulerPolicy:
     - name: DefaultEvictor
       args:
         evictLocalStoragePods: true
+    - name: PodLifeTime
+      args:
         namespaces:
           include:
           - frank
-    - name: PodLifeTime
-      args:
         maxPodLifeTimeSeconds: 86400  # 24 hours
         states:
         - Running


### PR DESCRIPTION
Move namespaces filter from DefaultEvictor (not supported in
v1alpha2) to PodLifeTime plugin args where it belongs.