### PR TITLE
Update IPv6 prefix from 2ece:7500 to 2eec:a000

### DIFF
--- a/ansible/group_vars/all/ipv6.yaml
+++ b/ansible/group_vars/all/ipv6.yaml
@@ -1,4 +1,4 @@
 ---
-infrastructure_ipv6_prefix: "2600:4040:2ece:7500"
-infrastructure_ipv6_gateway: "2600:4040:2ece:7500::1"
+infrastructure_ipv6_prefix: "2600:4040:2eec:a000"
+infrastructure_ipv6_gateway: "2600:4040:2eec:a000::1"
 infrastructure_ipv6_netmask: "64"

--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -16,7 +16,7 @@
 
 locals {
   # IPv6 prefix for Default VLAN (172.19.74.0/24)
-  infrastructure_ipv6_prefix = "2600:4040:2ece:7500"
+  infrastructure_ipv6_prefix = "2600:4040:2eec:a000"
 
   infrastructure_hosts = {
     # Proxmox VE hosts


### PR DESCRIPTION
The ISP-delegated /64 on the Default VLAN changed. Applied in tofu and ansible, deployed to all IPv6-enabled hosts.