### PR TITLE
Use rebase strategy for Renovate automerge

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -10,6 +10,7 @@
     "ansible/galaxy/**"
   ],
   "rebaseWhen": "behind-base-branch",
+  "automergeStrategy": "rebase",
   "minimumReleaseAge": "14 days",
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,


### PR DESCRIPTION
Configure Renovate automerge to use the rebase merge method so GitHub-native automerge matches the main branch ruleset, which disallows squash merges.