### PR TITLE
hass: suppress habluetooth.manager startup error

### DIFF
--- a/kubernetes/hass/config/configuration.yaml
+++ b/kubernetes/hass/config/configuration.yaml
@@ -57,6 +57,15 @@ person:
 
 logger:
   default: info
+  logs:
+    # Suppress "Missing NET_ADMIN/NET_RAW capabilities for Bluetooth
+    # management" startup ERROR. HA's bluetooth integration is enabled
+    # only to receive advertisements from the ESPHome Bluetooth proxy;
+    # there is no local adapter on this node for HA to manage, so the
+    # adapter-recovery capability check is inapplicable. Raise to fatal
+    # to silence this module's errors without granting unused
+    # NET_ADMIN/NET_RAW capabilities.
+    habluetooth.manager: fatal
 
 homekit:
   filter:


### PR DESCRIPTION
HA's bluetooth integration emits an ERROR at startup complaining about
missing NET_ADMIN/NET_RAW capabilities for local adapter management.
The node running HA has no local Bluetooth adapter; all BT flows through
the ESPHome Bluetooth proxy, which doesn't use those capabilities.

Raise habluetooth.manager to fatal rather than granting the capabilities.
With hostNetwork: true, NET_ADMIN/NET_RAW would apply in the host network
namespace — unnecessary privilege for a feature with no hardware to act on.

Closes infra-6ee.8.
