### PR TITLE
Set Frank thinking default to medium

### DIFF
--- a/kubernetes/frank/openclaw.json
+++ b/kubernetes/frank/openclaw.json
@@ -59,6 +59,7 @@
   "agents": {
     "defaults": {
       "model": "openai-codex/gpt-5.4",
+      "thinkingDefault": "medium",
       "sandbox": {
         "mode": "off",
         "workspaceAccess": "rw"


### PR DESCRIPTION
GPT 5.4 defaults to "low" thinking which limits multi-step
reasoning. Bumping to "medium" for better continuity and
fewer incomplete responses.
