### PR TITLE
Add Tailscale ingress for byparr

### DIFF
--- a/kubernetes/byparr/kustomization.yaml
+++ b/kubernetes/byparr/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - namespace.yaml
 - deployment.yaml
 - service.yaml
+- tailscale-ingress.yaml
 
 commonAnnotations:
   argoManaged: 'true'

--- a/kubernetes/byparr/tailscale-ingress.yaml
+++ b/kubernetes/byparr/tailscale-ingress.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+
+metadata:
+  name: byparr-tailscale
+  annotations:
+    tailscale.com/tags: tag:byparr
+
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: byparr
+      port:
+        number: 8191
+  tls:
+  - hosts:
+    - byparr

--- a/opentofu/tailscale.tf
+++ b/opentofu/tailscale.tf
@@ -19,6 +19,7 @@ resource "tailscale_acl" "main" {
             "tag:restic": ["tag:k8s-operator"],
             "tag:healthchecks": ["tag:k8s-operator"],
             "tag:netdata": ["tag:k8s-operator"],
+            "tag:byparr": ["tag:k8s-operator"],
         },
 
         // Define access control lists for users, groups, autogroups, tags,


### PR DESCRIPTION
Expose byparr over the tailnet at byparr.cow-banjo.ts.net. Adds
tag:byparr to the Tailscale ACL tagOwners and creates the
corresponding Ingress resource pointing at the in-cluster service.
