### PR TITLE
Add B-hyve valve watering metrics

### DIFF
--- a/kubernetes/hass/config/kustomization.yaml
+++ b/kubernetes/hass/config/kustomization.yaml
@@ -16,6 +16,7 @@ configMapGenerator:
   - packages__basement_clock.yaml=packages/basement_clock.yaml
   - packages__basement_entertainment.yaml=packages/basement_entertainment.yaml
   - packages__basement_humidifier_alert.yaml=packages/basement_humidifier_alert.yaml
+  - packages__bhyve_valve_metrics.yaml=packages/bhyve_valve_metrics.yaml
   - packages__birdfy.yaml=packages/birdfy.yaml
   - packages__ego_charger_maintenance.yaml=packages/ego_charger_maintenance.yaml
   - packages__landroid_mower_alert.yaml=packages/landroid_mower_alert.yaml

--- a/kubernetes/hass/config/packages/bhyve_valve_metrics.yaml
+++ b/kubernetes/hass/config/packages/bhyve_valve_metrics.yaml
@@ -1,0 +1,33 @@
+---
+template:
+
+- binary_sensor:
+  - name: Deck Raspberries Valve Open
+    unique_id: deck_raspberries_valve_open
+    state: "{{ is_state('valve.deck_raspberries_zone', 'open') }}"
+    availability: "{{ states('valve.deck_raspberries_zone') in ['open', 'opening', 'closing', 'closed'] }}"
+
+  - name: Deck Strawberries Valve Open
+    unique_id: deck_strawberries_valve_open
+    state: "{{ is_state('valve.deck_strawberries_zone', 'open') }}"
+    availability: "{{ states('valve.deck_strawberries_zone') in ['open', 'opening', 'closing', 'closed'] }}"
+
+  - name: Deck Peppers Valve Open
+    unique_id: deck_peppers_valve_open
+    state: "{{ is_state('valve.deck_peppers_zone', 'open') }}"
+    availability: "{{ states('valve.deck_peppers_zone') in ['open', 'opening', 'closing', 'closed'] }}"
+
+  - name: Deck Watermelons Valve Open
+    unique_id: deck_watermelons_valve_open
+    state: "{{ is_state('valve.deck_watermelons_zone', 'open') }}"
+    availability: "{{ states('valve.deck_watermelons_zone') in ['open', 'opening', 'closing', 'closed'] }}"
+
+  - name: Deck 2 Hanging Plants Valve Open
+    unique_id: deck_2_hanging_plants_valve_open
+    state: "{{ is_state('valve.deck_2_hanging_plants_zone', 'open') }}"
+    availability: "{{ states('valve.deck_2_hanging_plants_zone') in ['open', 'opening', 'closing', 'closed'] }}"
+
+  - name: Deck 2 Verbena Valve Open
+    unique_id: deck_2_verbena_valve_open
+    state: "{{ is_state('valve.deck_2_verbena_zone', 'open') }}"
+    availability: "{{ states('valve.deck_2_verbena_zone') in ['open', 'opening', 'closing', 'closed'] }}"


### PR DESCRIPTION
Adds Home Assistant template binary sensors that mirror the B-hyve valve open state for the plant watering zones. These give Prometheus stable boolean metrics for the Plants Grafana watering overlays after the B-hyve integration moved zone controls from switches to valves.

Validated with:
- pre-commit hooks during commit, including HASS config validation, kubeconform, kustomization formatting, and kyverno policy validation
- kubectl apply -k kubernetes/hass/config --dry-run=server