### PR TITLE
immich: bump chart to v0.11.1, pin images via kustomize

### DIFF
--- a/kubernetes/immich/Chart.yaml
+++ b/kubernetes/immich/Chart.yaml
@@ -4,7 +4,7 @@ name: immich-meta
 version: 0.1.0
 dependencies:
 - name: immich
-  version: 0.10.3
+  version: 0.11.1
   repository: https://immich-app.github.io/immich-charts
 - name: valkey
   version: 2.2.5

--- a/kubernetes/immich/helm/immich/machine-learning.yaml
+++ b/kubernetes/immich/helm/immich/machine-learning.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: immich
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: machine-learning
-    app.kubernetes.io/version: v2.0.0
+    app.kubernetes.io/version: v2.6.3
   namespace: immich
 spec:
   accessModes:
@@ -27,7 +27,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: machine-learning
     app.kubernetes.io/service: immich-machine-learning
-    app.kubernetes.io/version: v2.0.0
+    app.kubernetes.io/version: v2.6.3
   namespace: immich
 spec:
   type: ClusterIP
@@ -51,7 +51,7 @@ metadata:
     app.kubernetes.io/instance: immich
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: machine-learning
-    app.kubernetes.io/version: v2.0.0
+    app.kubernetes.io/version: v2.6.3
   annotations:
     reloader.stakater.com/auto: "true"
   namespace: immich
@@ -120,7 +120,7 @@ spec:
           envFrom:
           - secretRef:
               name: immich-secrets
-          image: ghcr.io/immich-app/immich-machine-learning:v2.3.1-cuda
+          image: ghcr.io/immich-app/immich-machine-learning:v2.6.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3

--- a/kubernetes/immich/helm/immich/server.yaml
+++ b/kubernetes/immich/helm/immich/server.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/service: immich-server
-    app.kubernetes.io/version: v2.0.0
+    app.kubernetes.io/version: v2.6.3
   namespace: immich
 spec:
   type: ClusterIP
@@ -18,6 +18,8 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      appProtocol: kubernetes.io/ws
+        
   selector:
     app.kubernetes.io/controller: main
     app.kubernetes.io/instance: immich
@@ -33,7 +35,7 @@ metadata:
     app.kubernetes.io/instance: immich
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
-    app.kubernetes.io/version: v2.0.0
+    app.kubernetes.io/version: v2.6.3
   annotations:
     reloader.stakater.com/auto: "true"
   namespace: immich
@@ -92,7 +94,7 @@ spec:
           envFrom:
           - secretRef:
               name: immich-secrets
-          image: ghcr.io/immich-app/immich-server:v2.3.1
+          image: ghcr.io/immich-app/immich-server:v2.6.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -140,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: immich
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
-    app.kubernetes.io/version: v2.0.0
+    app.kubernetes.io/version: v2.6.3
   annotations:
     ak-oidc-callback: /auth/login
     ak-oidc-extra-redirects: |

--- a/kubernetes/immich/kustomization.yaml
+++ b/kubernetes/immich/kustomization.yaml
@@ -9,9 +9,9 @@ commonAnnotations:
 
 images:
 - name: ghcr.io/immich-app/immich-server
-  newTag: v2.3.1
+  newTag: v2.3.1@sha256:f8d06a32b1b2a81053d78e40bf8e35236b9faefb5c3903ce9ca8712c9ed78445
 - name: ghcr.io/immich-app/immich-machine-learning
-  newTag: v2.3.1-cuda
+  newTag: v2.3.1-cuda@sha256:723c82610d713bc9bc15d90d8426f96915c2cbd634ef5bec1bf45a098d82d81d
 
 resources:
 - namespace.yaml

--- a/kubernetes/immich/kustomization.yaml
+++ b/kubernetes/immich/kustomization.yaml
@@ -7,6 +7,12 @@ namespace: immich
 commonAnnotations:
   argoManaged: 'true'
 
+images:
+- name: ghcr.io/immich-app/immich-server
+  newTag: v2.3.1
+- name: ghcr.io/immich-app/immich-machine-learning
+  newTag: v2.3.1-cuda
+
 resources:
 - namespace.yaml
 - immich-postgres-cluster.yaml

--- a/kubernetes/immich/values.yaml
+++ b/kubernetes/immich/values.yaml
@@ -3,8 +3,6 @@ controllers:
   main:
     containers:
       main:
-        image:
-          tag: v2.3.1
         env:
           TZ: America/New_York
           DB_DATABASE_NAME: immich
@@ -38,9 +36,7 @@ server:
       annotations:
         reloader.stakater.com/auto: 'true'
       containers:
-        main:
-          image:
-            tag: v2.3.1
+        main: {}
   ingress:
     main:
       enabled: true
@@ -79,8 +75,6 @@ machine-learning:
           kubernetes.io/hostname: k2
       containers:
         main:
-          image:
-            tag: v2.3.1-cuda
           resources:
             limits:
               nvidia.com/gpu: 1


### PR DESCRIPTION
Move image tag pins from values.yaml to kustomize images overrides.
Chart renders to v2.6.3 by default; kustomize overrides back to v2.3.1.
