### PR TITLE
Upgrade alertmanager to v0.31.0, eliminate gomplate init container

### DIFF
--- a/kubernetes/alertmanager/config.yaml
+++ b/kubernetes/alertmanager/config.yaml
@@ -3,11 +3,11 @@ global:
   # SMTP relay for mail notifications
   smtp_smarthost: smtp.k.oneill.net:587
   smtp_from: alertmanager@oneill.net
-  smtp_auth_username: '{{ .Env.SMTP_USERNAME }}'
-  smtp_auth_password: '{{ .Env.SMTP_PASSWORD }}'
+  smtp_auth_username: relay@oneill.net
+  smtp_auth_password_file: /secrets/SMTP_PASSWORD
   smtp_require_tls: true
 
-# # The directory from which notification templates are read.
+#  # The directory from which notification templates are read.
 templates:
 - /etc/alertmanager-templates/*.tmpl
 
@@ -39,6 +39,3 @@ receivers:
   email_configs:
   - to: clayton.oneill@gmail.com
     send_resolved: true
-  webhook_configs:
-    # admin view: https://webhook.site/#/49de981e-b39b-48b0-a889-d053cd0a025d
-  - url: https://webhook.site/49de981e-b39b-48b0-a889-d053cd0a025d

--- a/kubernetes/alertmanager/deploy.yaml
+++ b/kubernetes/alertmanager/deploy.yaml
@@ -20,33 +20,9 @@ spec:
         app.kubernetes.io/name: alertmanager
         app.kubernetes.io/instance: alertmanager
     spec:
-      initContainers:
-      - name: gomplate-config
-        image: hairyhenderson/gomplate:v4.3.3@sha256:55db623a1e3d620501fbf3ff01753cfde101d9b49fa5ff0132b4a8d0c246c16c
-        args:
-        - --file
-        - /etc/alertmanager/config.template.yaml
-        - --out
-        - /config/config.yaml
-        env:
-        - name: SMTP_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: alertmanager
-              key: SMTP_USERNAME
-        - name: SMTP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: alertmanager
-              key: SMTP_PASSWORD
-        volumeMounts:
-        - name: config-template
-          mountPath: /etc/alertmanager
-        - name: alertmanager-config
-          mountPath: /config
       containers:
       - name: alertmanager
-        image: prom/alertmanager:v0.30.1@sha256:286ad8838533a5a01d89bd09643f43d2b68b65203123b5700e54a8f80ff9c1f4
+        image: prom/alertmanager:v0.31.0@sha256:cc54cc450174ada901b32eb2538de5fc70ee259a1ac551ed38023f2ca2ad00e3
         args:
         - --config.file=/config/config.yaml
         - --storage.path=/alertmanager
@@ -55,21 +31,25 @@ spec:
         - name: alertmanager
           containerPort: 9093
         volumeMounts:
+        - name: config
+          mountPath: /config
+        - name: secrets
+          mountPath: /secrets
+          readOnly: true
         - name: templates
           mountPath: /etc/alertmanager-templates
-        - name: alertmanager-config
-          mountPath: /config
         - name: alertmanager-data
           mountPath: /alertmanager
       volumes:
-      - name: config-template
+      - name: config
         configMap:
           name: alertmanager
+      - name: secrets
+        secret:
+          secretName: alertmanager
       - name: templates
         configMap:
           name: alertmanager-templates
-      - name: alertmanager-config
-        emptyDir: {}
       - name: alertmanager-data
         persistentVolumeClaim:
           claimName: alertmanager-data

--- a/kubernetes/alertmanager/externalsecret.yaml
+++ b/kubernetes/alertmanager/externalsecret.yaml
@@ -10,10 +10,6 @@ spec:
     name: production
     kind: ClusterSecretStore
   data:
-  - secretKey: SMTP_USERNAME
-    remoteRef:
-      key: smtp-relay
-      property: relay-username
   - secretKey: SMTP_PASSWORD
     remoteRef:
       key: smtp-relay

--- a/kubernetes/alertmanager/kustomization.yaml
+++ b/kubernetes/alertmanager/kustomization.yaml
@@ -24,10 +24,13 @@ labels:
     app.kubernetes.io/instance: alertmanager
   includeSelectors: true
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
 - name: alertmanager
   files:
-  - config.template.yaml
+  - config.yaml
 - name: alertmanager-templates
   files:
   - templates/default.tmpl


### PR DESCRIPTION
- Use native smtp_auth_password_file to read SMTP password from
  mounted Secret instead of templating it into config via gomplate
- Hardcode SMTP username, simplify ExternalSecret to password only
- Remove webhook.site debugging endpoint
- Disable ConfigMap suffix hashing, rely on Reloader for rollouts
