### PR TITLE
Add Prowlarr 18 to cross-seed

### DIFF
--- a/kubernetes/cross-seed/config.js
+++ b/kubernetes/cross-seed/config.js
@@ -27,6 +27,7 @@ module.exports = {
             prowlarr(14),
             prowlarr(16),
             prowlarr(17),
+            prowlarr(18),
         ];
     })(),
     sonarr: [`http://${process.env.SONARR_SERVICE_HOST}:${process.env.SONARR_SERVICE_PORT}/?apikey=${process.env.SONARR_API_KEY}`],


### PR DESCRIPTION
Adds Prowlarr indexer 18 to the cross-seed Torznab list.

Deployed with `kubectl apply -k kubernetes/cross-seed` and verified the rollout completed.