### PR TITLE
Cut Velero backups over to Hetzner

### DIFF
--- a/.secrets.tmpl
+++ b/.secrets.tmpl
@@ -35,12 +35,13 @@ export RCLONE_CONFIG_B2_KEY="{{ op://infra/resticprofile-rclone/RCLONE_CONFIG_B2
 export SEMAPHORE_API_TOKEN="{{ op://infra/semaphore-api-token/password }}"
 
 # Velero/Kopia (used by: kubernetes/velero/run-kopia, run-rclone)
-export VELERO_RCLONE_CONFIG_B2_ACCOUNT="{{ op://infra/velero-b2-credentials/RCLONE_CONFIG_B2_ACCOUNT }}"
-export VELERO_RCLONE_CONFIG_B2_KEY="{{ op://infra/velero-b2-credentials/RCLONE_CONFIG_B2_KEY }}"
-export VELERO_RCLONE_ENCRYPTION_PASSWORD="{{ op://infra/velero-b2-credentials/RCLONE_ENCRYPTION_PASSWORD }}"
-export VELERO_RCLONE_S3_ACCESS_KEY="{{ op://infra/velero-b2-credentials/RCLONE_S3_ACCESS_KEY }}"
-export VELERO_RCLONE_S3_SECRET_KEY="{{ op://infra/velero-b2-credentials/RCLONE_S3_SECRET_KEY }}"
-export KOPIA_PASSWORD="{{ op://infra/velero-b2-credentials/KOPIA_PASSWORD }}"
+export VELERO_RCLONE_HETZNER_URL="{{ op://infra/hetzner-velero/url }}"
+export VELERO_RCLONE_HETZNER_USER="{{ op://infra/hetzner-velero/username }}"
+export VELERO_RCLONE_HETZNER_PASS="{{ op://infra/hetzner-velero/password }}"
+export VELERO_RCLONE_ENCRYPTION_PASSWORD="{{ op://infra/hetzner-velero/RCLONE_ENCRYPTION_PASSWORD }}"
+export VELERO_RCLONE_S3_ACCESS_KEY="{{ op://infra/hetzner-velero/RCLONE_S3_ACCESS_KEY }}"
+export VELERO_RCLONE_S3_SECRET_KEY="{{ op://infra/hetzner-velero/RCLONE_S3_SECRET_KEY }}"
+export KOPIA_PASSWORD="{{ op://infra/hetzner-velero/KOPIA_PASSWORD }}"
 
 # Gemini (used by: tools/weather-bg/generate)
 export GEMINI_API_KEY="{{ op://infra/gemini-api-key/password }}"

--- a/kubernetes/velero/externalsecret.yaml
+++ b/kubernetes/velero/externalsecret.yaml
@@ -3,7 +3,7 @@ apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 
 metadata:
-  name: velero-b2-credentials
+  name: velero-credentials
   namespace: velero
 
 spec:
@@ -12,7 +12,7 @@ spec:
     name: production
     kind: ClusterSecretStore
   target:
-    name: velero-b2-credentials
+    name: velero-credentials
     creationPolicy: Owner
     template:
       data:
@@ -23,9 +23,9 @@ spec:
   data:
   - secretKey: s3_access_key
     remoteRef:
-      key: velero-b2-credentials
+      key: hetzner-velero
       property: RCLONE_S3_ACCESS_KEY
   - secretKey: s3_secret_key
     remoteRef:
-      key: velero-b2-credentials
+      key: hetzner-velero
       property: RCLONE_S3_SECRET_KEY

--- a/kubernetes/velero/helm/backupstoragelocation.yaml
+++ b/kubernetes/velero/helm/backupstoragelocation.yaml
@@ -14,7 +14,6 @@ spec:
   accessMode: ReadWrite
   objectStorage:
     bucket: "data"
-    prefix: "velero"
   config:
     checksumAlgorithm: ""
     region: "rclone"

--- a/kubernetes/velero/helm/deployment.yaml
+++ b/kubernetes/velero/helm/deployment.yaml
@@ -108,7 +108,7 @@ spec:
       volumes:
         - name: cloud-credentials
           secret:
-            secretName: velero-b2-credentials
+            secretName: velero-credentials
         - name: plugins
           emptyDir: {}
         - name: scratch

--- a/kubernetes/velero/helm/node-agent-daemonset.yaml
+++ b/kubernetes/velero/helm/node-agent-daemonset.yaml
@@ -34,7 +34,7 @@ spec:
       volumes:
         - name: cloud-credentials
           secret:
-            secretName: velero-b2-credentials
+            secretName: velero-credentials
         - name: host-pods
           hostPath:
             path: /var/lib/kubelet/pods

--- a/kubernetes/velero/rclone-deployment.yaml
+++ b/kubernetes/velero/rclone-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - /scripts/start.sh
         - serve
         - s3
