### PR TITLE
Remove stale office lights group and fix MCP config path

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -62,7 +62,7 @@ if [[ -f .secrets.age ]]; then
 fi
 
 # MCP CLI config (used by: mcp-cli for hass-mcp)
-export MCP_CONFIG_PATH=".mcp_servers.json"
+export MCP_CONFIG_PATH="${PWD}/.mcp_servers.json"
 
 # Loki (used by: logcli)
 export LOKI_ADDR=https://loki.k.oneill.net

--- a/kubernetes/hass/config/configuration.yaml
+++ b/kubernetes/hass/config/configuration.yaml
@@ -84,7 +84,6 @@ homekit:
     - light.garage_overhead_lights_8
     - light.office_floor_lamp_19
     - light.office_light_76
-    - light.office_sink_light
     - lock.front_door_lock
     - lock.garage_door_lock
     - sensor.garage_humidity
@@ -161,21 +160,6 @@ generic_hygrostat:
   wet_tolerance: 0
   min_cycle_duration:
     minutes: 20
-
-light:
-- platform: switch
-  name: Office Sink Light
-  entity_id: switch.office_sink
-- platform: switch
-  name: Office Closet Light
-  entity_id: switch.office_closet_relay
-- platform: group
-  name: Office lights
-  entities:
-  - light.office_floor_lamp
-  - light.basement_office_main_lights
-  - light.office_sink_light
-  - light.office_closet_light
 
 template:
 


### PR DESCRIPTION
- Remove broken light-switch wrappers and light group for office
  lights (switch.office_sink was dead, switch.office_closet_relay
  didn't exist). Motion automations now target individual entities
  directly via homeassistant.turn_on/turn_off.
- Remove stale light.office_sink_light from HomeKit entity filter
- Fix MCP_CONFIG_PATH to use absolute path so mcp-cli works from
  any directory
