### PR TITLE
Remove fixed postfix deprecations from allowlist

### DIFF
--- a/ansible/deprecation-allowlist.yaml
+++ b/ansible/deprecation-allowlist.yaml
@@ -6,10 +6,5 @@
 #
 # Regenerate with: check-deprecations --generate <logfile>
 
-"INJECT_FACTS_AS_VARS default to `True` is deprecat":
-  - "TASK [oefenweb.postfix : configure mailname]"
-  - "TASK [oefenweb.postfix : facts | set | is_docker_guest]"
-  - "TASK [oefenweb.postfix : update configuration file]"
-
 "Importing 'to_native' from 'ansible.module_utils._":
   - "TASK [common : Configure sysctl for inotify]"

--- a/ansible/galaxy/roles/oefenweb.postfix/README.md
+++ b/ansible/galaxy/roles/oefenweb.postfix/README.md
@@ -12,8 +12,8 @@ None
 #### Variables
 
  * `postfix_install` [default: `[postfix, mailutils, libsasl2-2, sasl2-bin, libsasl2-modules]`]: Packages to install
- * `postfix_hostname` [default: `{{ ansible_fqdn }}`]: Host name, used for `myhostname` and in `mydestination`
- * `postfix_mailname` [default: `{{ ansible_fqdn }}`]: Mail name (in `/etc/mailname`), used for `myorigin`
+ * `postfix_hostname` [default: `{{ ansible_facts['fqdn'] }}`]: Host name, used for `myhostname` and in `mydestination`
+ * `postfix_mailname` [default: `{{ ansible_facts['fqdn'] }}`]: Mail name (in `/etc/mailname`), used for `myorigin`
 
  * `postfix_compatibility_level` [optional]: With backwards compatibility turned on (the compatibility_level value is less than the Postfix built-in value), Postfix looks for settings that are left at their implicit default value, and logs a message when a backwards-compatible default setting is required (e.g. `2`, `Postfix >= 3.0`)
 
@@ -55,7 +55,7 @@ None
  * `postfix_smtpd_data_restrictions` [optional]: List of data restrictions ([see](http://www.postfix.org/postconf.5.html#smtpd_data_restrictions))
 
  * `postfix_sasl_auth_enable` [default: `true`]: Enable SASL authentication in the SMTP client
- * `postfix_sasl_user` [default: `postmaster@{{ ansible_domain }}`]: SASL relay username
+ * `postfix_sasl_user` [default: `postmaster@{{ ansible_facts['domain'] }}`]: SASL relay username
  * `postfix_sasl_password` [default: `k8+haga4@#pR`]: SASL relay password **Make sure to change!**
  * `postfix_sasl_security_options` [default: `noanonymous`]: SMTP client SASL security options
  * `postfix_sasl_tls_security_option` [default: `noanonymous`]: SMTP client SASL TLS security options

--- a/ansible/galaxy/roles/oefenweb.postfix/defaults/main.yml
+++ b/ansible/galaxy/roles/oefenweb.postfix/defaults/main.yml
@@ -7,8 +7,8 @@ postfix_install:
   - sasl2-bin
   - libsasl2-modules
 
-postfix_hostname: "{{ ansible_fqdn }}"
-postfix_mailname: "{{ ansible_fqdn }}"
+postfix_hostname: "{{ ansible_facts['fqdn'] }}"
+postfix_mailname: "{{ ansible_facts['fqdn'] }}"
 
 postfix_default_database_type: hash
 postfix_aliases: []
@@ -33,7 +33,7 @@ postfix_relayhost_port: 587
 postfix_relaytls: false
 
 postfix_sasl_auth_enable: true
-postfix_sasl_user: "postmaster@{{ ansible_domain }}"
+postfix_sasl_user: "postmaster@{{ ansible_facts['domain'] }}"
 postfix_sasl_password: 'k8+haga4@#pR'
 postfix_sasl_security_options: noanonymous
 postfix_sasl_tls_security_options: noanonymous

--- a/ansible/galaxy/roles/oefenweb.postfix/tasks/main.yml
+++ b/ansible/galaxy/roles/oefenweb.postfix/tasks/main.yml
@@ -8,7 +8,7 @@
   block:
     - name: facts | set | is_docker_guest
       ansible.builtin.set_fact:
-        is_docker_guest: "{{ ansible_virtualization_role | default('host') == 'guest' and ansible_virtualization_type | default('none') == 'docker' }}"
+        is_docker_guest: "{{ ansible_facts['virtualization_role'] | default('host') == 'guest' and ansible_facts['virtualization_type'] | default('none') == 'docker' }}"
 
     - name: facts | set | postfix_relayhosts
       ansible.builtin.set_fact:

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -7,7 +7,7 @@ roles:
   - src: anxs.generic-users
     version: v1.2.0
   - name: oefenweb.postfix
-    version: "v3.8.1"
+    version: "v3.8.2"
   - name: geerlingguy.node_exporter
     version: "2.2.0"
   - src: michaelrigart.interfaces


### PR DESCRIPTION
oefenweb.postfix v3.8.2 (PR #1477) fixes the INJECT_FACTS_AS_VARS
warnings. Only the ansible.posix to_native import warning remains.

Ref #1258