-        - 'crypt_b2:'
+        - 'hetzner_velero:'
         - --force-path-style=true
         - --addr=:8080
         - --log-level=INFO

--- a/kubernetes/velero/rclone-externalsecret.yaml
+++ b/kubernetes/velero/rclone-externalsecret.yaml
@@ -16,28 +16,33 @@ spec:
     creationPolicy: Owner
     template:
       data:
-        b2_account: '{{ .b2_account }}'
-        b2_key: '{{ .b2_key }}'
+        hetzner_url: '{{ .hetzner_url }}'
+        hetzner_user: '{{ .hetzner_user }}'
+        hetzner_pass: '{{ .hetzner_pass }}'
         encryption_password: '{{ .encryption_password }}'
         auth_key: '"{{ .s3_access_key }},{{ .s3_secret_key }}"'
   data:
-  - secretKey: b2_account
+  - secretKey: hetzner_url
     remoteRef:
-      key: velero-b2-credentials
-      property: RCLONE_CONFIG_B2_ACCOUNT
-  - secretKey: b2_key
+      key: hetzner-velero
+      property: url
+  - secretKey: hetzner_user
     remoteRef:
-      key: velero-b2-credentials
-      property: RCLONE_CONFIG_B2_KEY
+      key: hetzner-velero
+      property: username
+  - secretKey: hetzner_pass
+    remoteRef:
+      key: hetzner-velero
+      property: password
   - secretKey: encryption_password
     remoteRef:
-      key: velero-b2-credentials
+      key: hetzner-velero
       property: RCLONE_ENCRYPTION_PASSWORD
   - secretKey: s3_access_key
     remoteRef:
-      key: velero-b2-credentials
+      key: hetzner-velero
       property: RCLONE_S3_ACCESS_KEY
   - secretKey: s3_secret_key
     remoteRef:
-      key: velero-b2-credentials
+      key: hetzner-velero
       property: RCLONE_S3_SECRET_KEY

--- a/kubernetes/velero/repo-credentials-externalsecret.yaml
+++ b/kubernetes/velero/repo-credentials-externalsecret.yaml
@@ -16,5 +16,5 @@ spec:
   data:
   - secretKey: repository-password
     remoteRef:
-      key: velero-b2-credentials
+      key: hetzner-velero
       property: KOPIA_PASSWORD

--- a/kubernetes/velero/run-kopia
+++ b/kubernetes/velero/run-kopia
@@ -12,24 +12,18 @@ REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 # shellcheck source=../../scripts/require-secrets
 source "$REPO_ROOT/scripts/require-secrets"
 
-require_secrets VELERO_RCLONE_CONFIG_B2_ACCOUNT VELERO_RCLONE_CONFIG_B2_KEY \
-	VELERO_RCLONE_S3_ACCESS_KEY VELERO_RCLONE_S3_SECRET_KEY KOPIA_PASSWORD || exit 1
+require_secrets VELERO_RCLONE_S3_ACCESS_KEY VELERO_RCLONE_S3_SECRET_KEY \
+	KOPIA_PASSWORD || exit 1
 
 # Re-export with names expected by the script
-export RCLONE_CONFIG_B2_ACCOUNT="$VELERO_RCLONE_CONFIG_B2_ACCOUNT"
-export RCLONE_CONFIG_B2_KEY="$VELERO_RCLONE_CONFIG_B2_KEY"
 export RCLONE_S3_ACCESS_KEY="$VELERO_RCLONE_S3_ACCESS_KEY"
 export RCLONE_S3_SECRET_KEY="$VELERO_RCLONE_S3_SECRET_KEY"
-
-# Create temporary directory for kopia config
-TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
 
 # Kopia repository is accessed via the rclone S3 gateway
 # This matches how Velero accesses it
 S3_ENDPOINT="rclone-s3-velero.k.oneill.net"
 S3_BUCKET="data"
-S3_PREFIX="velero/kopia/default"
+S3_PREFIX="kopia/default"
 
 # S3 credentials (for accessing the rclone S3 gateway)
 export AWS_ACCESS_KEY_ID="$RCLONE_S3_ACCESS_KEY"
@@ -45,7 +39,7 @@ export KOPIA_CHECK_FOR_UPDATES=false
 # Use persistent kopia config directory in user's cache
 KOPIA_CONFIG_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/kopia"
 mkdir -p "$KOPIA_CONFIG_DIR"
-KOPIA_CONFIG="$KOPIA_CONFIG_DIR/velero.config"
+KOPIA_CONFIG="$KOPIA_CONFIG_DIR/velero-hetzner-default.config"
 
 # Connect to the repository if not already connected
 if [ ! -f "$KOPIA_CONFIG" ]; then

