### PR TITLE
Update Frank OpenClaw to GPT 5.5

### DIFF
--- a/kubernetes/frank/deployment.yaml
+++ b/kubernetes/frank/deployment.yaml
@@ -125,7 +125,7 @@ spec:
           readOnly: true
       containers:
       - name: frank
-        image: ghcr.io/openclaw/openclaw:2026.4.8@sha256:cfd0d7fbd222bf570f9b19293b70d161b046da05a25651c2bef6146935fb9209
+        image: ghcr.io/openclaw/openclaw:2026.5.7@sha256:1af3f457a2d5a1d210f4d95634fa5da6e23f9c0ac7b52ef4bc38e2ecf09704fd
         command:
         - node
         - dist/index.js

--- a/kubernetes/frank/openclaw.json
+++ b/kubernetes/frank/openclaw.json
@@ -66,7 +66,7 @@
   },
   "agents": {
     "defaults": {
-      "model": "openai-codex/gpt-5.4",
+      "model": "openai-codex/gpt-5.5",
       "thinkingDefault": "xhigh",
       "sandbox": {
         "mode": "off",


### PR DESCRIPTION
Bump Frank's OpenClaw image from 2026.4.8 to 2026.5.7 with the pinned digest.

Update the default OpenClaw model from openai-codex/gpt-5.4 to openai-codex/gpt-5.5.
