### PR TITLE
Update dawarich to 1.6.1

### DIFF
--- a/kubernetes/dawarich/deploy-sidekiq.yaml
+++ b/kubernetes/dawarich/deploy-sidekiq.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: sidekiq
-        image: freikin/dawarich:1.3.4@sha256:1c9ba9e0bde48688af8253b2a042adbb2fe245b23b61c977b01b227452ab0547
+        image: freikin/dawarich:1.6.1@sha256:a884f69f19ce0f66992f3872d24544d1e587e133b8a003e072711aafc1e02429
         command: [bundle, exec, sidekiq]
         args: []
         env:

--- a/kubernetes/dawarich/deploy-web.yaml
+++ b/kubernetes/dawarich/deploy-web.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: web
-        image: freikin/dawarich:1.3.4@sha256:1c9ba9e0bde48688af8253b2a042adbb2fe245b23b61c977b01b227452ab0547
+        image: freikin/dawarich:1.6.1@sha256:a884f69f19ce0f66992f3872d24544d1e587e133b8a003e072711aafc1e02429
         command: [web-entrypoint.sh]
         args: [bin/rails, server, -p, '3000', -b, '::']
         ports:


### PR DESCRIPTION
Supersedes Renovate PR #1989 (1.6.0). 1.6.1 fixes the anomaly filter
OOM regression introduced in 1.5.0 by processing points in monthly
chunks instead of all at once, and also fixes compressed zip import
failures due to temp file garbage collection.