--- a/kubernetes/velero/run-rclone
+++ b/kubernetes/velero/run-rclone
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Script to run rclone with Velero B2 credentials
+# Script to run rclone with Velero Hetzner credentials
 # For local development use only
 
 # Directory where this script is located
@@ -11,33 +11,37 @@ REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 # shellcheck source=../../scripts/require-secrets
 source "$REPO_ROOT/scripts/require-secrets"
 
-require_secrets VELERO_RCLONE_CONFIG_B2_ACCOUNT VELERO_RCLONE_CONFIG_B2_KEY \
-	VELERO_RCLONE_ENCRYPTION_PASSWORD || exit 1
+require_secrets VELERO_RCLONE_HETZNER_URL VELERO_RCLONE_HETZNER_USER \
+	VELERO_RCLONE_HETZNER_PASS VELERO_RCLONE_ENCRYPTION_PASSWORD || exit 1
 
 # Re-export with names expected by the script
-export RCLONE_CONFIG_B2_ACCOUNT="$VELERO_RCLONE_CONFIG_B2_ACCOUNT"
-export RCLONE_CONFIG_B2_KEY="$VELERO_RCLONE_CONFIG_B2_KEY"
+export RCLONE_CONFIG_HETZNER_URL="$VELERO_RCLONE_HETZNER_URL"
+export RCLONE_CONFIG_HETZNER_USER="$VELERO_RCLONE_HETZNER_USER"
+export RCLONE_CONFIG_HETZNER_PASS="$VELERO_RCLONE_HETZNER_PASS"
 export RCLONE_ENCRYPTION_PASSWORD="$VELERO_RCLONE_ENCRYPTION_PASSWORD"
 
 # Create temporary directory for rclone config
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-# Obscure the encryption password for rclone
-OBSCURED_PASSWORD=$(rclone obscure "$RCLONE_ENCRYPTION_PASSWORD")
+OBSCURED_HETZNER_PASS=$(rclone obscure "$RCLONE_CONFIG_HETZNER_PASS")
+OBSCURED_ENCRYPTION_PASSWORD=$(rclone obscure "$RCLONE_ENCRYPTION_PASSWORD")
 
 # Create rclone config matching the Velero deployment
 cat > "$TMPDIR/rclone.conf" <<EOF
-[b2]
-type = b2
-account = $RCLONE_CONFIG_B2_ACCOUNT
-key = $RCLONE_CONFIG_B2_KEY
+[hetzner]
+type = webdav
+url = $RCLONE_CONFIG_HETZNER_URL
+vendor = other
+user = $RCLONE_CONFIG_HETZNER_USER
+pass = $OBSCURED_HETZNER_PASS
 
-[crypt_b2]
+[hetzner_velero]
 type = crypt
-remote = b2:cmo-velero
+remote = hetzner:
+filename_encryption = standard
 directory_name_encryption = true
-password = $OBSCURED_PASSWORD
+password = $OBSCURED_ENCRYPTION_PASSWORD
 EOF
 
 # Set rclone config location

--- a/kubernetes/velero/start.sh
+++ b/kubernetes/velero/start.sh
@@ -1,77 +1,52 @@
 #!/bin/sh
 set -e
 
-# Get plain-text password from secret
-PLAIN_PASSWORD="$(cat /secrets/encryption_password)"
+HETZNER_PASS="$(cat /secrets/hetzner_pass)"
+ENCRYPTION_PASSWORD="$(cat /secrets/encryption_password)"
 
-# Obscure it using rclone
-OBSCURED_PASSWORD="$(rclone obscure "$PLAIN_PASSWORD")"
+OBSCURED_HETZNER_PASS="$(rclone obscure "$HETZNER_PASS")"
+OBSCURED_ENCRYPTION_PASSWORD="$(rclone obscure "$ENCRYPTION_PASSWORD")"
 
-# Create rclone.conf with obscured password
 cat > /tmp/rclone.conf <<EOF
-[b2]
-type = b2
-account = $(cat /secrets/b2_account)
-key = $(cat /secrets/b2_key)
+[hetzner]
+type = webdav
+url = $(cat /secrets/hetzner_url)
+vendor = other
+user = $(cat /secrets/hetzner_user)
+pass = ${OBSCURED_HETZNER_PASS}
 
-[crypt_b2]
+[hetzner_velero]
 type = crypt
-remote = b2:cmo-velero
+remote = hetzner:
+filename_encryption = standard
 directory_name_encryption = true
-password = ${OBSCURED_PASSWORD}
-
-[out_s3]
-type = s3
-provider = Other
-access_key_id = $(cat /secrets/b2_account)
-secret_access_key = $(cat /secrets/b2_key)
-endpoint = https://s3.us-west-000.backblazeb2.com
-region = us-west-000
-
-[crypt_out_s3]
-type = crypt
-remote = out_s3:cmo-velero
-directory_name_encryption = true
-password = ${OBSCURED_PASSWORD}
+password = ${OBSCURED_ENCRYPTION_PASSWORD}
 EOF
 
