### PR TITLE
Move issue triage to Codex

### DIFF
--- a/.github/workflows/issue-triage.yaml
+++ b/.github/workflows/issue-triage.yaml
@@ -15,10 +15,95 @@ on:
         required: false
         type: boolean
         default: false
+      provider:
+        description: AI provider for triage
+        required: false
+        type: choice
+        options:
+        - claude
+        - codex
+        default: codex
+      codex_runner_label:
+        description: Runner label for provider=codex
+        required: false
+        type: string
+        default: codex
+      codex_reasoning_effort:
+        description: Codex reasoning effort for provider=codex
+        required: false
+        type: string
+        default: xhigh
+      codex_agent_timeout:
+        description: Codex agent subprocess timeout in seconds; 0 disables the timeout
+        required: false
+        type: string
+        default: '1800'
+      codex_version:
+        description: Codex CLI npm package version
+        required: false
+        type: string
+        default: latest
 
 jobs:
+  resolve-provider:
+    runs-on: ubuntu-latest
+    outputs:
+      provider: ${{ steps.resolve.outputs.provider }}
+      runner_label: ${{ steps.resolve.outputs.runner_label }}
+      codex_reasoning_effort: ${{ steps.resolve.outputs.codex_reasoning_effort }}
+      codex_agent_timeout: ${{ steps.resolve.outputs.codex_agent_timeout }}
+      codex_version: ${{ steps.resolve.outputs.codex_version }}
+    steps:
+    - name: Resolve provider
+      id: resolve
+      env:
+        INPUT_PROVIDER: ${{ inputs.provider }}
+        INPUT_CODEX_RUNNER_LABEL: ${{ inputs.codex_runner_label }}
+        INPUT_CODEX_REASONING_EFFORT: ${{ inputs.codex_reasoning_effort }}
+        INPUT_CODEX_AGENT_TIMEOUT: ${{ inputs.codex_agent_timeout }}
+        INPUT_CODEX_VERSION: ${{ inputs.codex_version }}
+      run: |
+        PROVIDER="${INPUT_PROVIDER:-codex}"
+        CODEX_REASONING_EFFORT=""
+        CODEX_AGENT_TIMEOUT=""
+        CODEX_VERSION=""
+
+        case "$PROVIDER" in
+          claude)
+            RUNNER_LABEL="ubuntu-latest"
+            ;;
+          codex)
+            RUNNER_LABEL="${INPUT_CODEX_RUNNER_LABEL:-codex}"
+            CODEX_REASONING_EFFORT="${INPUT_CODEX_REASONING_EFFORT:-xhigh}"
+            CODEX_AGENT_TIMEOUT="${INPUT_CODEX_AGENT_TIMEOUT:-1800}"
+            CODEX_VERSION="${INPUT_CODEX_VERSION:-latest}"
+            if [[ -z "$RUNNER_LABEL" ]]; then
+              echo "Codex runner label must not be empty" >&2
+              exit 1
+            fi
+            if ! [[ "$CODEX_AGENT_TIMEOUT" =~ ^[0-9]+$ ]]; then
+              echo "Codex agent timeout must be a non-negative integer" >&2
+              exit 1
+            fi
+            ;;
+          *)
+            echo "Unsupported provider: $PROVIDER" >&2
+            exit 1
+            ;;
+        esac
+
+        {
+          echo "provider=$PROVIDER"
+          echo "runner_label=$RUNNER_LABEL"
+          echo "codex_reasoning_effort=$CODEX_REASONING_EFFORT"
+          echo "codex_agent_timeout=$CODEX_AGENT_TIMEOUT"
+          echo "codex_version=$CODEX_VERSION"
+        } >> "$GITHUB_OUTPUT"
+
   collect-issues:
     runs-on: ubuntu-latest
+    permissions:
+      issues: read
     outputs:
       matrix: ${{ steps.get-issues.outputs.matrix }}
       has_issues: ${{ steps.get-issues.outputs.has_issues }}
