### PR TITLE
Add garagepi eth0 interface and fix bootstrap-secrets

### DIFF
--- a/ansible/host_vars/garagepi.yaml
+++ b/ansible/host_vars/garagepi.yaml
@@ -1,5 +1,6 @@
 ---
 manage_network: true
+interfaces_pause_time: 5
 host_ipv4: "172.19.74.216"
 
 # WiFi configuration (layereight.wifi role)
@@ -9,6 +10,16 @@ wifi_psk: "{{ vault_wifi_psk_bleh }}"
 
 # Static IP configuration (michaelrigart.interfaces role)
 interfaces_ether_interfaces:
+  - device: eth0
+    bootproto: static
+    address: "172.19.74.221"
+    netmask: "255.255.255.0"
+    dnsnameservers: 172.19.74.1
+    dnssearch: oneill.net
+    pre_up: "sysctl -w net.ipv6.conf.eth0.accept_ra=0"
+    ip6:
+      address: "{{ infrastructure_ipv6_prefix }}::74:221"
+      prefix: "{{ infrastructure_ipv6_netmask }}"
   - device: wlan0
     bootproto: static
     address: "172.19.74.216"

--- a/kubernetes/smokeping-prober/config.yaml
+++ b/kubernetes/smokeping-prober/config.yaml
@@ -17,6 +17,7 @@ targets:
   - infra1.oneill.net
   - pantrypi.oneill.net
   - garagepi.oneill.net
+  - garagepi-eth.oneill.net
   - fs2.oneill.net
   interval: 1s
   network: ip

--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -106,6 +106,12 @@ locals {
       hostname = "garagepi.oneill.net"
       note     = "Raspberry Pi in garage - rtl433"
     }
+    garagepi-eth = {
+      mac      = "d8:3a:dd:1c:15:2f"
+      ip       = "172.19.74.221"
+      hostname = "garagepi-eth.oneill.net"
+      note     = "Raspberry Pi in garage - wired interface"
+    }
     pantrypi = {
       mac      = "dc:a6:32:9d:b7:0f"
       ip       = "172.19.74.120"

--- a/scripts/bootstrap-secrets
+++ b/scripts/bootstrap-secrets
@@ -67,6 +67,10 @@ get_secrets() {
     echo "  - Retrieving ${var_name}..."
     # Convert string to array for proper argument handling
     read -ra op_args <<< "$op_args_string"
+    # 'item get' requires --reveal to output secret values
+    if [[ "${op_args[0]}" == "item" && "${op_args[1]}" == "get" ]]; then
+      op_args+=(--reveal)
+    fi
     if ! secret_value=$(op --vault "$VAULT" "${op_args[@]}" 2>/dev/null); then
       echo "❌ Failed to retrieve ${var_name} from 1Password"
       exit 1


### PR DESCRIPTION
- Add eth0 static interface config with IPv6 (no gateway) to garagepi
- Disable accept_ra on eth0 via pre-up to prevent SLAAC route from
  competing with wlan0's static IPv6 default route
- Add DHCP reservation and DNS for garagepi-eth.oneill.net
- Add garagepi-eth to smokeping-prober targets
- Fix bootstrap-secrets to pass --reveal to op item get
