### PR TITLE
qbittorrent: move bittorrent port from 51414 to 51413

### DIFF
--- a/kubernetes/qbittorrent/deploy.yaml
+++ b/kubernetes/qbittorrent/deploy.yaml
@@ -27,7 +27,7 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
-        - containerPort: 51414
+        - containerPort: 51413
         volumeMounts:
         - mountPath: /config
           name: config

--- a/kubernetes/qbittorrent/service.yaml
+++ b/kubernetes/qbittorrent/service.yaml
@@ -17,8 +17,8 @@ spec:
     port: 8080
     targetPort: 8080
   - name: bittorrent
-    port: 51414
-    targetPort: 51414
+    port: 51413
+    targetPort: 51413
     protocol: TCP
   selector:
     app: qbittorrent
@@ -39,8 +39,8 @@ spec:
   loadBalancerIP: 172.19.74.22
   ports:
   - name: bittorrent
-    port: 51414
-    targetPort: 51414
+    port: 51413
+    targetPort: 51413
     protocol: UDP
   selector:
     app: qbittorrent


### PR DESCRIPTION
Inbound 51414 was being dropped upstream, so the public-facing port had
to change. Update the Deployment containerPort and both LoadBalancer
services to match the new internal port.
