### PR TITLE
Monitor deck AP with smokeping

### DIFF
--- a/kubernetes/smokeping-prober/config.yaml
+++ b/kubernetes/smokeping-prober/config.yaml
@@ -18,6 +18,7 @@ targets:
   - pantrypi.oneill.net
   - garagepi.oneill.net
   - garagepi-eth.oneill.net
+  - deck.oneill.net
   - fs2.oneill.net
   interval: 1s
   network: ip


### PR DESCRIPTION
Add deck.oneill.net to the smokeping-prober internal ICMP target list so Prometheus records latency and packet-loss metrics for the UniFi Deck AP.
