### PR TITLE
Add Codex account fallback for Frank

### DIFF
--- a/kubernetes/frank/openclaw.json
+++ b/kubernetes/frank/openclaw.json
@@ -56,10 +56,18 @@
       }
     }
   },
+  "auth": {
+    "order": {
+      "openai-codex": [
+        "openai-codex:coneill@oneill.net",
+        "openai-codex:clayton@oneill.net"
+      ]
+    }
+  },
   "agents": {
     "defaults": {
       "model": "openai-codex/gpt-5.4",
-      "thinkingDefault": "medium",
+      "thinkingDefault": "high",
       "sandbox": {
         "mode": "off",
         "workspaceAccess": "rw"


### PR DESCRIPTION
Configure auth profile ordering so coneill@oneill.net is primary
and clayton@oneill.net is secondary, with automatic rotation on
rate limit or quota exhaustion.
