### PR TITLE
Gate humidifier alerts on hygrostat

### DIFF
--- a/kubernetes/hass/config/packages/basement_humidifier_alert.yaml
+++ b/kubernetes/hass/config/packages/basement_humidifier_alert.yaml
@@ -8,11 +8,14 @@ template:
     delay_on:
       minutes: 25
     state: >
+      {% set hygrostat_on = is_state('humidifier.basement', 'on') %}
       {% set switch_on = is_state('switch.rec_room_humidifier', 'on') %}
       {% set power = states('sensor.rec_room_humidifier_power') | float(0) %}
-      {{ switch_on and power < 2 }}
+      {{ hygrostat_on and switch_on and power < 2 }}
     availability: >
-      {{ states('sensor.rec_room_humidifier_power') | is_number }}
+      {{ states('humidifier.basement') in ['on', 'off']
+        and states('switch.rec_room_humidifier') in ['on', 'off']
+        and states('sensor.rec_room_humidifier_power') | is_number }}
 
   - name: Basement Hallway Humidifier Not Running
     unique_id: basement_hallway_humidifier_not_running
@@ -20,12 +23,15 @@ template:
     delay_on:
       minutes: 25
     state: >
+      {% set hygrostat_on = is_state('humidifier.basement', 'on') %}
       {% set switch_on = is_state('switch.basement_hallway_humidifier', 'on') %}
       {% set power = states('sensor.basement_hallway_humidifier_power') | float(0)
       %}
-      {{ switch_on and power < 2 }}
+      {{ hygrostat_on and switch_on and power < 2 }}
     availability: >
-      {{ states('sensor.basement_hallway_humidifier_power') | is_number }}
+      {{ states('humidifier.basement') in ['on', 'off']
+        and states('switch.basement_hallway_humidifier') in ['on', 'off']
+        and states('sensor.basement_hallway_humidifier_power') | is_number }}
 
 alert:
   rec_room_humidifier_not_running:

--- a/scripts/hass-check-config
+++ b/scripts/hass-check-config
@@ -3,8 +3,9 @@
 BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$BASEDIR/../kubernetes/hass"
 
-# Extract Home Assistant image from rendered Kubernetes manifests
-HASS_IMAGE=$(yq '.spec.template.spec.containers[] | select(.name == "home-assistant") | .image' helm/statefulset.yaml)
+# Extract Home Assistant image from final kustomize output, not the raw Helm
+# render. The kustomization may override the chart image used at runtime.
+HASS_IMAGE=$(kustomize build . | yq 'select(.kind == "StatefulSet" and .metadata.name == "hass-home-assistant") | .spec.template.spec.containers[] | select(.name == "home-assistant") | .image')
 
 # Create temporary config directory
 mkdir -p config-check


### PR DESCRIPTION
Only report no-load humidifier alerts when the basement hygrostat is enabled. This avoids repeated water-level notifications after the humidifiers or their smart plugs are put away for the season.

Validate Home Assistant config with the final kustomize-rendered runtime image instead of the raw Helm chart image, so the check matches the image that will actually deploy.
