### PR TITLE
Use wall-clock restic retention

### DIFF
--- a/kubernetes/restic/profiles.yaml
+++ b/kubernetes/restic/profiles.yaml
@@ -64,10 +64,10 @@ b2:
       - name: Content-Type
         value: text/plain; charset=UTF-8
   forget:
-    keep-hourly: 24
-    keep-daily: 14
-    keep-monthly: 24
-    keep-weekly: 12
+    keep-within-hourly: 24h
+    keep-within-daily: 14d
+    keep-within-monthly: 24m
+    keep-within-weekly: 3m
     prune: true
     send-before: *send_before
     send-after: *send_after
@@ -137,11 +137,11 @@ xtal-b2:
   env: *rclone_env
 
   forget:
-    keep-hourly: 24
-    keep-daily: 7
-    keep-weekly: 12
-    keep-monthly: 12
-    keep-yearly: 5
+    keep-within-hourly: 24h
+    keep-within-daily: 7d
+    keep-within-weekly: 3m
+    keep-within-monthly: 12m
+    keep-within-yearly: 5y
     prune: true
     send-before: *send_before
     send-after: *send_after
@@ -172,10 +172,10 @@ main: &nfs_maintenance
     RESTIC_CACHE_DIR: /cache
 
   forget: &nfs_forget
-    keep-hourly: 48
-    keep-daily: 14
-    keep-weekly: 12
-    keep-monthly: 24
+    keep-within-hourly: 48h
+    keep-within-daily: 14d
+    keep-within-weekly: 3m
+    keep-within-monthly: 24m
     prune: true
     send-before: *send_before
     send-after: *send_after
@@ -201,8 +201,8 @@ xtal:
   repository: /source/backups/restic/repos/xtal
   forget:
     <<: *nfs_forget
-    keep-hourly: 24
-    keep-daily: 7
-    keep-weekly: 12
-    keep-monthly: 12
-    keep-yearly: 5
+    keep-within-hourly: 24h
+    keep-within-daily: 7d
+    keep-within-weekly: 3m
+    keep-within-monthly: 12m
+    keep-within-yearly: 5y

--- a/kubernetes/restic/scripts/run
+++ b/kubernetes/restic/scripts/run
@@ -10,7 +10,14 @@ cd "$SCRIPT_DIR"
 # shellcheck source=../../../scripts/require-secrets
 source "$REPO_ROOT/scripts/require-secrets"
 
-image=$(yq -r .spec.jobTemplate.spec.template.spec.containers[0].image <"$BASEDIR/cronjobs/cronjob-b2.yaml")
+base_image=$(yq -r .spec.jobTemplate.spec.template.spec.containers[0].image <"$BASEDIR/cronjobs/cronjob-b2.yaml")
+image_tag=$(yq -r ".images[] | select(.name == \"$base_image\") | .newTag" <"$BASEDIR/kustomization.yaml")
+
+if [[ "$image_tag" == "null" || -z "$image_tag" ]]; then
+	image="$base_image"
+else
+	image="${base_image}:$image_tag"
+fi
 
 mkdir -p .cache
 mkdir -p .tmp


### PR DESCRIPTION
Replace the restic forget policies with keep-within durations, using 3m for the weekly window.

Update the local restic helper to resolve the pinned image tag from kubernetes/restic/kustomization.yaml so local runs match the deployed image.