-# Export rclone config location
 export RCLONE_CONFIG=/tmp/rclone.conf
 
-# Create the "data" directory in the B2 bucket using B2 native API with encryption
-# The S3 API tries to create buckets which requires account-level permissions
-# The B2 native API properly handles directory/file creation within the bucket
-# We use crypt_b2 (not crypt_out_s3) to ensure directory names are encrypted
-# This allows Velero to access bucket "data" with prefix "velero"
-echo "Creating encrypted 'data' directory via B2 native API..."
-echo "Velero encrypted backup marker file" > /tmp/.velero-marker
-rclone copy /tmp/.velero-marker crypt_b2:/data/.velero-marker
-rm -f /tmp/.velero-marker
-echo "✓ Created encrypted data directory with marker file"
+echo "Creating encrypted 'data' directory via Hetzner WebDAV..."
+rclone mkdir hetzner_velero:/data
+echo "✓ Created encrypted data directory"
 
-# Wait for B2 eventual consistency to propagate the directory
 echo "Waiting for directory to be visible..."
 sleep 3
 
-# Verify via crypt_b2 (encrypted view) - this is the remote we'll serve from
-# We can't verify via out_s3 because directory name encryption is enabled
 for i in 1 2 3; do
-    if rclone lsd crypt_b2: 2>/dev/null | grep -q "data"; then
-        echo "✓ Verified 'data' bucket directory exists and is visible via crypt_b2"
+    if rclone lsd hetzner_velero: 2>/dev/null | grep -q "data"; then
+        echo "✓ Verified 'data' bucket directory exists and is visible via hetzner_velero"
         break
     fi
-    echo "⚠ Waiting for 'data' directory to be visible via crypt_b2 (attempt $i/3)..."
+    echo "⚠ Waiting for 'data' directory to be visible via hetzner_velero (attempt $i/3)..."
     sleep 2
 done
 
-# Final verification - fail if directory still not visible via crypt remote
-if ! rclone lsd crypt_b2: 2>/dev/null | grep -q "data"; then
-    echo "✗ ERROR: 'data' directory not visible via crypt_b2 after retries"
+if ! rclone lsd hetzner_velero: 2>/dev/null | grep -q "data"; then
+    echo "✗ ERROR: 'data' directory not visible via hetzner_velero after retries"
     echo "Directory listing (encrypted names):"
-    rclone lsd crypt_b2: 2>&1 || echo "Failed to list directories"
+    rclone lsd hetzner_velero: 2>&1 || echo "Failed to list directories"
     exit 1
 fi
 
-# Exec rclone serve with remaining arguments
 # Note: --no-cleanup flag is added via deployment args to prevent automatic cleanup of empty dirs
 exec rclone "$@"

--- a/kubernetes/velero/values.yaml
+++ b/kubernetes/velero/values.yaml
@@ -4,7 +4,6 @@ configuration:
   - name: default
     provider: aws
     bucket: data
-    prefix: velero
     config:
       region: rclone
       s3Url: https://rclone-s3-velero.k.oneill.net
@@ -29,7 +28,7 @@ nodeAgent:
 uploaderType: kopia
 
 credentials:
-  existingSecret: velero-b2-credentials
+  existingSecret: velero-credentials
 
 metrics:
   enabled: true


### PR DESCRIPTION
## Summary
- move Velero rclone/crypt backend and credentials from B2 to the Hetzner Storage Box subaccount
- remove the Velero object-storage prefix for a fresh no-history Hetzner backup location
- update local Velero rclone/kopia helpers, including a new Kopia config cache name for the Hetzner repo

## Validation
- kubernetes/velero/render
- sh -n kubernetes/velero/start.sh
- bash -n kubernetes/velero/run-rclone kubernetes/velero/run-kopia
- kubectl kustomize kubernetes/velero
- git diff --check -- .secrets.tmpl kubernetes/velero
- kubectl diff -k kubernetes/velero
- live smoke backup: hetzner-smoke-20260502171748 completed with 15/15 DataUploads
- live scratch restore: hetzner-smoke-restore-20260502172656 restored frank-syncthing-config into scratch namespace and cleanup completed
- live seed backup: hetzner-seed-20260502172739 completed with 15/15 DataUploads

## Notes
- old B2 Velero objects are intentionally not migrated
- stale BackupRepository CRs were deleted live so Velero could initialize fresh Kopia repositories in the no-prefix Hetzner store
- the old live velero-b2-credentials ExternalSecret/Secret was deleted after workloads switched to the new secrets
