### PR TITLE
Add rclone exporter backup repository metrics

### DIFF
--- a/kubernetes/prometheus/config/prometheus.yml
+++ b/kubernetes/prometheus/config/prometheus.yml
@@ -333,6 +333,23 @@ scrape_configs:
   - target_label: __address__
     replacement: prometheus-pve-exporter.o11y.svc:9221
 
+- job_name: rclone-exporter
+  scrape_interval: 120s
+  scrape_timeout: 120s
+  metrics_path: /probe
+  static_configs:
+  - targets:
+    - "hetzner_crypt_restic_main:"
+    - "hetzner_crypt_restic_xtal:"
+    - "hetzner_velero:"
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: __param_remote
+  - source_labels: [__param_remote]
+    target_label: instance
+  - target_label: __address__
+    replacement: rclone-exporter.o11y.svc:9116
+
 - job_name: karakeep
   metrics_path: /api/metrics
   static_configs:

--- a/kubernetes/rclone-exporter/deployment.yaml
+++ b/kubernetes/rclone-exporter/deployment.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: rclone-exporter
+  annotations:
+    reloader.stakater.com/auto: 'true'
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rclone-exporter
+      app.kubernetes.io/instance: rclone-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rclone-exporter
+        app.kubernetes.io/instance: rclone-exporter
+    spec:
+      containers:
+      - name: rclone-exporter
+        image: ghcr.io/crazyuploader/rclone_exporter:latest@sha256:bfed0633be29c7d14f895b578452e5356dca28644878dfa5a6eebe5021a84c5b
+        env:
+        - name: RC_EXPORTER_RCLONE_TIMEOUT
+          value: 1m50s
+        - name: RCLONE_CONFIG
+          value: /config/rclone.conf
+        envFrom:
+        - secretRef:
+            name: rclone-exporter
+        ports:
+        - name: http
+          containerPort: 9116
+        volumeMounts:
+        - name: config
+          mountPath: /config
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 10000
+          runAsGroup: 10000
+          capabilities:
+            drop: [ALL]
+      volumes:
+      - name: config
+        configMap:
+          name: rclone-exporter
+      - name: tmp
+        emptyDir: {}

--- a/kubernetes/rclone-exporter/externalsecret.yaml
+++ b/kubernetes/rclone-exporter/externalsecret.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+  name: rclone-exporter
+
+spec:
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  data:
+  - secretKey: RCLONE_CONFIG_HETZNER_WEBDAV_RESTIC_MAIN_URL
+    remoteRef:
+      key: hetzner-restic-main
+      property: url
+  - secretKey: RCLONE_CONFIG_HETZNER_WEBDAV_RESTIC_MAIN_USER
+    remoteRef:
+      key: hetzner-restic-main
+      property: username
+  - secretKey: RCLONE_CONFIG_HETZNER_WEBDAV_RESTIC_MAIN_PASS
+    remoteRef:
+      key: hetzner-restic-rclone
+      property: RCLONE_CONFIG_HETZNER_WEBDAV_RESTIC_MAIN_PASS
+  - secretKey: RCLONE_CONFIG_HETZNER_CRYPT_RESTIC_MAIN_PASSWORD
+    remoteRef:
+      key: hetzner-restic-main
+      property: RCLONE_CONFIG_HETZNER_RESTIC_PASSWORD
+  - secretKey: RCLONE_CONFIG_HETZNER_CRYPT_RESTIC_MAIN_PASSWORD2
+    remoteRef:
+      key: hetzner-restic-main
+      property: RCLONE_CONFIG_HETZNER_RESTIC_PASSWORD2
+  - secretKey: RCLONE_CONFIG_HETZNER_WEBDAV_RESTIC_XTAL_URL
+    remoteRef:
+      key: hetzner-restic-xtal
+      property: url
+  - secretKey: RCLONE_CONFIG_HETZNER_WEBDAV_RESTIC_XTAL_USER
+    remoteRef:
+      key: hetzner-restic-xtal
+      property: username
+  - secretKey: RCLONE_CONFIG_HETZNER_WEBDAV_RESTIC_XTAL_PASS
+    remoteRef:
+      key: hetzner-restic-rclone
+      property: RCLONE_CONFIG_HETZNER_WEBDAV_RESTIC_XTAL_PASS
+  - secretKey: RCLONE_CONFIG_HETZNER_CRYPT_RESTIC_XTAL_PASSWORD
+    remoteRef:
+      key: hetzner-restic-xtal
+      property: RCLONE_CONFIG_HETZNER_RESTIC_PASSWORD
+  - secretKey: RCLONE_CONFIG_HETZNER_CRYPT_RESTIC_XTAL_PASSWORD2
+    remoteRef:
+      key: hetzner-restic-xtal
+      property: RCLONE_CONFIG_HETZNER_RESTIC_PASSWORD2
+  - secretKey: RCLONE_CONFIG_HETZNER_WEBDAV_VELERO_URL
+    remoteRef:
+      key: hetzner-velero
+      property: url
+  - secretKey: RCLONE_CONFIG_HETZNER_WEBDAV_VELERO_USER
+    remoteRef:
+      key: hetzner-velero
+      property: username
+  - secretKey: RCLONE_CONFIG_HETZNER_WEBDAV_VELERO_PASS
+    remoteRef:
+      key: hetzner-velero-rclone
+      property: RCLONE_CONFIG_HETZNER_WEBDAV_VELERO_PASS
+  - secretKey: RCLONE_CONFIG_HETZNER_VELERO_PASSWORD
+    remoteRef:
+      key: hetzner-velero-rclone
+      property: RCLONE_CONFIG_HETZNER_VELERO_PASSWORD
+  target:
+    name: rclone-exporter

