### PR TITLE
Add dnd:read bot scope to Home Slack app

### DIFF
--- a/opentofu/slack/apps.tf
+++ b/opentofu/slack/apps.tf
@@ -86,6 +86,7 @@ resource "slack-app_manifest" "home" {
       scopes = {
         bot = [
           "chat:write",
+          "dnd:read",
           "incoming-webhook",
         ]
       }


### PR DESCRIPTION
The HA Slack integration's DND sensor polled dnd.info every 10 seconds and
errored with missing_scope, spamming the HA log. HA uses the bot token
(xoxb-), so dnd:read must be on the bot scope list.
