### PR TITLE
Exclude mutable tags from Spegel resolution

### DIFF
--- a/kubernetes/spegel/helm/templates/daemonset.yaml
+++ b/kubernetes/spegel/helm/templates/daemonset.yaml
@@ -76,6 +76,10 @@ spec:
           - --containerd-namespace=k8s.io
           - --bootstrap-kind=dns
           - --dns-bootstrap-domain=spegel-bootstrap.spegel.svc.cluster.local.
+          - --registry-filters
+          - ".*:latest$"
+          - ".*:dev$"
+          - ".*:edge$"
           - --containerd-content-path=/var/lib/containerd/io.containerd.content.v1.content
           - --debug-web-enabled=true
           - --data-dir=/var/lib/spegel

--- a/kubernetes/spegel/values.yaml
+++ b/kubernetes/spegel/values.yaml
@@ -2,3 +2,8 @@
 service:
   registry:
     usePreferSameNodeTrafficDistribution: true
+spegel:
+  registryFilters:
+  - ".*:latest$"
+  - ".*:dev$"
+  - ".*:edge$"


### PR DESCRIPTION
Configure Spegel registry filters for latest, dev, and edge tags so mutable image tags resolve through the upstream registry instead of the cluster mirror cache.

Applied to the cluster with kubectl apply -k kubernetes/spegel and verified the Spegel DaemonSet rolled out successfully.