### PR TITLE
Add Hetzner backup OpenTofu resources

### DIFF
--- a/opentofu/.terraform.lock.hcl
+++ b/opentofu/.terraform.lock.hcl
@@ -225,6 +225,28 @@ provider "registry.opentofu.org/hashicorp/random" {
   ]
 }
 
+provider "registry.opentofu.org/hetznercloud/hcloud" {
+  version     = "1.60.1"
+  constraints = "~> 1.60"
+  hashes = [
+    "h1:Yn/7M+RswavjNlD0nPMUayi76qyu3jkKf4h1UczNqkc=",
+    "h1:aFTtCV6KIyK8QpkQrJZfAyjx+GXNVaBm4qN3Vvqmwlc=",
+    "zh:0a746671e3f149b998a2abf730a5401a07305c67f93d5bbfdcf60aa19fdebb4d",
+    "zh:156273b900a006253841727387671dd67c7c5c502998d6a9af5a5abbf5717fdf",
+    "zh:2daa1290c50c081bb6a6cfa76b2872ea9fd9658eb3f2e81deab58b1ee48cf348",
+    "zh:36d6dac96ac6389f35bb1f19f40c4263bf78fa36fa7468971cf646c69eeae663",
+    "zh:5d0040a11470ced3eddf7d3e8e823982f80f8eb127cf285cd351bfc26a4d1108",
+    "zh:60ac7d3d948d7280a6e53088d5c41c444712f05e4274e37b0f4a81da9dcd1edb",
+    "zh:9fe5dd114ebb6f8da0dc9b5485c42d01cd41ed61a6fe2fc92bb3038fe4d708ea",
+    "zh:ae755ea4faca6ee410a397702a2c74f10ea28ec1ab95e1656be7a6f5908d1d23",
+    "zh:b3edcf6ea0f6498bcbdcbac8ec69dfb79278c64c7ea46c3050cd361a603302b0",
+    "zh:c6059fad0c4d2ecc3475c1767779a8e8adfcb1168101aae57ba7783510a24ae2",
+    "zh:dfdeb297e97d5b97b04d16ded3f8ef6779fc22cbd0322a16aeff3b5feee36fe2",
+    "zh:e38d04e7a5d0dbc3858eaa678167b6ec5e73035dae3479c7a61e6d971e58c765",
+    "zh:fd60acd9f16b4eb7b442a557d19294a89f6a8a05f7ca57f4aa689a2a554e74bd",
+  ]
+}
+
 provider "registry.opentofu.org/integrations/github" {
   version     = "6.11.1"
   constraints = "~> 6.0"

--- a/opentofu/healthchecks.tf
+++ b/opentofu/healthchecks.tf
@@ -187,6 +187,54 @@ resource "healthchecksio_check" "kube_restic_b2_check" {
   channels = [data.healthchecksio_channel.selfhosted_email.id]
 }
 
+# kube-restic Hetzner backup - expects ping every 24 hours
+resource "healthchecksio_check" "kube_restic_hetzner_backup" {
+  provider = healthchecksio.selfhosted
+
+  name     = "kube-restic-hetzner-backup"
+  desc     = "Daily Hetzner restic backup from Kubernetes"
+  tags     = ["backup", "kubernetes", "restic"]
+  timeout  = 86400 # 1 day
+  grace    = 86400 # 1 day
+  channels = [data.healthchecksio_channel.selfhosted_email.id]
+}
+
+# kube-restic Hetzner forget - expects ping every 24 hours
+resource "healthchecksio_check" "kube_restic_hetzner_forget" {
+  provider = healthchecksio.selfhosted
+
+  name     = "kube-restic-hetzner-forget"
+  desc     = "Daily Hetzner restic forget/prune from Kubernetes"
+  tags     = ["backup", "kubernetes", "restic"]
+  timeout  = 86400 # 1 day
+  grace    = 86400 # 1 day
+  channels = [data.healthchecksio_channel.selfhosted_email.id]
+}
+
+# kube-restic Hetzner check - weekly integrity check
+resource "healthchecksio_check" "kube_restic_hetzner_check" {
+  provider = healthchecksio.selfhosted
+
+  name     = "kube-restic-hetzner-check"
+  desc     = "Weekly Hetzner restic integrity check from Kubernetes"
+  tags     = ["backup", "kubernetes", "restic"]
+  timeout  = 604800 # 7 days
+  grace    = 86400  # 1 day
+  channels = [data.healthchecksio_channel.selfhosted_email.id]
+}
+
+# kube-restic hetzner-main-copy - copies main backup to Hetzner
+resource "healthchecksio_check" "kube_restic_hetzner_main_copy" {
+  provider = healthchecksio.selfhosted
+
+  name     = "kube-restic-hetzner-main-copy-copy"
+  desc     = "Daily copy of main restic backup to Hetzner"
+  tags     = ["backup", "kubernetes", "restic"]
+  timeout  = 86400  # 1 day
+  grace    = 108000 # 30 hours - allow one failure + next day to complete
+  channels = [data.healthchecksio_channel.selfhosted_email.id]
+}
+
 # kube-restic xtal-b2-forget - daily forget/prune on xtal B2 repo
 resource "healthchecksio_check" "kube_restic_xtal_b2_forget" {
   provider = healthchecksio.selfhosted
@@ -205,6 +253,42 @@ resource "healthchecksio_check" "kube_restic_xtal_b2_check" {
 
   name     = "kube-restic-xtal-b2-check"
   desc     = "Weekly integrity check on xtal B2 repo"
+  tags     = ["backup", "kubernetes", "restic"]
+  timeout  = 604800 # 7 days
+  grace    = 86400  # 1 day
+  channels = [data.healthchecksio_channel.selfhosted_email.id]
+}
+
+# kube-restic hetzner-xtal-copy - copies xtal backup to Hetzner
+resource "healthchecksio_check" "kube_restic_hetzner_xtal_copy" {
+  provider = healthchecksio.selfhosted
+
+  name     = "kube-restic-hetzner-xtal-copy-copy"
+  desc     = "Daily copy of xtal restic backup to Hetzner"
+  tags     = ["backup", "kubernetes", "restic"]
+  timeout  = 86400  # 1 day
+  grace    = 108000 # 30 hours - allow one failure + next day to complete
+  channels = [data.healthchecksio_channel.selfhosted_email.id]
+}
+
+# kube-restic xtal-hetzner-forget - daily forget/prune on xtal Hetzner repo
+resource "healthchecksio_check" "kube_restic_xtal_hetzner_forget" {
+  provider = healthchecksio.selfhosted
+
+  name     = "kube-restic-xtal-hetzner-forget"
+  desc     = "Daily forget/prune on xtal Hetzner repo"
+  tags     = ["backup", "kubernetes", "restic"]
+  timeout  = 86400  # 1 day
+  grace    = 108000 # 30 hours - allow one failure + next day to complete
+  channels = [data.healthchecksio_channel.selfhosted_email.id]
+}
+
+# kube-restic xtal-hetzner-check - weekly integrity check on xtal Hetzner repo
+resource "healthchecksio_check" "kube_restic_xtal_hetzner_check" {
+  provider = healthchecksio.selfhosted
+
+  name     = "kube-restic-xtal-hetzner-check"
+  desc     = "Weekly integrity check on xtal Hetzner repo"
   tags     = ["backup", "kubernetes", "restic"]
   timeout  = 604800 # 7 days
   grace    = 86400  # 1 day

--- a/opentofu/hetzner.tf
+++ b/opentofu/hetzner.tf
@@ -1,0 +1,263 @@
+resource "random_password" "storage_box_parent" {
+  length           = 32
+  min_lower        = 1
+  min_numeric      = 1
+  min_special      = 1
+  min_upper        = 1
+  override_special = "^!$%()=?+#-.,:~*@{}_&"
+}
+
+resource "random_password" "storage_box_main" {
+  length           = 32
+  min_lower        = 1
+  min_numeric      = 1
+  min_special      = 1
+  min_upper        = 1
+  override_special = "^!$%()=?+#-.,:~*@{}_&"
+}
+
+resource "random_password" "storage_box_xtal" {
+  length           = 32
+  min_lower        = 1
+  min_numeric      = 1
+  min_special      = 1
+  min_upper        = 1
+  override_special = "^!$%()=?+#-.,:~*@{}_&"
+}
+
+resource "random_password" "storage_box_velero" {
+  length           = 32
+  min_lower        = 1
+  min_numeric      = 1
+  min_special      = 1
+  min_upper        = 1
+  override_special = "^!$%()=?+#-.,:~*@{}_&"
+}
+
+resource "hcloud_storage_box" "backups" {
+  location         = "fsn1" # Falkenstein, Germany
+  storage_box_type = "bx41" # 10 TB class
+  name             = "homelab-backups"
+  password         = random_password.storage_box_parent.result
+  access_settings = {
+    reachable_externally = true
+    webdav_enabled       = true
+  }
+
+  delete_protection = true
+
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes  = [ssh_keys]
+  }
+}
+
+resource "onepassword_item" "hetzner_storage_box_parent" {
+  vault    = data.onepassword_vault.infra.uuid
+  title    = "hetzner-storage-box-parent"
+  url      = local.hetzner_storage_box_urls.parent
+  username = hcloud_storage_box.backups.username
+  password = random_password.storage_box_parent.result
+
+  section {
+    label = "credentials"
+
+    field {
+      label = "url"
+      value = local.hetzner_storage_box_urls.parent
+    }
+  }
+}
+
+# Keep SSH enabled during migration so SFTP remains available for WebDAV
+# troubleshooting and emergency access.
+resource "hcloud_storage_box_subaccount" "main" {
+  storage_box_id = hcloud_storage_box.backups.id
+  home_directory = "restic-main"
+  password       = random_password.storage_box_main.result
+  description    = "restic main"
+
+  access_settings = {
+    ssh_enabled          = true
+    reachable_externally = true
+    webdav_enabled       = true
+  }
+}
+
+resource "hcloud_storage_box_subaccount" "xtal" {
+  storage_box_id = hcloud_storage_box.backups.id
+  home_directory = "restic-xtal"
+  password       = random_password.storage_box_xtal.result
+  description    = "restic xtal"
+
+  access_settings = {
+    ssh_enabled          = true
+    reachable_externally = true
+    webdav_enabled       = true
+  }
+}
+
+resource "hcloud_storage_box_subaccount" "velero" {
+  storage_box_id = hcloud_storage_box.backups.id
+  home_directory = "velero"
+  password       = random_password.storage_box_velero.result
+  description    = "velero kopia repo"
+
+  access_settings = {
+    ssh_enabled          = true
+    reachable_externally = true
+    webdav_enabled       = true
+  }
+}
+
+locals {
+  hetzner_storage_box_urls = {
+    parent = "https://${hcloud_storage_box.backups.server}"
+    main   = "https://${hcloud_storage_box_subaccount.main.server}"
+    xtal   = "https://${hcloud_storage_box_subaccount.xtal.server}"
+    velero = "https://${hcloud_storage_box_subaccount.velero.server}"
+  }
+
+  hetzner_restic_note_context = {
+    main = {
+      destination           = "main"
+      url_description       = "is consumed directly by `kubernetes/restic/shared/externalsecret.yaml`"
+      obscured_pass_setting = "RCLONE_CONFIG_HETZNER_WEBDAV_RESTIC_MAIN_PASS"
+    }
+    xtal = {
+      destination           = "xtal"
+      url_description       = "is the xtal destination URL consumed by the same restic/rclone pattern"
+      obscured_pass_setting = "RCLONE_CONFIG_HETZNER_WEBDAV_RESTIC_XTAL_PASS"
+    }
+  }
+
+  hetzner_restic_note_values = {
+    for name, context in local.hetzner_restic_note_context : name => <<-EOF
+      Managed by OpenTofu.
+
+      This login item holds the raw Hetzner Storage Box WebDAV credentials for the ${context.destination} restic destination.
+      - `username` and the built-in `password` are the raw WebDAV login credentials.
+      - `url` ${context.url_description}.
+      - `RCLONE_CONFIG_HETZNER_RESTIC_PASSWORD` and `RCLONE_CONFIG_HETZNER_RESTIC_PASSWORD2` are the crypt backend passwords copied from `resticprofile-rclone`.
+
+      The companion secure note `hetzner-restic-rclone` stores `${context.obscured_pass_setting}`, which must be the literal output of `rclone obscure` for this item's raw built-in password.
+      If this password rotates, update the companion item's obscured field too.
+    EOF
+  }
+}
+
+resource "onepassword_item" "hetzner_restic_main" {
+  vault      = data.onepassword_vault.infra.uuid
+  title      = "hetzner-restic-main"
+  url        = local.hetzner_storage_box_urls.main
+  username   = hcloud_storage_box_subaccount.main.username
+  note_value = local.hetzner_restic_note_values.main
+  # Keep this raw; rclone's pre-obscured WebDAV password is maintained in the
+  # companion item read and validated from `secrets.tf`.
+  password = random_password.storage_box_main.result
+
+  section {
+    label = "credentials"
+
+    field {
+      label = "url"
+      value = local.hetzner_storage_box_urls.main
+    }
+
+    field {
+      label = "RCLONE_CONFIG_HETZNER_RESTIC_PASSWORD"
+      type  = "CONCEALED"
+      value = local.resticprofile_rclone_fields["RCLONE_CONFIG_CRYPT_PASSWORD"]
+    }
+
+    field {
+      label = "RCLONE_CONFIG_HETZNER_RESTIC_PASSWORD2"
+      type  = "CONCEALED"
+      value = local.resticprofile_rclone_fields["RCLONE_CONFIG_CRYPT_PASSWORD2"]
+    }
+  }
+}
+
+resource "onepassword_item" "hetzner_restic_xtal" {
+  vault      = data.onepassword_vault.infra.uuid
+  title      = "hetzner-restic-xtal"
+  url        = local.hetzner_storage_box_urls.xtal
+  username   = hcloud_storage_box_subaccount.xtal.username
+  note_value = local.hetzner_restic_note_values.xtal
+  # Keep this raw; rclone's pre-obscured WebDAV password is maintained in the
+  # companion item read and validated from `secrets.tf`.
+  password = random_password.storage_box_xtal.result
+
+  section {
+    label = "credentials"
+
+    field {
+      label = "url"
+      value = local.hetzner_storage_box_urls.xtal
+    }
+
+    field {
+      label = "RCLONE_CONFIG_HETZNER_RESTIC_PASSWORD"
+      type  = "CONCEALED"
+      value = local.resticprofile_rclone_fields["RCLONE_CONFIG_CRYPT_PASSWORD"]
+    }
+
+    field {
+      label = "RCLONE_CONFIG_HETZNER_RESTIC_PASSWORD2"
+      type  = "CONCEALED"
+      value = local.resticprofile_rclone_fields["RCLONE_CONFIG_CRYPT_PASSWORD2"]
+    }
+  }
+}
+
+resource "onepassword_item" "hetzner_velero" {
+  vault    = data.onepassword_vault.infra.uuid
+  title    = "hetzner-velero"
+  url      = local.hetzner_storage_box_urls.velero
+  username = hcloud_storage_box_subaccount.velero.username
+  password = random_password.storage_box_velero.result
+
+  section {
+    label = "credentials"
+
+    field {
+      label = "url"
+      value = local.hetzner_storage_box_urls.velero
+    }
+
+    field {
+      label = "RCLONE_ENCRYPTION_PASSWORD"
+      type  = "CONCEALED"
+      value = random_password.rclone_encryption.result
+    }
+
+    field {
+      label = "RCLONE_S3_ACCESS_KEY"
+      value = "velero"
+    }
+
+    field {
+      label = "RCLONE_S3_SECRET_KEY"
+      type  = "CONCEALED"
+      value = random_password.rclone_s3_secret.result
+    }
+
+    field {
+      label = "KOPIA_PASSWORD"
+      type  = "CONCEALED"
+      value = random_password.kopia_password.result
+    }
+  }
+}
+
+output "hetzner_storage_box_main_server" {
+  value = hcloud_storage_box_subaccount.main.server
+}
+
+output "hetzner_storage_box_xtal_server" {
+  value = hcloud_storage_box_subaccount.xtal.server
+}
+
+output "hetzner_storage_box_velero_server" {
+  value = hcloud_storage_box_subaccount.velero.server
+}

--- a/opentofu/main.tf
+++ b/opentofu/main.tf
@@ -58,6 +58,10 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "~> 5.0"
     }
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.60"
+    }
   }
 
   backend "s3" {
@@ -113,6 +117,10 @@ provider "proxmox" {
 
 provider "cloudflare" {
   api_token = local.cloudflare_api_token
+}
+
+provider "hcloud" {
+  token = local.hcloud_token
 }
 
 module "dns" {

--- a/opentofu/secrets.tf
+++ b/opentofu/secrets.tf
@@ -9,10 +9,36 @@ ephemeral "onepassword_item" "vultr_api" {
   title = "Vultr API"
 }
 
+# Hetzner Cloud API credentials from 1Password
+ephemeral "onepassword_item" "hetzner_cloud_api" {
+  vault = data.onepassword_vault.infra.uuid
+  title = "hetzner-cloud-api"
+}
+
 # Backblaze B2 credentials from 1Password (master key with writeBuckets permission)
 data "onepassword_item" "terraform_b2" {
   vault = data.onepassword_vault.infra.uuid
   title = "terraform-b2"
+}
+
+data "onepassword_item" "resticprofile_rclone" {
+  vault = data.onepassword_vault.infra.uuid
+  title = "resticprofile-rclone"
+}
+
+# Manual companion item for Hetzner WebDAV rclone pass values. The built-in
+# `password` fields on the tofu-managed `hetzner-restic-main` /
+# `hetzner-restic-xtal` login items stay as the raw WebDAV login passwords.
+# This secure note carries only the pre-obscured `RCLONE_CONFIG_HETZNER_WEBDAV_*`
+# values that Kubernetes needs for rclone's `webdav pass` setting.
+#
+# We keep this as a separate item because `rclone obscure` uses a random IV.
+# If OpenTofu tried to regenerate the obscured values during plan/apply, the
+# result would drift every time even when the underlying raw password had not
+# changed.
+data "onepassword_item" "hetzner_restic_rclone" {
+  vault = data.onepassword_vault.infra.uuid
+  title = "hetzner-restic-rclone"
 }
 
 # Tailscale OpenTofu OAuth credentials from 1Password (for managing policy/ACLs/OAuth clients)
@@ -52,11 +78,39 @@ locals {
       for k, v in sec.field_map : k => v.value
     }
   ]...)
+
+  resticprofile_rclone_fields = merge([
+    for _, sec in data.onepassword_item.resticprofile_rclone.section_map : {
+      for k, v in sec.field_map : k => v.value
+    }
+  ]...)
+
+  hetzner_restic_rclone_fields = merge([
+    for _, sec in data.onepassword_item.hetzner_restic_rclone.section_map : {
+      for k, v in sec.field_map : k => v.value
+    }
+  ]...)
+}
+
+# Read the companion item intentionally and fail early if the manual rclone
+# fields are missing. This keeps the relationship between the tofu-managed login
+# items and the manual companion secure note explicit in OpenTofu.
+resource "terraform_data" "validate_hetzner_restic_rclone" {
+  lifecycle {
+    precondition {
+      condition = alltrue([
+        can(local.hetzner_restic_rclone_fields["RCLONE_CONFIG_HETZNER_WEBDAV_RESTIC_MAIN_PASS"]),
+        can(local.hetzner_restic_rclone_fields["RCLONE_CONFIG_HETZNER_WEBDAV_RESTIC_XTAL_PASS"]),
+      ])
+      error_message = "1Password item 'hetzner-restic-rclone' must contain RCLONE_CONFIG_HETZNER_WEBDAV_RESTIC_MAIN_PASS and RCLONE_CONFIG_HETZNER_WEBDAV_RESTIC_XTAL_PASS as pre-obscured rclone WebDAV passwords."
+    }
+  }
 }
 
 # Local values for easier reference
 locals {
   vultr_api_key = ephemeral.onepassword_item.vultr_api.password
+  hcloud_token  = ephemeral.onepassword_item.hetzner_cloud_api.password
 
   # B2 credentials using clean field mapping
   b2_application_key_id = local.b2_fields["RCLONE_CONFIG_B2_ACCOUNT"]


### PR DESCRIPTION
Adds the Hetzner Storage Box, subaccounts, generated passwords, 1Password items, provider wiring, and restic Healthchecks resources needed for the backup migration.