--- a/kubernetes/rclone-exporter/kustomization.yaml
+++ b/kubernetes/rclone-exporter/kustomization.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: o11y
+
+commonAnnotations:
+  argoManaged: 'true'
+
+resources:
+- deployment.yaml
+- service.yaml
+- externalsecret.yaml
+
+configMapGenerator:
+
+- files:
+  - rclone.conf
+  name: rclone-exporter
+  options:
+    disableNameSuffixHash: true
+
+labels:
+
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: rclone-exporter
+    app.kubernetes.io/instance: rclone-exporter

--- a/kubernetes/rclone-exporter/rclone.conf
+++ b/kubernetes/rclone-exporter/rclone.conf
@@ -1,0 +1,29 @@
+[hetzner_webdav_restic_main]
+type = webdav
+vendor = other
+
+[hetzner_webdav_restic_xtal]
+type = webdav
+vendor = other
+
+[hetzner_webdav_velero]
+type = webdav
+vendor = other
+
+[hetzner_crypt_restic_main]
+type = crypt
+remote = hetzner_webdav_restic_main:
+filename_encryption = standard
+directory_name_encryption = true
+
+[hetzner_crypt_restic_xtal]
+type = crypt
+remote = hetzner_webdav_restic_xtal:
+filename_encryption = standard
+directory_name_encryption = true
+
+[hetzner_velero]
+type = crypt
+remote = hetzner_webdav_velero:
+filename_encryption = standard
+directory_name_encryption = true

--- a/kubernetes/rclone-exporter/service.yaml
+++ b/kubernetes/rclone-exporter/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: rclone-exporter
+
+spec:
+  selector:
+    app.kubernetes.io/name: rclone-exporter
+    app.kubernetes.io/instance: rclone-exporter
+  ports:
+  - name: http
+    port: 9116
+    targetPort: 9116


### PR DESCRIPTION
## Summary

- add repo-managed `kubernetes/rclone-exporter` deployment, service, ExternalSecret, and runtime rclone config generation
- add Prometheus `/probe` scraping for Hetzner restic main, restic xtal, and Velero remotes
- replace the temporary hcloud-exporter monitoring path with rclone exporter repository-level metrics
- update the live Grafana Rclone dashboard to use rclone exporter repo size/object panels and remove hcloud panels

## Verification

- `kubectl kustomize kubernetes/rclone-exporter`
- `kubectl kustomize kubernetes/prometheus`
- `promtool check config /etc/prometheus/prometheus.yml` using the pinned Prometheus image
- commit hooks passed, including yamlfix, yamllint, kubeconform, kyverno, shellcheck, and shfmt
- live `rclone-exporter` deployment/service/ExternalSecret are healthy in `o11y`
- Prometheus reports `rclone_remote_size_bytes`, `rclone_remote_objects_count`, and `up=1` for `hetzner_crypt_restic_main:`, `hetzner_crypt_restic_xtal:`, and `hetzner_velero:`
- live `hcloud-exporter` resources removed from `o11y` after replacement metrics were verified

Bead: `infra-mr9h.15`