### PR TITLE
Fix basement clock template ValueError on idle media player

### DIFF
--- a/kubernetes/hass/config/packages/basement_clock.yaml
+++ b/kubernetes/hass/config/packages/basement_clock.yaml
@@ -47,10 +47,10 @@ template:
     is_active: "{{ states('media_player.rec_room') in ['playing', 'paused'] }}"
     dur: >-
       {{ state_attr('media_player.rec_room', 'media_duration')
-        | default(0) | int }}
+        | int(0) }}
     pos: >-
       {% set p = state_attr('media_player.rec_room', 'media_position')
-        | default(0) | float %}
+        | float(0) %}
       {% set updated = state_attr('media_player.rec_room',
         'media_position_updated_at') %}
       {% if updated and states('media_player.rec_room') == 'playing' %}


### PR DESCRIPTION
state_attr() returns None when media_player.rec_room has no active
media. The default() filter only catches undefined, not None, so
| int received None and raised ValueError every 10 seconds.

Replace | default(0) | int with | int(0) and | default(0) | float
with | float(0) — these filters handle None natively via their
default parameter.
