### PR TITLE
Disable garagepi Ethernet

### DIFF
--- a/ansible/host_vars/garagepi.yaml
+++ b/ansible/host_vars/garagepi.yaml
@@ -8,18 +8,7 @@ wifi_country: "US"
 wifi_ssid: "bleh"
 wifi_psk: "{{ vault_wifi_psk_bleh }}"
 
-# Static IP configuration (michaelrigart.interfaces role)
 interfaces_ether_interfaces:
-  - device: eth0
-    bootproto: static
-    address: "172.19.74.221"
-    netmask: "255.255.255.0"
-    dnsnameservers: 172.19.74.1
-    dnssearch: oneill.net
-    pre_up: "sysctl -w net.ipv6.conf.eth0.accept_ra=0"
-    ip6:
-      address: "{{ infrastructure_ipv6_prefix }}::74:221"
-      prefix: "{{ infrastructure_ipv6_netmask }}"
   - device: wlan0
     bootproto: static
     address: "172.19.74.216"

--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -106,26 +106,6 @@ locals {
       hostname = "garagepi.oneill.net"
       note     = "Raspberry Pi in garage - rtl433"
     }
-    garagepi-eth = {
-      mac      = "d8:3a:dd:1c:15:2f"
-      ip       = "172.19.74.221"
-      hostname = "garagepi-eth.oneill.net"
-      note     = "Raspberry Pi in garage - wired interface"
-    }
-    den-powerline = {
-      mac         = "b8:d5:26:f6:ff:72"
-      ip          = "172.19.74.147"
-      hostname    = "den-powerline.oneill.net"
-      note        = "Zyxel PLA6456 G.hn powerline adapter in den"
-      enable_ipv6 = false
-    }
-    garage-powerline = {
-      mac         = "b8:d5:26:f6:ff:73"
-      ip          = "172.19.74.151"
-      hostname    = "garage-powerline.oneill.net"
-      note        = "Zyxel PLA6456 G.hn powerline adapter in garage"
-      enable_ipv6 = false
-    }
     wr741nd = {
       mac         = "64:70:02:63:e6:cc"
       ip          = "172.20.6.81"


### PR DESCRIPTION
## Summary
- disable garagepi eth0 by keeping garagepi managed on Wi-Fi only
- remove `garagepi-eth` and the broken powerline adapter host reservations from OpenTofu
- remove the previous ifmetric/common-role workaround from this PR

## Validation
- `git diff --check`
- `ansible-playbook -i inventory/default site.yaml --limit garagepi --syntax-check`
- `ansible-inventory -i inventory/default --host garagepi | jq '.interfaces_ether_interfaces'`
- `tofu fmt -check -diff`
- pre-commit hooks on amend, including Terraform fmt/validate/tflint
- previously deployed with `cd ansible && ansible-playbook -i inventory/default site.yaml --limit garagepi`
- verified `/etc/network/interfaces.d/ifcfg-eth0` is absent, `eth0` is down with no addresses, `wlan0` is up with the default route, and `garagepi.oneill.net` ping succeeds