@@ -42,18 +127,27 @@ jobs:
         COUNT=$(echo "$ISSUES" | jq 'length')
         echo "Found $COUNT open issues"
         if [ "$COUNT" -eq 0 ]; then
-          echo "has_issues=false" >> "$GITHUB_OUTPUT"
-          echo 'matrix={"issue":[]}' >> "$GITHUB_OUTPUT"
+          {
+            echo "has_issues=false"
+            echo 'matrix={"issue":[]}'
+          } >> "$GITHUB_OUTPUT"
         else
-          echo "has_issues=true" >> "$GITHUB_OUTPUT"
-          echo "matrix=$(echo "$ISSUES" | jq -c '{issue: [.[].number]}')" >> "$GITHUB_OUTPUT"
+          MATRIX=$(echo "$ISSUES" | jq -c '{issue: [.[].number]}')
+          {
+            echo "has_issues=true"
+            echo "matrix=$MATRIX"
+          } >> "$GITHUB_OUTPUT"
         fi
 
   triage-issue:
     name: 'Triage #${{ matrix.issue }}'
-    runs-on: ubuntu-latest
-    needs: collect-issues
+    runs-on: ${{ needs.resolve-provider.outputs.runner_label }}
+    needs: [collect-issues, resolve-provider]
     if: needs.collect-issues.outputs.has_issues == 'true'
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -90,19 +184,9 @@ jobs:
         cp -r .tmp/superpowers/skills/verification-before-completion .claude/skills/
         ls -la .claude/skills/
 
-    - name: Run Claude Issue Triage
-      uses: anthropics/claude-code-action@86eb26bf0139bdd75acd15ea5f00f45ee0a284c2  # v1
-      with:
-        claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        github_token: ${{ github.token }}
-        claude_args: |
-          --model opus
-          --dangerously-skip-permissions
-        settings: |
-          {
-            "alwaysThinkingEnabled": true
-          }
-        prompt: |-
+    - name: Generate issue triage prompt
+      env:
+        PROMPT: |-
           # Issue Triage for  #${{ matrix.issue }}
 
           Repository: ${{ github.repository }}
@@ -138,7 +222,7 @@ jobs:
           - Follow ALL links found in issues/comments to check their status
           - Verify claims independently (if comment says "fixed in v2.0", check if v2.0 exists)
           - Don't trust - verify. Check actual state, not just what people say
-          - If one approach doesn't find info, try alternatives (gh, WebFetch, skopeo)
+          - If one approach doesn't find info, try alternatives (gh, curl, skopeo)
 
           **DO NOT SKIP THIS STEP.** Your triage quality depends on following these skills' discipline.
 
@@ -169,7 +253,7 @@ jobs:
 
           - **GitHub PRs:** `gh pr view {url} --json state,mergedAt,title`
           - **GitHub Issues:** `gh issue view {url} --json state,stateReason,title`
-          - **Other URLs:** Use WebFetch to check current status
+          - **Other URLs:** Use curl or available web-fetching tools to check current status
           - **Container images:** Use `skopeo list-tags docker://{image}` to check available versions
 
           **IMPORTANT:** This repo uses Renovate for dependency updates. Even if an upstream
@@ -293,6 +377,84 @@ jobs:
 
           **STATE_JSON** is a compact JSON object embedded in the HTML comment to track state:
           `{"status":"BLOCKED","upstreams":[{"url":"...","state":"open"}]}`
