### PR TITLE
Refactor cross-seed Prowlarr config and add 3 indexers

### DIFF
--- a/kubernetes/cross-seed/config.js
+++ b/kubernetes/cross-seed/config.js
@@ -15,12 +15,19 @@ module.exports = {
      * For Prowlarr, click on the indexer name and copy the Torznab Url, then append "?apikey=YOUR_PROWLARR_API_KEY"
      * Wrap each URL in quotation marks, and separate them with commas, and surround the entire set in brackets.
      */
-    torznab: [
-        process.env.PROWLARR_URL_1,
-        process.env.PROWLARR_URL_2,
-        process.env.PROWLARR_URL_3,
-        process.env.PROWLARR_URL_4
-    ].filter(Boolean),
+    torznab: (() => {
+        const prowlarr = (id) =>
+            `https://prowlarr.k.oneill.net/${id}/api?apikey=${process.env.PROWLARR_API_KEY}`;
+        return [
+            prowlarr(2),
+            prowlarr(3),
+            prowlarr(7),
+            prowlarr(11),
+            prowlarr(13),
+            prowlarr(14),
+            prowlarr(16),
+        ];
+    })(),
     sonarr: [`http://${process.env.SONARR_SERVICE_HOST}:${process.env.SONARR_SERVICE_PORT}/?apikey=${process.env.SONARR_API_KEY}`],
     radarr: [`http://${process.env.RADARR_SERVICE_HOST}:${process.env.RADARR_SERVICE_PORT}/?apikey=${process.env.RADARR_API_KEY}`],
     /**
@@ -112,7 +119,7 @@ module.exports = {
      * To search for everything except season pack episodes (data-based)
      *    use (includeEpisodes: false, includeSingleEpisodes: true, includeNonVideos: true)
      */
-    includeNonVideos: false,
+    includeNonVideos: true,
     /**
      * fuzzy size match threshold
      * decimal value (0.02 = 2%)

--- a/kubernetes/cross-seed/deploy.yaml
+++ b/kubernetes/cross-seed/deploy.yaml
@@ -45,26 +45,11 @@ spec:
         env:
         - name: TZ
           value: EST5EDT
-        - name: PROWLARR_URL_1
+        - name: PROWLARR_API_KEY
           valueFrom:
             secretKeyRef:
               name: cross-seed-secrets
-              key: prowlarr-url-1
-        - name: PROWLARR_URL_2
-          valueFrom:
-            secretKeyRef:
-              name: cross-seed-secrets
-              key: prowlarr-url-2
-        - name: PROWLARR_URL_3
-          valueFrom:
-            secretKeyRef:
-              name: cross-seed-secrets
-              key: prowlarr-url-3
-        - name: PROWLARR_URL_4
-          valueFrom:
-            secretKeyRef:
-              name: cross-seed-secrets
-              key: prowlarr-url-4
+              key: prowlarr-api-key
         - name: QBITTORRENT_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
- Collapse prowlarr-url-1..4 secrets into a single prowlarr-api-key,
  listing Torznab base URLs directly in config.js via a small helper.
- Add 3 new Prowlarr indexers to the torznab list.
- Set includeNonVideos: true so the non-video trackers produce hits.
