### PR TITLE
Default renovate eval workflow to Codex

### DIFF
--- a/.claude/skills/renovate-eval/README.md
+++ b/.claude/skills/renovate-eval/README.md
@@ -69,21 +69,17 @@ python3 .claude/skills/renovate-eval/renovate_eval.py render path/to/eval-data.j
 
 ### GitHub Actions
 
-The workflow at `.github/workflows/renovate-eval.yaml` runs automatically for
-eligible Renovate PRs and can also run via `workflow_dispatch`. It uses the
-composite action at `.claude/skills/renovate-eval/action.yaml`.
+This skill includes a composite GitHub Action in `action.yaml`. The action
+installs only the selected provider CLI.
 
-`workflow_dispatch` accepts `provider=claude` or `provider=codex`. Codex
-dispatches also accept `codex_runner_label` so callers can choose the runner
-label that matches their Codex environment.
-
-The composite action installs only the selected provider CLI. In Codex mode,
-`codex_version` defaults to `latest` and optional `codex_evaluator_model` /
-`codex_auditor_model` inputs can override the Codex CLI default model.
-`codex_reasoning_effort` defaults to empty so the composite action uses the
-Codex CLI default unless a caller overrides it. `agent_timeout` defaults to
-`600` seconds, and `0` disables the subprocess timeout. Callers that use higher
-reasoning effort or slower private runners can pass a larger timeout.
+The `provider` input accepts `claude` or `codex`. If omitted, provider
+resolution order is explicit `provider` input, then `RENOVATE_EVAL_PROVIDER`,
+then Claude. In Codex mode, `codex_version` defaults to `latest` and optional
+`codex_evaluator_model` / `codex_auditor_model` inputs can override the Codex
+CLI default model. `codex_reasoning_effort` defaults to empty so the composite
+action uses the Codex CLI default unless a caller overrides it. `agent_timeout`
+defaults to `600` seconds, and `0` disables the subprocess timeout. Callers that
+use higher reasoning effort or slower private runners can pass a larger timeout.
 
 Provisioning working Codex subscription auth, persistent `CODEX_HOME`, and
 private runner state is out of scope for the action. That infrastructure is

--- a/.github/workflows/renovate-eval.yaml
+++ b/.github/workflows/renovate-eval.yaml
@@ -22,12 +22,12 @@ on:
         options:
         - claude
         - codex
-        default: claude
+        default: codex
       codex_runner_label:
         description: Runner label for provider=codex
         required: false
         type: string
-        default: ubuntu-latest
+        default: codex
       codex_reasoning_effort:
         description: Codex reasoning effort for provider=codex
         required: false
@@ -80,7 +80,9 @@ jobs:
         INPUT_CODEX_REASONING_EFFORT: ${{ inputs.codex_reasoning_effort }}
         INPUT_CODEX_AGENT_TIMEOUT: ${{ inputs.codex_agent_timeout }}
       run: |
-        PROVIDER="${INPUT_PROVIDER:-claude}"
+        # This repo opts into Codex by default; explicit provider=claude still
+        # routes the evaluator job to GitHub-hosted ubuntu-latest.
+        PROVIDER="${INPUT_PROVIDER:-codex}"
         CODEX_REASONING_EFFORT=""
         CODEX_AGENT_TIMEOUT=""
         case "$PROVIDER" in
@@ -88,7 +90,7 @@ jobs:
             RUNNER_LABEL="ubuntu-latest"
             ;;
           codex)
-            RUNNER_LABEL="${INPUT_CODEX_RUNNER_LABEL:-ubuntu-latest}"
+            RUNNER_LABEL="${INPUT_CODEX_RUNNER_LABEL:-codex}"
             CODEX_REASONING_EFFORT="${INPUT_CODEX_REASONING_EFFORT:-xhigh}"
             CODEX_AGENT_TIMEOUT="${INPUT_CODEX_AGENT_TIMEOUT:-1800}"
             if [[ -z "$RUNNER_LABEL" ]]; then


### PR DESCRIPTION
Set this repo's renovate eval workflow defaults to Codex while keeping the reusable skill/action provider defaults unchanged.

- default workflow_dispatch provider and Codex runner label to codex
- document the repo-level opt-in in the workflow
- keep skill README generic for future extraction
