### PR TITLE
[codex] Link repo skills for Codex

### DIFF
--- a/.agents/skills/mcp-cli
+++ b/.agents/skills/mcp-cli
@@ -1,0 +1,1 @@
+../../.claude/skills/mcp-cli

--- a/.agents/skills/renovate-eval
+++ b/.agents/skills/renovate-eval
@@ -1,0 +1,1 @@
+../../.claude/skills/renovate-eval


### PR DESCRIPTION
Links the repo-local Claude skills into Codex's repo skill discovery path.

This adds `.agents/skills` symlinks for the existing `mcp-cli` and `renovate-eval` skills so Codex can discover the same repo-specific skill instructions without duplicating their contents.

Validation: pre-commit hooks ran during commit; all applicable hooks passed or were skipped because the change only adds symlinks.