### PR TITLE
Add Zyxel powerline hosts

### DIFF
--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -112,6 +112,20 @@ locals {
       hostname = "garagepi-eth.oneill.net"
       note     = "Raspberry Pi in garage - wired interface"
     }
+    den-powerline = {
+      mac         = "b8:d5:26:f6:ff:72"
+      ip          = "172.19.74.147"
+      hostname    = "den-powerline.oneill.net"
+      note        = "Zyxel PLA6456 G.hn powerline adapter in den"
+      enable_ipv6 = false
+    }
+    garage-powerline = {
+      mac         = "b8:d5:26:f6:ff:73"
+      ip          = "172.19.74.151"
+      hostname    = "garage-powerline.oneill.net"
+      note        = "Zyxel PLA6456 G.hn powerline adapter in garage"
+      enable_ipv6 = false
+    }
     pantrypi = {
       mac      = "dc:a6:32:9d:b7:0f"
       ip       = "172.19.74.120"


### PR DESCRIPTION
Add infrastructure host entries for the Zyxel PLA6456 G.hn adapters in the den and garage.

These entries drive UniFi static DHCP reservations plus oneill.net DNS records. IPv6 is disabled because the adapter management interfaces were only verified on IPv4.
