### PR TITLE
Upgrade k8s 1.33.5→1.33.8, resize worker disks to 150G

### DIFF
--- a/ansible/group_vars/kubernetes.yaml
+++ b/ansible/group_vars/kubernetes.yaml
@@ -26,10 +26,10 @@ containerd_config: |
 
 # Our goal is to stay one version behind
 kubernetes_short_version: "1.33"
-kubernetes_version: "1.33.5"
-kubeadm_version: "1.33.5-1.1"
-kubelet_version: "1.33.5-1.1"
-kubectl_version: "1.33.5-1.1"
+kubernetes_version: "1.33.8"
+kubeadm_version: "1.33.8-1.1"
+kubelet_version: "1.33.8-1.1"
+kubectl_version: "1.33.8-1.1"
 cri_tools_version: "1.33.0-1.1"
 kubernetes_cni_version: "1.6.0-1.1"
 

--- a/opentofu/proxmox.tf
+++ b/opentofu/proxmox.tf
@@ -135,7 +135,7 @@ resource "proxmox_virtual_environment_vm" "k2" {
   disk {
     interface    = "scsi0"
     datastore_id = "local-zfs"
-    size         = 100
+    size         = 150
     file_format  = "raw"
     iothread     = true
     discard      = "on"
@@ -193,7 +193,7 @@ resource "proxmox_virtual_environment_vm" "k3" {
   disk {
     interface    = "scsi0"
     datastore_id = "local-zfs"
-    size         = 100
+    size         = 150
     file_format  = "raw"
     iothread     = true
     discard      = "on"
@@ -244,7 +244,7 @@ resource "proxmox_virtual_environment_vm" "k4" {
   disk {
     interface    = "scsi0"
     datastore_id = "local-zfs"
-    size         = 100
+    size         = 150
     file_format  = "raw"
     iothread     = true
     discard      = "on"


### PR DESCRIPTION
- Bump kubernetes, kubeadm, kubelet, kubectl to 1.33.8
- Increase k2, k3, k4 root disks from 100G to 150G to prevent
  disk pressure from container image accumulation
