### PR TITLE
Use proper TLS verification for netdata backend

### DIFF
--- a/kubernetes/netdata/patch-service-traefik.yaml
+++ b/kubernetes/netdata/patch-service-traefik.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: netdata
   annotations:
     traefik.ingress.kubernetes.io/service.serversscheme: https
-    traefik.ingress.kubernetes.io/service.serverstransport: netdata-netdata-insecure@kubernetescrd
+    traefik.ingress.kubernetes.io/service.serverstransport: netdata-netdata-tls@kubernetescrd

--- a/kubernetes/netdata/serverstransport.yaml
+++ b/kubernetes/netdata/serverstransport.yaml
@@ -3,8 +3,8 @@ apiVersion: traefik.io/v1alpha1
 kind: ServersTransport
 
 metadata:
-  name: netdata-insecure
+  name: netdata-tls
   namespace: netdata
 
 spec:
-  insecureSkipVerify: true
+  serverName: netdata-stream.k.oneill.net


### PR DESCRIPTION
Replace insecureSkipVerify with serverName on the ServersTransport,
so Traefik validates the ZeroSSL cert against the streaming hostname
instead of skipping verification entirely.
