### PR TITLE
Quote YAML time trigger values to prevent sexagesimal parsing

### DIFF
--- a/.yamlfix.toml
+++ b/.yamlfix.toml
@@ -2,6 +2,7 @@ indent_mapping = 2
 indent_offset = 0
 indent_sequence = 2
 quote_basic_values = false
+preserve_quotes = true
 whitelines = 1
 section_whitelines = 1
 sequence_style = "keep_style"

--- a/kubernetes/hass/config/packages/birdfy.yaml
+++ b/kubernetes/hass/config/packages/birdfy.yaml
@@ -29,7 +29,7 @@ automation:
   id: notify_slack_low_bird_count
   trigger:
   - platform: time
-    at: 09:00:00
+    at: "09:00:00"
   condition:
   - condition: numeric_state
     entity_id: sensor.birdfy_birds_last_24h

--- a/kubernetes/hass/config/packages/ego_charger_maintenance.yaml
+++ b/kubernetes/hass/config/packages/ego_charger_maintenance.yaml
@@ -14,7 +14,7 @@ automation:
   description: Sequential charging of EGO batteries every 3 months
   trigger:
   - platform: time
-    at: 03:00:00
+    at: "03:00:00"
   condition:
   - condition: template
     value_template: >
@@ -134,7 +134,7 @@ automation:
   description: Ensure chargers are off every morning (safety reset)
   trigger:
   - platform: time
-    at: 12:00:00
+    at: "12:00:00"
   action:
   - service: switch.turn_off
     target:


### PR DESCRIPTION
In YAML 1.1, unquoted `12:00:00` is parsed as sexagesimal integer 43200,
causing HA to fail with "Got None" on the EGO Charger Daily Safety Off
automation. Values starting with 0 (03:00:00, 09:00:00) happened to work
because they don't match the sexagesimal pattern, but they should be
quoted too for correctness.

Enable `preserve_quotes` in yamlfix so quoted values aren't stripped.
