### PR TITLE
Update frank OpenClaw defaults

### DIFF
--- a/kubernetes/frank/deployment.yaml
+++ b/kubernetes/frank/deployment.yaml
@@ -125,7 +125,7 @@ spec:
           readOnly: true
       containers:
       - name: frank
-        image: ghcr.io/openclaw/openclaw:2026.4.8@sha256:cfd0d7fbd222bf570f9b19293b70d161b046da05a25651c2bef6146935fb9209
+        image: ghcr.io/openclaw/openclaw:2026.4.23@sha256:1e6e1b562bbaa4816005f7a379fe2f5bc894289a08c0631f64263d705b81d809
         command:
         - node
         - dist/index.js

--- a/kubernetes/frank/openclaw.json
+++ b/kubernetes/frank/openclaw.json
@@ -42,6 +42,20 @@
     "entries": {
       "slack": {
         "enabled": true
+      },
+      "active-memory": {
+        "enabled": true,
+        "config": {
+          "enabled": true,
+          "agents": ["main"],
+          "allowedChatTypes": ["direct", "group", "channel"],
+          "queryMode": "recent",
+          "promptStyle": "balanced",
+          "timeoutMs": 15000,
+          "maxSummaryChars": 220,
+          "logging": true,
+          "persistTranscripts": false
+        }
       }
     }
   },
@@ -66,8 +80,8 @@
   },
   "agents": {
     "defaults": {
-      "model": "openai-codex/gpt-5.4",
-      "thinkingDefault": "high",
+      "model": "openai-codex/gpt-5.5",
+      "thinkingDefault": "xhigh",
       "sandbox": {
         "mode": "off",
         "workspaceAccess": "rw"


### PR DESCRIPTION
Update `frank` to OpenClaw `2026.4.23` and move the default model to `openai-codex/gpt-5.5`.

This also enables Active Memory for the main agent across chat types and raises the default thinking level to `xhigh`, while keeping the stable PI embedded runner path.

Refs #2061.
