### PR TITLE
Upgrade ArgoCD to v3.3.0, enable SSA for self-sync

### DIFF
--- a/kubernetes/argocd/Chart.yaml
+++ b/kubernetes/argocd/Chart.yaml
@@ -4,5 +4,5 @@ name: argocd-meta
 version: 0.1.0
 dependencies:
 - name: argo-cd
-  version: 9.3.7
+  version: 9.4.0
   repository: https://argoproj.github.io/argo-helm

--- a/kubernetes/argocd/appset.yaml
+++ b/kubernetes/argocd/appset.yaml
@@ -38,5 +38,5 @@ spec:
       syncPolicy:
         syncOptions:
         - CreateNamespace=true
-        - ServerSideApply={{ if or (eq (index .path.segments 1) "external-secrets") (eq (index .path.segments 1) "cloudnative-pg") }}true{{
+        - ServerSideApply={{ if or (eq (index .path.segments 1) "external-secrets") (eq (index .path.segments 1) "cloudnative-pg") (eq (index .path.segments 1) "argocd") }}true{{
           else }}false{{ end }}

--- a/kubernetes/argocd/helm/templates/argocd-application-controller/clusterrole.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-application-controller/clusterrole.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 rules:
   - apiGroups:
     - '*'

--- a/kubernetes/argocd/helm/templates/argocd-application-controller/clusterrolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-application-controller/clusterrolebinding.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/kubernetes/argocd/helm/templates/argocd-application-controller/role.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-application-controller/role.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 rules:
 - apiGroups:
   - ""

--- a/kubernetes/argocd/helm/templates/argocd-application-controller/rolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-application-controller/rolebinding.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/kubernetes/argocd/helm/templates/argocd-application-controller/serviceaccount.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-application-controller/serviceaccount.yaml
@@ -12,4 +12,4 @@ metadata:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"

--- a/kubernetes/argocd/helm/templates/argocd-application-controller/statefulset.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-application-controller/statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 5
@@ -29,7 +29,7 @@ spec:
         app.kubernetes.io/component: application-controller
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: "v3.2.6"
+        app.kubernetes.io/version: "v3.3.0"
     spec:
       terminationGracePeriodSeconds: 30
       serviceAccountName: argocd-application-controller
@@ -38,7 +38,7 @@ spec:
       - args:
         - /usr/local/bin/argocd-application-controller
         - --metrics-port=8082
-        image: quay.io/argoproj/argocd:v3.2.6
+        image: quay.io/argoproj/argocd:v3.3.0
         imagePullPolicy: IfNotPresent
         name: application-controller
         env:

--- a/kubernetes/argocd/helm/templates/argocd-applicationset/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-applicationset/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: applicationset-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -28,14 +28,14 @@ spec:
         app.kubernetes.io/component: applicationset-controller
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: "v3.2.6"
+        app.kubernetes.io/version: "v3.3.0"
     spec:
       terminationGracePeriodSeconds: 30
       serviceAccountName: argocd-applicationset-controller
       automountServiceAccountToken: true
       containers:
         - name: applicationset-controller
-          image: quay.io/argoproj/argocd:v3.2.6
+          image: quay.io/argoproj/argocd:v3.3.0
           imagePullPolicy: IfNotPresent
           args:
             - /usr/local/bin/argocd-applicationset-controller

--- a/kubernetes/argocd/helm/templates/argocd-applicationset/role.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-applicationset/role.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: applicationset-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 rules:
   - apiGroups:
     - argoproj.io

--- a/kubernetes/argocd/helm/templates/argocd-applicationset/rolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-applicationset/rolebinding.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: applicationset-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/kubernetes/argocd/helm/templates/argocd-applicationset/service.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-applicationset/service.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: applicationset-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 spec:
   type: ClusterIP  
   ports:

--- a/kubernetes/argocd/helm/templates/argocd-applicationset/serviceaccount.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-applicationset/serviceaccount.yaml
@@ -12,4 +12,4 @@ metadata:
     app.kubernetes.io/component: applicationset-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-cm.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 data:
   accounts.github-actions: apiKey
   admin.enabled: "true"

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-cmd-params-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-cmd-params-cm.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 data:
   applicationsetcontroller.enable.leader.election: "false"
   applicationsetcontroller.log.format: text

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-gpg-keys-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-gpg-keys-cm.yaml
@@ -10,4 +10,4 @@ metadata:
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-notifications-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-notifications-cm.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 data:
   context: |
     argocdUrl: https://argocd.example.com

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-notifications-secret.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-notifications-secret.yaml
@@ -11,6 +11,6 @@ metadata:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 type: Opaque
 stringData:

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-rbac-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-rbac-cm.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 data:
   policy.csv: |
     # Allow GitHub Actions to read application status

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-secret.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-secret.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 type: Opaque

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-ssh-known-hosts-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-ssh-known-hosts-cm.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 data:
   ssh_known_hosts: |
     [ssh.github.com]:443 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=

--- a/kubernetes/argocd/helm/templates/argocd-configs/argocd-tls-certs-cm.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-configs/argocd-tls-certs-cm.yaml
@@ -10,4 +10,4 @@ metadata:
     app.kubernetes.io/instance: argocd
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"

--- a/kubernetes/argocd/helm/templates/argocd-notifications/clusterrole.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-notifications/clusterrole.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 rules:
   - apiGroups:
     - argoproj.io

--- a/kubernetes/argocd/helm/templates/argocd-notifications/clusterrolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-notifications/clusterrolebinding.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/kubernetes/argocd/helm/templates/argocd-notifications/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-notifications/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -30,14 +30,14 @@ spec:
         app.kubernetes.io/component: notifications-controller
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: "v3.2.6"
+        app.kubernetes.io/version: "v3.3.0"
     spec:
       terminationGracePeriodSeconds: 30
       serviceAccountName: argocd-notifications-controller
       automountServiceAccountToken: true
       containers:
         - name: notifications-controller
-          image: quay.io/argoproj/argocd:v3.2.6
+          image: quay.io/argoproj/argocd:v3.3.0
           imagePullPolicy: IfNotPresent
           args:
             - /usr/local/bin/argocd-notifications

--- a/kubernetes/argocd/helm/templates/argocd-notifications/role.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-notifications/role.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 rules:
 - apiGroups:
   - argoproj.io

--- a/kubernetes/argocd/helm/templates/argocd-notifications/rolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-notifications/rolebinding.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/kubernetes/argocd/helm/templates/argocd-notifications/serviceaccount.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-notifications/serviceaccount.yaml
@@ -12,4 +12,4 @@ metadata:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"

--- a/kubernetes/argocd/helm/templates/argocd-repo-server/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-repo-server/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -28,14 +28,14 @@ spec:
         app.kubernetes.io/component: repo-server
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: "v3.2.6"
+        app.kubernetes.io/version: "v3.3.0"
     spec:
       terminationGracePeriodSeconds: 30
       serviceAccountName: argocd-repo-server
       automountServiceAccountToken: true
       containers:
       - name: repo-server
-        image: quay.io/argoproj/argocd:v3.2.6
+        image: quay.io/argoproj/argocd:v3.3.0
         imagePullPolicy: IfNotPresent
         args:
         - /usr/local/bin/argocd-repo-server
@@ -357,11 +357,11 @@ spec:
             type: RuntimeDefault
       initContainers:
       - command:
-        - /bin/cp
-        - --update=none
-        - /usr/local/bin/argocd
-        - /var/run/argocd/argocd-cmp-server
-        image: quay.io/argoproj/argocd:v3.2.6
+        - sh
+        - '-c'
+        args:
+        - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -s /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+        image: quay.io/argoproj/argocd:v3.3.0
         imagePullPolicy: IfNotPresent
         name: copyutil
         resources:

--- a/kubernetes/argocd/helm/templates/argocd-repo-server/role.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-repo-server/role.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 rules:

--- a/kubernetes/argocd/helm/templates/argocd-repo-server/rolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-repo-server/rolebinding.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/kubernetes/argocd/helm/templates/argocd-repo-server/service.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-repo-server/service.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
   name: argocd-repo-server
   namespace: argocd
 spec:  

--- a/kubernetes/argocd/helm/templates/argocd-repo-server/serviceaccount.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-repo-server/serviceaccount.yaml
@@ -12,4 +12,4 @@ metadata:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"

--- a/kubernetes/argocd/helm/templates/argocd-server/clusterrole.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/clusterrole.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 rules:
   - apiGroups:
       - '*'

--- a/kubernetes/argocd/helm/templates/argocd-server/clusterrolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/clusterrolebinding.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/kubernetes/argocd/helm/templates/argocd-server/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -28,14 +28,14 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: "v3.2.6"
+        app.kubernetes.io/version: "v3.3.0"
     spec:
       terminationGracePeriodSeconds: 30
       serviceAccountName: argocd-server
       automountServiceAccountToken: true
       containers:
       - name: server
-        image: quay.io/argoproj/argocd:v3.2.6
+        image: quay.io/argoproj/argocd:v3.3.0
         imagePullPolicy: IfNotPresent
         args:
         - /usr/local/bin/argocd-server

--- a/kubernetes/argocd/helm/templates/argocd-server/ingress.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
   annotations:
     ak-oidc-callback: "/api/dex/callback"
     ak-type: "oidc"

--- a/kubernetes/argocd/helm/templates/argocd-server/role.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/role.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 rules:
 - apiGroups:
   - ""

--- a/kubernetes/argocd/helm/templates/argocd-server/rolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/rolebinding.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/kubernetes/argocd/helm/templates/argocd-server/service.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/service.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 spec:
   type: ClusterIP  
   sessionAffinity: None

--- a/kubernetes/argocd/helm/templates/argocd-server/serviceaccount.yaml
+++ b/kubernetes/argocd/helm/templates/argocd-server/serviceaccount.yaml
@@ -12,4 +12,4 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"

--- a/kubernetes/argocd/helm/templates/crds/crd-application.yaml
+++ b/kubernetes/argocd/helm/templates/crds/crd-application.yaml
@@ -1446,10 +1446,357 @@ spec:
                     description: DrySource specifies where the dry "don't repeat yourself"
                       manifest source lives.
                     properties:
+                      directory:
+                        description: Directory specifies path/directory specific options
+                        properties:
+                          exclude:
+                            description: Exclude contains a glob pattern to match
+                              paths against that should be explicitly excluded from
+                              being used during manifest generation
+                            type: string
+                          include:
+                            description: Include contains a glob pattern to match
+                              paths against that should be explicitly included during
+                              manifest generation
+                            type: string
+                          jsonnet:
+                            description: Jsonnet holds options specific to Jsonnet
+                            properties:
+                              extVars:
+                                description: ExtVars is a list of Jsonnet External
+                                  Variables
+                                items:
+                                  description: JsonnetVar represents a variable to
+                                    be passed to jsonnet during manifest generation
+                                  properties:
+                                    code:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              libs:
+                                description: Additional library search dirs
+                                items:
+                                  type: string
+                                type: array
+                              tlas:
+                                description: TLAS is a list of Jsonnet Top-level Arguments
+                                items:
+                                  description: JsonnetVar represents a variable to
+                                    be passed to jsonnet during manifest generation
+                                  properties:
+                                    code:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          recurse:
+                            description: Recurse specifies whether to scan a directory
+                              recursively for manifests
+                            type: boolean
+                        type: object
+                      helm:
+                        description: Helm specifies helm specific options
+                        properties:
+                          apiVersions:
+                            description: |-
+                              APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                              Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                            items:
+                              type: string
+                            type: array
+                          fileParameters:
+                            description: FileParameters are file parameters to the
+                              helm template
+                            items:
+                              description: HelmFileParameter is a file parameter that's
+                                passed to helm template during manifest generation
+                              properties:
+                                name:
+                                  description: Name is the name of the Helm parameter
+                                  type: string
+                                path:
+                                  description: Path is the path to the file containing
+                                    the values for the Helm parameter
+                                  type: string
+                              type: object
+                            type: array
+                          ignoreMissingValueFiles:
+                            description: IgnoreMissingValueFiles prevents helm template
+                              from failing when valueFiles do not exist locally by
+                              not appending them to helm template --values
+                            type: boolean
+                          kubeVersion:
+                            description: |-
+                              KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                              uses the Kubernetes version of the target cluster.
+                            type: string
+                          namespace:
+                            description: Namespace is an optional namespace to template
+                              with. If left empty, defaults to the app's destination
+                              namespace.
+                            type: string
+                          parameters:
+                            description: Parameters is a list of Helm parameters which
+                              are passed to the helm template command upon manifest
+                              generation
+                            items:
+                              description: HelmParameter is a parameter that's passed
+                                to helm template during manifest generation
+                              properties:
+                                forceString:
+                                  description: ForceString determines whether to tell
+                                    Helm to interpret booleans and numbers as strings
+                                  type: boolean
+                                name:
+                                  description: Name is the name of the Helm parameter
+                                  type: string
+                                value:
+                                  description: Value is the value for the Helm parameter
+                                  type: string
+                              type: object
+                            type: array
+                          passCredentials:
+                            description: PassCredentials pass credentials to all domains
+                              (Helm's --pass-credentials)
+                            type: boolean
+                          releaseName:
+                            description: ReleaseName is the Helm release name to use.
+                              If omitted it will use the application name
+                            type: string
+                          skipCrds:
+                            description: SkipCrds skips custom resource definition
+                              installation step (Helm's --skip-crds)
+                            type: boolean
+                          skipSchemaValidation:
+                            description: SkipSchemaValidation skips JSON schema validation
+                              (Helm's --skip-schema-validation)
+                            type: boolean
+                          skipTests:
+                            description: SkipTests skips test manifest installation
+                              step (Helm's --skip-tests).
+                            type: boolean
+                          valueFiles:
+                            description: ValuesFiles is a list of Helm value files
+                              to use when generating a template
+                            items:
+                              type: string
+                            type: array
+                          values:
+                            description: Values specifies Helm values to be passed
+                              to helm template, typically defined as a block. ValuesObject
+                              takes precedence over Values, so use one or the other.
+                            type: string
+                          valuesObject:
+                            description: ValuesObject specifies Helm values to be
+                              passed to helm template, defined as a map. This takes
+                              precedence over Values.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          version:
+                            description: Version is the Helm version to use for templating
+                              ("3")
+                            type: string
+                        type: object
+                      kustomize:
+                        description: Kustomize specifies kustomize specific options
+                        properties:
+                          apiVersions:
+                            description: |-
+                              APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                              Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                            items:
+                              type: string
+                            type: array
+                          commonAnnotations:
+                            additionalProperties:
+                              type: string
+                            description: CommonAnnotations is a list of additional
+                              annotations to add to rendered manifests
+                            type: object
+                          commonAnnotationsEnvsubst:
+                            description: CommonAnnotationsEnvsubst specifies whether
+                              to apply env variables substitution for annotation values
+                            type: boolean
+                          commonLabels:
+                            additionalProperties:
+                              type: string
+                            description: CommonLabels is a list of additional labels
+                              to add to rendered manifests
+                            type: object
+                          components:
+                            description: Components specifies a list of kustomize
+                              components to add to the kustomization before building
+                            items:
+                              type: string
+                            type: array
+                          forceCommonAnnotations:
+                            description: ForceCommonAnnotations specifies whether
+                              to force applying common annotations to resources for
+                              Kustomize apps
+                            type: boolean
+                          forceCommonLabels:
+                            description: ForceCommonLabels specifies whether to force
+                              applying common labels to resources for Kustomize apps
+                            type: boolean
+                          ignoreMissingComponents:
+                            description: IgnoreMissingComponents prevents kustomize
+                              from failing when components do not exist locally by
+                              not appending them to kustomization file
+                            type: boolean
+                          images:
+                            description: Images is a list of Kustomize image override
+                              specifications
+                            items:
+                              description: KustomizeImage represents a Kustomize image
+                                definition in the format [old_image_name=]<image_name>:<image_tag>
+                              type: string
+                            type: array
+                          kubeVersion:
+                            description: |-
+                              KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                              uses the Kubernetes version of the target cluster.
+                            type: string
+                          labelIncludeTemplates:
+                            description: LabelIncludeTemplates specifies whether to
+                              apply common labels to resource templates or not
+                            type: boolean
+                          labelWithoutSelector:
+                            description: LabelWithoutSelector specifies whether to
+                              apply common labels to resource selectors or not
+                            type: boolean
+                          namePrefix:
+                            description: NamePrefix is a prefix appended to resources
+                              for Kustomize apps
+                            type: string
+                          nameSuffix:
+                            description: NameSuffix is a suffix appended to resources
+                              for Kustomize apps
+                            type: string
+                          namespace:
+                            description: Namespace sets the namespace that Kustomize
+                              adds to all resources
+                            type: string
+                          patches:
+                            description: Patches is a list of Kustomize patches
+                            items:
+                              properties:
+                                options:
+                                  additionalProperties:
+                                    type: boolean
+                                  type: object
+                                patch:
+                                  type: string
+                                path:
+                                  type: string
+                                target:
+                                  properties:
+                                    annotationSelector:
+                                      type: string
+                                    group:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    labelSelector:
+                                      type: string
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    version:
+                                      type: string
+                                  type: object
+                              type: object
+                            type: array
+                          replicas:
+                            description: Replicas is a list of Kustomize Replicas
+                              override specifications
+                            items:
+                              properties:
+                                count:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number of replicas
+                                  x-kubernetes-int-or-string: true
+                                name:
+                                  description: Name of Deployment or StatefulSet
+                                  type: string
+                              required:
+                              - count
+                              - name
+                              type: object
+                            type: array
+                          version:
+                            description: Version controls which version of Kustomize
+                              to use for rendering manifests
+                            type: string
+                        type: object
                       path:
                         description: Path is a directory path within the Git repository
                           where the manifests are located
                         type: string
+                      plugin:
+                        description: Plugin specifies config management plugin specific
+                          options
+                        properties:
+                          env:
+                            description: Env is a list of environment variable entries
+                            items:
+                              description: EnvEntry represents an entry in the application's
+                                environment
+                              properties:
+                                name:
+                                  description: Name is the name of the variable, usually
+                                    expressed in uppercase
+                                  type: string
+                                value:
+                                  description: Value is the value of the variable
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                          parameters:
+                            items:
+                              properties:
+                                array:
+                                  description: Array is the value of an array type
+                                    parameter.
+                                  items:
+                                    type: string
+                                  type: array
+                                map:
+                                  additionalProperties:
+                                    type: string
+                                  description: Map is the value of a map type parameter.
+                                  type: object
+                                name:
+                                  description: Name is the name identifying a parameter.
+                                  type: string
+                                string:
+                                  description: String_ is the value of a string type
+                                    parameter.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
                       repoURL:
                         description: RepoURL is the URL to the git repository that
                           contains the application manifests
@@ -4862,10 +5209,380 @@ spec:
                             description: DrySource specifies where the dry "don't
                               repeat yourself" manifest source lives.
                             properties:
+                              directory:
+                                description: Directory specifies path/directory specific
+                                  options
+                                properties:
+                                  exclude:
+                                    description: Exclude contains a glob pattern to
+                                      match paths against that should be explicitly
+                                      excluded from being used during manifest generation
+                                    type: string
+                                  include:
+                                    description: Include contains a glob pattern to
+                                      match paths against that should be explicitly
+                                      included during manifest generation
+                                    type: string
+                                  jsonnet:
+                                    description: Jsonnet holds options specific to
+                                      Jsonnet
+                                    properties:
+                                      extVars:
+                                        description: ExtVars is a list of Jsonnet
+                                          External Variables
+                                        items:
+                                          description: JsonnetVar represents a variable
+                                            to be passed to jsonnet during manifest
+                                            generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      libs:
+                                        description: Additional library search dirs
+                                        items:
+                                          type: string
+                                        type: array
+                                      tlas:
+                                        description: TLAS is a list of Jsonnet Top-level
+                                          Arguments
+                                        items:
+                                          description: JsonnetVar represents a variable
+                                            to be passed to jsonnet during manifest
+                                            generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                    type: object
+                                  recurse:
+                                    description: Recurse specifies whether to scan
+                                      a directory recursively for manifests
+                                    type: boolean
+                                type: object
+                              helm:
+                                description: Helm specifies helm specific options
+                                properties:
+                                  apiVersions:
+                                    description: |-
+                                      APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                      Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                    items:
+                                      type: string
+                                    type: array
+                                  fileParameters:
+                                    description: FileParameters are file parameters
+                                      to the helm template
+                                    items:
+                                      description: HelmFileParameter is a file parameter
+                                        that's passed to helm template during manifest
+                                        generation
+                                      properties:
+                                        name:
+                                          description: Name is the name of the Helm
+                                            parameter
+                                          type: string
+                                        path:
+                                          description: Path is the path to the file
+                                            containing the values for the Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  ignoreMissingValueFiles:
+                                    description: IgnoreMissingValueFiles prevents
+                                      helm template from failing when valueFiles do
+                                      not exist locally by not appending them to helm
+                                      template --values
+                                    type: boolean
+                                  kubeVersion:
+                                    description: |-
+                                      KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                      uses the Kubernetes version of the target cluster.
+                                    type: string
+                                  namespace:
+                                    description: Namespace is an optional namespace
+                                      to template with. If left empty, defaults to
+                                      the app's destination namespace.
+                                    type: string
+                                  parameters:
+                                    description: Parameters is a list of Helm parameters
+                                      which are passed to the helm template command
+                                      upon manifest generation
+                                    items:
+                                      description: HelmParameter is a parameter that's
+                                        passed to helm template during manifest generation
+                                      properties:
+                                        forceString:
+                                          description: ForceString determines whether
+                                            to tell Helm to interpret booleans and
+                                            numbers as strings
+                                          type: boolean
+                                        name:
+                                          description: Name is the name of the Helm
+                                            parameter
+                                          type: string
+                                        value:
+                                          description: Value is the value for the
+                                            Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  passCredentials:
+                                    description: PassCredentials pass credentials
+                                      to all domains (Helm's --pass-credentials)
+                                    type: boolean
+                                  releaseName:
+                                    description: ReleaseName is the Helm release name
+                                      to use. If omitted it will use the application
+                                      name
+                                    type: string
+                                  skipCrds:
+                                    description: SkipCrds skips custom resource definition
+                                      installation step (Helm's --skip-crds)
+                                    type: boolean
+                                  skipSchemaValidation:
+                                    description: SkipSchemaValidation skips JSON schema
+                                      validation (Helm's --skip-schema-validation)
+                                    type: boolean
+                                  skipTests:
+                                    description: SkipTests skips test manifest installation
+                                      step (Helm's --skip-tests).
+                                    type: boolean
+                                  valueFiles:
+                                    description: ValuesFiles is a list of Helm value
+                                      files to use when generating a template
+                                    items:
+                                      type: string
+                                    type: array
+                                  values:
+                                    description: Values specifies Helm values to be
+                                      passed to helm template, typically defined as
+                                      a block. ValuesObject takes precedence over
+                                      Values, so use one or the other.
+                                    type: string
+                                  valuesObject:
+                                    description: ValuesObject specifies Helm values
+                                      to be passed to helm template, defined as a
+                                      map. This takes precedence over Values.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  version:
+                                    description: Version is the Helm version to use
+                                      for templating ("3")
+                                    type: string
+                                type: object
+                              kustomize:
+                                description: Kustomize specifies kustomize specific
+                                  options
+                                properties:
+                                  apiVersions:
+                                    description: |-
+                                      APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                      Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                    items:
+                                      type: string
+                                    type: array
+                                  commonAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonAnnotations is a list of additional
+                                      annotations to add to rendered manifests
+                                    type: object
+                                  commonAnnotationsEnvsubst:
+                                    description: CommonAnnotationsEnvsubst specifies
+                                      whether to apply env variables substitution
+                                      for annotation values
+                                    type: boolean
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels is a list of additional
+                                      labels to add to rendered manifests
+                                    type: object
+                                  components:
+                                    description: Components specifies a list of kustomize
+                                      components to add to the kustomization before
+                                      building
+                                    items:
+                                      type: string
+                                    type: array
+                                  forceCommonAnnotations:
+                                    description: ForceCommonAnnotations specifies
+                                      whether to force applying common annotations
+                                      to resources for Kustomize apps
+                                    type: boolean
+                                  forceCommonLabels:
+                                    description: ForceCommonLabels specifies whether
+                                      to force applying common labels to resources
+                                      for Kustomize apps
+                                    type: boolean
+                                  ignoreMissingComponents:
+                                    description: IgnoreMissingComponents prevents
+                                      kustomize from failing when components do not
+                                      exist locally by not appending them to kustomization
+                                      file
+                                    type: boolean
+                                  images:
+                                    description: Images is a list of Kustomize image
+                                      override specifications
+                                    items:
+                                      description: KustomizeImage represents a Kustomize
+                                        image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                      type: string
+                                    type: array
+                                  kubeVersion:
+                                    description: |-
+                                      KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                      uses the Kubernetes version of the target cluster.
+                                    type: string
+                                  labelIncludeTemplates:
+                                    description: LabelIncludeTemplates specifies whether
+                                      to apply common labels to resource templates
+                                      or not
+                                    type: boolean
+                                  labelWithoutSelector:
+                                    description: LabelWithoutSelector specifies whether
+                                      to apply common labels to resource selectors
+                                      or not
+                                    type: boolean
+                                  namePrefix:
+                                    description: NamePrefix is a prefix appended to
+                                      resources for Kustomize apps
+                                    type: string
+                                  nameSuffix:
+                                    description: NameSuffix is a suffix appended to
+                                      resources for Kustomize apps
+                                    type: string
+                                  namespace:
+                                    description: Namespace sets the namespace that
+                                      Kustomize adds to all resources
+                                    type: string
+                                  patches:
+                                    description: Patches is a list of Kustomize patches
+                                    items:
+                                      properties:
+                                        options:
+                                          additionalProperties:
+                                            type: boolean
+                                          type: object
+                                        patch:
+                                          type: string
+                                        path:
+                                          type: string
+                                        target:
+                                          properties:
+                                            annotationSelector:
+                                              type: string
+                                            group:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            labelSelector:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            version:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    type: array
+                                  replicas:
+                                    description: Replicas is a list of Kustomize Replicas
+                                      override specifications
+                                    items:
+                                      properties:
+                                        count:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number of replicas
+                                          x-kubernetes-int-or-string: true
+                                        name:
+                                          description: Name of Deployment or StatefulSet
+                                          type: string
+                                      required:
+                                      - count
+                                      - name
+                                      type: object
+                                    type: array
+                                  version:
+                                    description: Version controls which version of
+                                      Kustomize to use for rendering manifests
+                                    type: string
+                                type: object
                               path:
                                 description: Path is a directory path within the Git
                                   repository where the manifests are located
                                 type: string
+                              plugin:
+                                description: Plugin specifies config management plugin
+                                  specific options
+                                properties:
+                                  env:
+                                    description: Env is a list of environment variable
+                                      entries
+                                    items:
+                                      description: EnvEntry represents an entry in
+                                        the application's environment
+                                      properties:
+                                        name:
+                                          description: Name is the name of the variable,
+                                            usually expressed in uppercase
+                                          type: string
+                                        value:
+                                          description: Value is the value of the variable
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  parameters:
+                                    items:
+                                      properties:
+                                        array:
+                                          description: Array is the value of an array
+                                            type parameter.
+                                          items:
+                                            type: string
+                                          type: array
+                                        map:
+                                          additionalProperties:
+                                            type: string
+                                          description: Map is the value of a map type
+                                            parameter.
+                                          type: object
+                                        name:
+                                          description: Name is the name identifying
+                                            a parameter.
+                                          type: string
+                                        string:
+                                          description: String_ is the value of a string
+                                            type parameter.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
                               repoURL:
                                 description: RepoURL is the URL to the git repository
                                   that contains the application manifests
@@ -4945,10 +5662,380 @@ spec:
                             description: DrySource specifies where the dry "don't
                               repeat yourself" manifest source lives.
                             properties:
+                              directory:
+                                description: Directory specifies path/directory specific
+                                  options
+                                properties:
+                                  exclude:
+                                    description: Exclude contains a glob pattern to
+                                      match paths against that should be explicitly
+                                      excluded from being used during manifest generation
+                                    type: string
+                                  include:
+                                    description: Include contains a glob pattern to
+                                      match paths against that should be explicitly
+                                      included during manifest generation
+                                    type: string
+                                  jsonnet:
+                                    description: Jsonnet holds options specific to
+                                      Jsonnet
+                                    properties:
+                                      extVars:
+                                        description: ExtVars is a list of Jsonnet
+                                          External Variables
+                                        items:
+                                          description: JsonnetVar represents a variable
+                                            to be passed to jsonnet during manifest
+                                            generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      libs:
+                                        description: Additional library search dirs
+                                        items:
+                                          type: string
+                                        type: array
+                                      tlas:
+                                        description: TLAS is a list of Jsonnet Top-level
+                                          Arguments
+                                        items:
+                                          description: JsonnetVar represents a variable
+                                            to be passed to jsonnet during manifest
+                                            generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                    type: object
+                                  recurse:
+                                    description: Recurse specifies whether to scan
+                                      a directory recursively for manifests
+                                    type: boolean
+                                type: object
+                              helm:
+                                description: Helm specifies helm specific options
+                                properties:
+                                  apiVersions:
+                                    description: |-
+                                      APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                      Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                    items:
+                                      type: string
+                                    type: array
+                                  fileParameters:
+                                    description: FileParameters are file parameters
+                                      to the helm template
+                                    items:
+                                      description: HelmFileParameter is a file parameter
+                                        that's passed to helm template during manifest
+                                        generation
+                                      properties:
+                                        name:
+                                          description: Name is the name of the Helm
+                                            parameter
+                                          type: string
+                                        path:
+                                          description: Path is the path to the file
+                                            containing the values for the Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  ignoreMissingValueFiles:
+                                    description: IgnoreMissingValueFiles prevents
+                                      helm template from failing when valueFiles do
+                                      not exist locally by not appending them to helm
+                                      template --values
+                                    type: boolean
+                                  kubeVersion:
+                                    description: |-
+                                      KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                      uses the Kubernetes version of the target cluster.
+                                    type: string
+                                  namespace:
+                                    description: Namespace is an optional namespace
+                                      to template with. If left empty, defaults to
+                                      the app's destination namespace.
+                                    type: string
+                                  parameters:
+                                    description: Parameters is a list of Helm parameters
+                                      which are passed to the helm template command
+                                      upon manifest generation
+                                    items:
+                                      description: HelmParameter is a parameter that's
+                                        passed to helm template during manifest generation
+                                      properties:
+                                        forceString:
+                                          description: ForceString determines whether
+                                            to tell Helm to interpret booleans and
+                                            numbers as strings
+                                          type: boolean
+                                        name:
+                                          description: Name is the name of the Helm
+                                            parameter
+                                          type: string
+                                        value:
+                                          description: Value is the value for the
+                                            Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  passCredentials:
+                                    description: PassCredentials pass credentials
+                                      to all domains (Helm's --pass-credentials)
+                                    type: boolean
+                                  releaseName:
+                                    description: ReleaseName is the Helm release name
+                                      to use. If omitted it will use the application
+                                      name
+                                    type: string
+                                  skipCrds:
+                                    description: SkipCrds skips custom resource definition
+                                      installation step (Helm's --skip-crds)
+                                    type: boolean
+                                  skipSchemaValidation:
+                                    description: SkipSchemaValidation skips JSON schema
+                                      validation (Helm's --skip-schema-validation)
+                                    type: boolean
+                                  skipTests:
+                                    description: SkipTests skips test manifest installation
+                                      step (Helm's --skip-tests).
+                                    type: boolean
+                                  valueFiles:
+                                    description: ValuesFiles is a list of Helm value
+                                      files to use when generating a template
+                                    items:
+                                      type: string
+                                    type: array
+                                  values:
+                                    description: Values specifies Helm values to be
+                                      passed to helm template, typically defined as
+                                      a block. ValuesObject takes precedence over
+                                      Values, so use one or the other.
+                                    type: string
+                                  valuesObject:
+                                    description: ValuesObject specifies Helm values
+                                      to be passed to helm template, defined as a
+                                      map. This takes precedence over Values.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  version:
+                                    description: Version is the Helm version to use
+                                      for templating ("3")
+                                    type: string
+                                type: object
+                              kustomize:
+                                description: Kustomize specifies kustomize specific
+                                  options
+                                properties:
+                                  apiVersions:
+                                    description: |-
+                                      APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                      Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                    items:
+                                      type: string
+                                    type: array
+                                  commonAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonAnnotations is a list of additional
+                                      annotations to add to rendered manifests
+                                    type: object
+                                  commonAnnotationsEnvsubst:
+                                    description: CommonAnnotationsEnvsubst specifies
+                                      whether to apply env variables substitution
+                                      for annotation values
+                                    type: boolean
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels is a list of additional
+                                      labels to add to rendered manifests
+                                    type: object
+                                  components:
+                                    description: Components specifies a list of kustomize
+                                      components to add to the kustomization before
+                                      building
+                                    items:
+                                      type: string
+                                    type: array
+                                  forceCommonAnnotations:
+                                    description: ForceCommonAnnotations specifies
+                                      whether to force applying common annotations
+                                      to resources for Kustomize apps
+                                    type: boolean
+                                  forceCommonLabels:
+                                    description: ForceCommonLabels specifies whether
+                                      to force applying common labels to resources
+                                      for Kustomize apps
+                                    type: boolean
+                                  ignoreMissingComponents:
+                                    description: IgnoreMissingComponents prevents
+                                      kustomize from failing when components do not
+                                      exist locally by not appending them to kustomization
+                                      file
+                                    type: boolean
+                                  images:
+                                    description: Images is a list of Kustomize image
+                                      override specifications
+                                    items:
+                                      description: KustomizeImage represents a Kustomize
+                                        image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                      type: string
+                                    type: array
+                                  kubeVersion:
+                                    description: |-
+                                      KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                      uses the Kubernetes version of the target cluster.
+                                    type: string
+                                  labelIncludeTemplates:
+                                    description: LabelIncludeTemplates specifies whether
+                                      to apply common labels to resource templates
+                                      or not
+                                    type: boolean
+                                  labelWithoutSelector:
+                                    description: LabelWithoutSelector specifies whether
+                                      to apply common labels to resource selectors
+                                      or not
+                                    type: boolean
+                                  namePrefix:
+                                    description: NamePrefix is a prefix appended to
+                                      resources for Kustomize apps
+                                    type: string
+                                  nameSuffix:
+                                    description: NameSuffix is a suffix appended to
+                                      resources for Kustomize apps
+                                    type: string
+                                  namespace:
+                                    description: Namespace sets the namespace that
+                                      Kustomize adds to all resources
+                                    type: string
+                                  patches:
+                                    description: Patches is a list of Kustomize patches
+                                    items:
+                                      properties:
+                                        options:
+                                          additionalProperties:
+                                            type: boolean
+                                          type: object
+                                        patch:
+                                          type: string
+                                        path:
+                                          type: string
+                                        target:
+                                          properties:
+                                            annotationSelector:
+                                              type: string
+                                            group:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            labelSelector:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            version:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    type: array
+                                  replicas:
+                                    description: Replicas is a list of Kustomize Replicas
+                                      override specifications
+                                    items:
+                                      properties:
+                                        count:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number of replicas
+                                          x-kubernetes-int-or-string: true
+                                        name:
+                                          description: Name of Deployment or StatefulSet
+                                          type: string
+                                      required:
+                                      - count
+                                      - name
+                                      type: object
+                                    type: array
+                                  version:
+                                    description: Version controls which version of
+                                      Kustomize to use for rendering manifests
+                                    type: string
+                                type: object
                               path:
                                 description: Path is a directory path within the Git
                                   repository where the manifests are located
                                 type: string
+                              plugin:
+                                description: Plugin specifies config management plugin
+                                  specific options
+                                properties:
+                                  env:
+                                    description: Env is a list of environment variable
+                                      entries
+                                    items:
+                                      description: EnvEntry represents an entry in
+                                        the application's environment
+                                      properties:
+                                        name:
+                                          description: Name is the name of the variable,
+                                            usually expressed in uppercase
+                                          type: string
+                                        value:
+                                          description: Value is the value of the variable
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  parameters:
+                                    items:
+                                      properties:
+                                        array:
+                                          description: Array is the value of an array
+                                            type parameter.
+                                          items:
+                                            type: string
+                                          type: array
+                                        map:
+                                          additionalProperties:
+                                            type: string
+                                          description: Map is the value of a map type
+                                            parameter.
+                                          type: object
+                                        name:
+                                          description: Name is the name identifying
+                                            a parameter.
+                                          type: string
+                                        string:
+                                          description: String_ is the value of a string
+                                            type parameter.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
                               repoURL:
                                 description: RepoURL is the URL to the git repository
                                   that contains the application manifests

--- a/kubernetes/argocd/helm/templates/crds/crd-applicationset.yaml
+++ b/kubernetes/argocd/helm/templates/crds/crd-applicationset.yaml
@@ -392,8 +392,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -1078,8 +1300,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -1765,8 +2209,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -2430,8 +3096,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -3120,8 +4008,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -3806,8 +4916,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -4493,8 +5825,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -5158,8 +6712,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -5831,8 +7607,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -6731,8 +8729,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -7622,8 +9842,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -8304,8 +10746,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -8996,8 +11660,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -9682,8 +12568,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -10369,8 +13477,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -11034,8 +14364,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -11707,8 +15259,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -12607,8 +16381,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -13498,8 +17494,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -14184,8 +18402,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -14856,8 +19296,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -15756,8 +20418,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -16647,8 +21531,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -17406,8 +22512,230 @@ spec:
                         properties:
                           drySource:
                             properties:
+                              directory:
+                                properties:
+                                  exclude:
+                                    type: string
+                                  include:
+                                    type: string
+                                  jsonnet:
+                                    properties:
+                                      extVars:
+                                        items:
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      libs:
+                                        items:
+                                          type: string
+                                        type: array
+                                      tlas:
+                                        items:
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                    type: object
+                                  recurse:
+                                    type: boolean
+                                type: object
+                              helm:
+                                properties:
+                                  apiVersions:
+                                    items:
+                                      type: string
+                                    type: array
+                                  fileParameters:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        path:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  ignoreMissingValueFiles:
+                                    type: boolean
+                                  kubeVersion:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                  parameters:
+                                    items:
+                                      properties:
+                                        forceString:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  passCredentials:
+                                    type: boolean
+                                  releaseName:
+                                    type: string
+                                  skipCrds:
+                                    type: boolean
+                                  skipSchemaValidation:
+                                    type: boolean
+                                  skipTests:
+                                    type: boolean
+                                  valueFiles:
+                                    items:
+                                      type: string
+                                    type: array
+                                  values:
+                                    type: string
+                                  valuesObject:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  version:
+                                    type: string
+                                type: object
+                              kustomize:
+                                properties:
+                                  apiVersions:
+                                    items:
+                                      type: string
+                                    type: array
+                                  commonAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  commonAnnotationsEnvsubst:
+                                    type: boolean
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  components:
+                                    items:
+                                      type: string
+                                    type: array
+                                  forceCommonAnnotations:
+                                    type: boolean
+                                  forceCommonLabels:
+                                    type: boolean
+                                  ignoreMissingComponents:
+                                    type: boolean
+                                  images:
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeVersion:
+                                    type: string
+                                  labelIncludeTemplates:
+                                    type: boolean
+                                  labelWithoutSelector:
+                                    type: boolean
+                                  namePrefix:
+                                    type: string
+                                  nameSuffix:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                  patches:
+                                    items:
+                                      properties:
+                                        options:
+                                          additionalProperties:
+                                            type: boolean
+                                          type: object
+                                        patch:
+                                          type: string
+                                        path:
+                                          type: string
+                                        target:
+                                          properties:
+                                            annotationSelector:
+                                              type: string
+                                            group:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            labelSelector:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            version:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    type: array
+                                  replicas:
+                                    items:
+                                      properties:
+                                        count:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        name:
+                                          type: string
+                                      required:
+                                      - count
+                                      - name
+                                      type: object
+                                    type: array
+                                  version:
+                                    type: string
+                                type: object
                               path:
                                 type: string
+                              plugin:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  parameters:
+                                    items:
+                                      properties:
+                                        array:
+                                          items:
+                                            type: string
+                                          type: array
+                                        map:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        name:
+                                          type: string
+                                        string:
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
                               repoURL:
                                 type: string
                               targetRevision:

--- a/kubernetes/argocd/helm/templates/crds/crd-project.yaml
+++ b/kubernetes/argocd/helm/templates/crds/crd-project.yaml
@@ -56,13 +56,17 @@ spec:
                 description: ClusterResourceBlacklist contains list of blacklisted
                   cluster level resources
                 items:
-                  description: |-
-                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
-                    concepts during lookup stages without having partially valid types
+                  description: ClusterResourceRestrictionItem is a cluster resource
+                    that is restricted by the project's whitelist or blacklist
                   properties:
                     group:
                       type: string
                     kind:
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the restricted resource. Glob patterns using Go's filepath.Match syntax are supported.
+                        Unlike the group and kind fields, if no name is specified, all resources of the specified group/kind are matched.
                       type: string
                   required:
                   - group
@@ -73,13 +77,17 @@ spec:
                 description: ClusterResourceWhitelist contains list of whitelisted
                   cluster level resources
                 items:
-                  description: |-
-                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
-                    concepts during lookup stages without having partially valid types
+                  description: ClusterResourceRestrictionItem is a cluster resource
+                    that is restricted by the project's whitelist or blacklist
                   properties:
                     group:
                       type: string
                     kind:
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the restricted resource. Glob patterns using Go's filepath.Match syntax are supported.
+                        Unlike the group and kind fields, if no name is specified, all resources of the specified group/kind are matched.
                       type: string
                   required:
                   - group

--- a/kubernetes/argocd/helm/templates/dex/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/dex/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -28,7 +28,7 @@ spec:
         app.kubernetes.io/component: dex-server
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: "v3.2.6"
+        app.kubernetes.io/version: "v3.3.0"
     spec:
       terminationGracePeriodSeconds: 30
       serviceAccountName: argocd-dex-server
@@ -111,7 +111,7 @@ spec:
           mountPath: /tls
       initContainers:
       - name: copyutil
-        image: quay.io/argoproj/argocd:v3.2.6
+        image: quay.io/argoproj/argocd:v3.3.0
         imagePullPolicy: IfNotPresent
         command:
         - /bin/cp

--- a/kubernetes/argocd/helm/templates/dex/role.yaml
+++ b/kubernetes/argocd/helm/templates/dex/role.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 rules:
 - apiGroups:
   - ""

--- a/kubernetes/argocd/helm/templates/dex/rolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/dex/rolebinding.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/kubernetes/argocd/helm/templates/dex/service.yaml
+++ b/kubernetes/argocd/helm/templates/dex/service.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 spec:  
   ports:
   - name: http

--- a/kubernetes/argocd/helm/templates/dex/serviceaccount.yaml
+++ b/kubernetes/argocd/helm/templates/dex/serviceaccount.yaml
@@ -12,4 +12,4 @@ metadata:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"

--- a/kubernetes/argocd/helm/templates/redis-secret-init/job.yaml
+++ b/kubernetes/argocd/helm/templates/redis-secret-init/job.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/component: redis-secret-init
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 spec:
   ttlSecondsAfterFinished: 60
   template:
@@ -25,14 +25,14 @@ spec:
         app.kubernetes.io/component: redis-secret-init
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: "v3.2.6"
+        app.kubernetes.io/version: "v3.3.0"
     spec:
       containers:
       - command:
           - argocd
           - admin
           - redis-initial-password
-        image: quay.io/argoproj/argocd:v3.2.6
+        image: quay.io/argoproj/argocd:v3.3.0
         imagePullPolicy: IfNotPresent
         name: secret-init
         resources:

--- a/kubernetes/argocd/helm/templates/redis-secret-init/role.yaml
+++ b/kubernetes/argocd/helm/templates/redis-secret-init/role.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/component: redis-secret-init
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
   name: argocd-redis-secret-init
   namespace: "argocd"
 rules:

--- a/kubernetes/argocd/helm/templates/redis-secret-init/rolebinding.yaml
+++ b/kubernetes/argocd/helm/templates/redis-secret-init/rolebinding.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/component: redis-secret-init
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
   name: argocd-redis-secret-init
   namespace: "argocd"
 roleRef:

--- a/kubernetes/argocd/helm/templates/redis-secret-init/serviceaccount.yaml
+++ b/kubernetes/argocd/helm/templates/redis-secret-init/serviceaccount.yaml
@@ -15,4 +15,4 @@ metadata:
     app.kubernetes.io/component: redis-secret-init
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"

--- a/kubernetes/argocd/helm/templates/redis/deployment.yaml
+++ b/kubernetes/argocd/helm/templates/redis/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/component: redis
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: "v3.2.6"
+        app.kubernetes.io/version: "v3.3.0"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -38,7 +38,7 @@ spec:
       automountServiceAccountToken: true
       containers:
       - name: redis
-        image: ecr-public.aws.com/docker/library/redis:8.2.2-alpine
+        image: ecr-public.aws.com/docker/library/redis:8.2.3-alpine
         imagePullPolicy: IfNotPresent
         args:
         - --save

--- a/kubernetes/argocd/helm/templates/redis/health-configmap.yaml
+++ b/kubernetes/argocd/helm/templates/redis/health-configmap.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 data:
   redis_liveness.sh: |
     response=$(

--- a/kubernetes/argocd/helm/templates/redis/service.yaml
+++ b/kubernetes/argocd/helm/templates/redis/service.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.2.6"
+    app.kubernetes.io/version: "v3.3.0"
 spec:  
   ports:
   - name: redis


### PR DESCRIPTION
## Summary

- Bump argo-cd helm chart 9.3.7 → 9.4.0 (app v3.2.6 → v3.3.0)
- Enable ServerSideApply for the argocd Application — the ApplicationSet CRD now exceeds the 262K client-side apply annotation limit

Supersedes #1475.