### PR TITLE
Update Home Assistant to 2026.3.4

### DIFF
--- a/kubernetes/hass/kustomization.yaml
+++ b/kubernetes/hass/kustomization.yaml
@@ -17,7 +17,7 @@ resources:
 images:
 - name: ghcr.io/home-assistant/home-assistant
   newName: homeassistant/home-assistant
-  newTag: 2025.12.5@sha256:9a5a3eb4a213dfb25932dee9dc6815c9305f78cecb5afa716fa2483163d8fb5b
+  newTag: 2026.3.4@sha256:916682086154a7390114a9788782b8efb199852d4f7d47066722c2bc5d1829e6
 
 labels:
 


### PR DESCRIPTION
Pin the Home Assistant container image to the 2026.3.4 digest that was tested live.

Validated with kubectl apply -k kubernetes/hass and a five-minute post-rollout log monitor. NWS initially hit a transient api.weather.gov 500 but recovered on the next refresh; Roborock, Bambu, MQTT, Matter, Z-Wave JS, UniFi Protect, Vera, and Xiaomi BLE config entries loaded.
