### PR TITLE
Add Tailscale SSH debug credentials

### DIFF
--- a/opentofu/github-repos.tf
+++ b/opentofu/github-repos.tf
@@ -1,5 +1,12 @@
 # GitHub repository secrets management
 
+locals {
+  tailscale_ssh_github_repositories = toset([
+    "github-actions",
+    "dotfiles",
+  ])
+}
+
 # Infra repository secrets
 resource "github_actions_secret" "infra_argocd_auth_token" {
   repository      = "infra"
@@ -23,6 +30,22 @@ resource "github_actions_secret" "infra_tailscale_oauth_client_secret" {
   repository      = "infra"
   secret_name     = "TAILSCALE_OAUTH_CLIENT_SECRET"
   plaintext_value = tailscale_oauth_client.github_actions.key
+}
+
+resource "github_actions_secret" "tailscale_ssh_oauth_client_id" {
+  for_each = local.tailscale_ssh_github_repositories
+
+  repository      = each.key
+  secret_name     = "TAILSCALE_SSH_OAUTH_CLIENT_ID"
+  plaintext_value = tailscale_oauth_client.github_actions_ssh.id
+}
+
+resource "github_actions_secret" "tailscale_ssh_oauth_client_secret" {
+  for_each = local.tailscale_ssh_github_repositories
+
+  repository      = each.key
+  secret_name     = "TAILSCALE_SSH_OAUTH_CLIENT_SECRET"
+  plaintext_value = tailscale_oauth_client.github_actions_ssh.key
 }
 
 resource "github_actions_secret" "infra_semaphore_api_token" {

--- a/opentofu/tailscale.tf
+++ b/opentofu/tailscale.tf
@@ -13,6 +13,7 @@ resource "tailscale_acl" "main" {
             "tag:k8s-operator": [],
             "tag:k8s": ["tag:k8s-operator"],
             "tag:github-actions": [],
+            "tag:github-actions-ssh": [],
             "tag:argocd": ["tag:k8s-operator"],
             "tag:semaphore": ["tag:k8s-operator"],
             "tag:flux": ["autogroup:admin"],
@@ -106,6 +107,14 @@ resource "tailscale_acl" "main" {
 
         // Define users and devices that can use Tailscale SSH.
         "ssh": [
+            // Allow members to debug ephemeral GitHub Actions runners.
+            {
+                "action": "check",
+                "src":    ["autogroup:member"],
+                "dst":    ["tag:github-actions-ssh"],
+                "users":  ["autogroup:nonroot"],
+            },
+
             // Allow all users to SSH into their own devices in check mode.
             // Comment this section out if you want to define specific restrictions.
             {
@@ -142,6 +151,15 @@ resource "tailscale_oauth_client" "github_actions" {
   description = "github-actions"
   scopes      = ["auth_keys"]
   tags        = ["tag:github-actions"]
+}
+
+# Create OAuth client for GitHub Actions SSH debugging (ephemeral nodes)
+resource "tailscale_oauth_client" "github_actions_ssh" {
+  description = "github-actions-ssh"
+  scopes      = ["auth_keys"]
+  tags        = ["tag:github-actions-ssh"]
+
+  depends_on = [tailscale_acl.main]
 }
 
 # Store operator OAuth credentials in 1Password
@@ -190,6 +208,31 @@ resource "onepassword_item" "tailscale_github_actions" {
       label = "client_secret"
       type  = "CONCEALED"
       value = tailscale_oauth_client.github_actions.key
+    }
+  }
+}
+
+# Store GitHub Actions SSH debug OAuth credentials in 1Password
+resource "onepassword_item" "tailscale_github_actions_ssh" {
+  vault    = data.onepassword_vault.infra.uuid
+  title    = "tailscale-github-actions-ssh"
+  category = "login"
+
+  note_value = "Tailscale OAuth client for GitHub Actions SSH debugging. Managed by OpenTofu - do not edit manually."
+
+  section {
+    label = "OAuth Credentials"
+
+    field {
+      label = "client_id"
+      type  = "STRING"
+      value = tailscale_oauth_client.github_actions_ssh.id
+    }
+
+    field {
+      label = "client_secret"
+      type  = "CONCEALED"
+      value = tailscale_oauth_client.github_actions_ssh.key
     }
   }
 }


### PR DESCRIPTION
Create a dedicated Tailscale OAuth client and tag for GitHub Actions SSH debugging.

Expose the credentials as GitHub Actions secrets for the github-actions and dotfiles repositories.
