### PR TITLE
Monitor Landroid network reachability

### DIFF
--- a/kubernetes/smokeping-prober/config.yaml
+++ b/kubernetes/smokeping-prober/config.yaml
@@ -23,6 +23,14 @@ targets:
   network: ip
   protocol: icmp
 
+  # IoT devices
+
+- hosts:
+  - landroid.oneill.net
+  interval: 1s
+  network: ip4
+  protocol: icmp
+
   # External domains
 
 - hosts:

--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -118,6 +118,14 @@ locals {
       hostname = "pantrypi.oneill.net"
       note     = "Raspberry Pi in pantry - zwavejs, zigbee2mqtt, rtl433"
     }
+    landroid = {
+      mac         = "7c:fa:80:61:08:2e"
+      ip          = "172.20.6.67"
+      hostname    = "landroid.oneill.net"
+      note        = "Worx Landroid WR310.1 mower"
+      public_dns  = false
+      enable_ipv6 = false
+    }
     # Test VMs
     testvm = {
       mac      = "BC:24:11:59:85:90"


### PR DESCRIPTION
## Summary
- add the Landroid WR310.1 to smokeping-prober by DNS name (`landroid.oneill.net`)
- add the Landroid UniFi DHCP reservation to the existing manual host map in `opentofu/locals.tf`
- keep the Landroid host out of public DNS/AAAA generation with `public_dns=false` and `enable_ipv6=false`

## Live rollout
- applied `kubectl apply -k kubernetes/smokeping-prober`
- updated the PVC-backed classic Smokeping `/config/Targets` live to use `landroid.oneill.net`
- restarted `smokeping-prober` and classic `smokeping` after config validation

## OpenTofu
- imported existing UniFi user `69ed3469846d528b55bffb48` into `unifi_user.infrastructure_hosts["landroid"]`
- targeted OpenTofu plan now reports no changes for `unifi_user.infrastructure_hosts["landroid"]`

## Verification
- commit hooks passed, including kubeconform, kyverno, Terraform fmt, Terraform validate, and tflint
- `tofu validate` passed
- smokeping-prober metrics show `host="landroid.oneill.net"`, `ip="172.20.6.67"`, and `smokeping_send_errors_total=0`
- classic Smokeping is using `host = landroid.oneill.net` and has `/data/InternalSites/Landroid.rrd`
- UniFi client `7c:fa:80:61:08:2e` has `use_fixedip=true`, `fixed_ip=172.20.6.67`, and `local_dns_record=landroid.oneill.net`