### PR TITLE
Configure Readest Slack notifications

### DIFF
--- a/kubernetes/readest-hardcover-sync/deploy.yaml
+++ b/kubernetes/readest-hardcover-sync/deploy.yaml
@@ -59,6 +59,13 @@ spec:
             secretKeyRef:
               name: readest-hardcover-sync
               key: HARDCOVER_TOKEN
+        - name: PUBLIC_BASE_URL
+          value: https://readest-hardcover-sync.k.oneill.net
+        - name: SLACK_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: readest-hardcover-sync
+              key: SLACK_WEBHOOK_URL
         - name: STATE_FILE
           value: /data/state.json
         - name: COVERS_DIR

--- a/kubernetes/readest-hardcover-sync/externalsecret.yaml
+++ b/kubernetes/readest-hardcover-sync/externalsecret.yaml
@@ -22,3 +22,7 @@ spec:
     remoteRef:
       key: readest-hardcover-sync
       property: HARDCOVER_TOKEN
+  - secretKey: SLACK_WEBHOOK_URL
+    remoteRef:
+      key: readest-hardcover-sync
+      property: SLACK_WEBHOOK_URL


### PR DESCRIPTION
Adds the Readest Sync public base URL and wires SLACK_WEBHOOK_URL through the existing ExternalSecret-backed Kubernetes Secret so the app can send Slack notifications with web UI links.

Validation: kubectl kustomize kubernetes/readest-hardcover-sync

1Password: SLACK_WEBHOOK_URL is present on the readest-hardcover-sync item.