+      run: |
+        printf '%s\n' "$PROMPT" > /tmp/issue-triage-prompt.md
+
+    - name: Setup Node for Codex
+      if: needs.resolve-provider.outputs.provider == 'codex'
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+      with:
+        node-version: '24'
+
+    - name: Install Codex CLI
+      if: needs.resolve-provider.outputs.provider == 'codex'
+      env:
+        CODEX_VERSION: ${{ needs.resolve-provider.outputs.codex_version }}
+      run: npm install -g "@openai/codex@$CODEX_VERSION"
+
+    - name: Install Claude CLI
+      if: needs.resolve-provider.outputs.provider == 'claude'
+      run: npm install -g @anthropic-ai/claude-code
+
+    - name: Run Codex Issue Triage
+      if: needs.resolve-provider.outputs.provider == 'codex'
+      env:
+        GH_TOKEN: ${{ github.token }}
+        CODEX_AGENT_TIMEOUT: ${{ needs.resolve-provider.outputs.codex_agent_timeout }}
+        CODEX_REASONING_EFFORT: ${{ needs.resolve-provider.outputs.codex_reasoning_effort }}
+      run: |
+        set -o pipefail
+        export CODEX_HOME="${HOME}/.codex"
+        mkdir -p "$CODEX_HOME"
+
+        args=(
+          exec
+          --cd "$GITHUB_WORKSPACE"
+          --json
+          --output-last-message /tmp/codex-last-message.md
+          --dangerously-bypass-approvals-and-sandbox
+        )
+        if [[ -n "$CODEX_REASONING_EFFORT" ]]; then
+          args+=(
+            -c
+            "model_reasoning_effort=$(jq -cn --arg effort "$CODEX_REASONING_EFFORT" '$effort')"
+          )
+        fi
+        args+=(-)
+
+        if [[ "$CODEX_AGENT_TIMEOUT" == "0" ]]; then
+          codex "${args[@]}" < /tmp/issue-triage-prompt.md | tee /tmp/codex-output.jsonl
+        else
+          timeout "$CODEX_AGENT_TIMEOUT" codex "${args[@]}" < /tmp/issue-triage-prompt.md | tee /tmp/codex-output.jsonl
+        fi
+
+        if [[ ! -f /tmp/triage-result.json ]]; then
+          echo "Codex did not write /tmp/triage-result.json" >&2
+          if [[ -f /tmp/codex-last-message.md ]]; then
+            cat /tmp/codex-last-message.md >&2
+          fi
+          exit 1
+        fi
+
+    - name: Run Claude Issue Triage
+      if: needs.resolve-provider.outputs.provider == 'claude'
+      env:
+        GH_TOKEN: ${{ github.token }}
+        CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      run: |
+        set -o pipefail
+
+        claude -p \
+          --model opus \
+          --permission-mode bypassPermissions \
+          --output-format json \
+          < /tmp/issue-triage-prompt.md \
+          | tee /tmp/claude-output.json
+
+        if [[ ! -f /tmp/triage-result.json ]]; then
+          echo "Claude did not write /tmp/triage-result.json" >&2
+          exit 1
+        fi
 
     - name: Rename triage result with issue number
       env:

--- a/.github/workflows/renovate-eval.yaml
+++ b/.github/workflows/renovate-eval.yaml
@@ -276,12 +276,17 @@ jobs:
           sleep "$INTERVAL"
         done
 
+    - name: Set Codex home
+      run: |
+        CODEX_HOME="${HOME}/.codex"
+        mkdir -p "$CODEX_HOME"
+        echo "CODEX_HOME=$CODEX_HOME" >> "$GITHUB_ENV"
+
     - name: Evaluate
       uses: ./.claude/skills/renovate-eval
       env:
         EVAL_TRIGGER: ${{ needs.gate.outputs.trigger }}
         EVAL_FINGERPRINT: ${{ needs.gate.outputs.fingerprint }}
-        CODEX_HOME: /home/runner/.codex
       with:
         pr_number: ${{ matrix.pr }}
         mode: ${{ inputs.dry_run && 'dry-run' || 'post' }}


### PR DESCRIPTION
Default weekly issue triage to the Codex CLI while keeping Claude available as a manual fallback.

The workflow now resolves provider-specific runner settings, runs Codex with the same read-only triage contract, and keeps GitHub writes isolated to the existing post-results job.
