### PR TITLE
Pin Frank to stable OpenClaw

### DIFF
--- a/kubernetes/frank/deployment.yaml
+++ b/kubernetes/frank/deployment.yaml
@@ -125,7 +125,7 @@ spec:
           readOnly: true
       containers:
       - name: frank
-        image: ghcr.io/openclaw/openclaw:2026.4.23@sha256:1e6e1b562bbaa4816005f7a379fe2f5bc894289a08c0631f64263d705b81d809
+        image: ghcr.io/openclaw/openclaw:2026.4.8@sha256:cfd0d7fbd222bf570f9b19293b70d161b046da05a25651c2bef6146935fb9209
         command:
         - node
         - dist/index.js

--- a/kubernetes/frank/openclaw.json
+++ b/kubernetes/frank/openclaw.json
@@ -42,20 +42,6 @@
     "entries": {
       "slack": {
         "enabled": true
-      },
-      "active-memory": {
-        "enabled": true,
-        "config": {
-          "enabled": true,
-          "agents": ["main"],
-          "allowedChatTypes": ["direct", "group", "channel"],
-          "queryMode": "recent",
-          "promptStyle": "balanced",
-          "timeoutMs": 15000,
-          "maxSummaryChars": 220,
-          "logging": true,
-          "persistTranscripts": false
-        }
       }
     }
   },
@@ -80,7 +66,7 @@
   },
   "agents": {
     "defaults": {
-      "model": "openai-codex/gpt-5.5",
+      "model": "openai-codex/gpt-5.4",
       "thinkingDefault": "xhigh",
       "sandbox": {
         "mode": "off",


### PR DESCRIPTION
Pin Frank back to OpenClaw 2026.4.8, the last known-good image for Slack Socket Mode in our deployment.

This keeps Frank on openai-codex/gpt-5.4 because the pinned OpenClaw build does not recognize gpt-5.5. It also removes plugin configuration introduced with the newer OpenClaw setup that is not part of the stable 2026.4.8 runtime. The newer-version Slack regression is tracked separately in #2064.