### PR TITLE
Clean up Prometheus alerts

### DIFF
--- a/kubernetes/prometheus/config/prometheus.yml
+++ b/kubernetes/prometheus/config/prometheus.yml
@@ -12,7 +12,7 @@ alerting:
   - scheme: https
     static_configs:
     - targets:
-      - alertmanager.k.oneill.net:443
+      - alertmanager.k.oneill.net
 
 scrape_configs:
 - job_name: prometheus
@@ -46,9 +46,6 @@ scrape_configs:
     module: [icmp]
   static_configs:
   - targets:
-    - left-garage-door.oneill.net
-    - right-garage-door.oneill.net
-    - veraplus.oneill.net
     - udmp.oneill.net
     - basement-guardian.oneill.net
   relabel_configs:
@@ -66,13 +63,6 @@ scrape_configs:
   static_configs:
   - targets:
     - hass-home-assistant.hass:8080
-
-- job_name: vera
-  scrape_interval: 15s
-  metrics_path: /data_request?id=lr_prometheus_metrics
-  static_configs:
-  - targets:
-    - veraplus.oneill.net:3480
 
 - job_name: kubernetes-apiservers
 

--- a/kubernetes/prometheus/config/rules.yml
+++ b/kubernetes/prometheus/config/rules.yml
@@ -18,16 +18,12 @@ groups:
     expr: up{job!="node resources", job!="hwinfo gaming pc", resticprofile!~".+"}
       == 0
     for: 15m
-  - alert: CO2_PPM_Too_High
-    expr: awair_sensor_co2 > 1000
-    for: 5m
-    annotations:
-      message: Open a window or door!
-  - alert: Netatmo_Battery_Low
-    expr: netatmo_sensor_battery_percent < 20
-    for: 2h
   - alert: Outdoor_Sensor_Battery_Low
-    expr: hass_sensor_voltage_v{entity=~"sensor.*(soil|rain).*battery.*"} < 1.2
+    expr: >
+      (hass_sensor_voltage_v{entity=~"sensor.*(soil|rain).*battery.*"} < 1.2)
+      or
+      ((hass_sensor_voltage_mv{entity=~"sensor.*(soil|rain).*battery.*"} / 1000) <
+      1.2)
     for: 1h
     annotations:
       message: '{{ $labels.friendly_name }} is at {{ $value }}V - replace battery'
@@ -37,36 +33,10 @@ groups:
     for: 1d
     annotations:
       message: '{{ $labels.friendly_name }} has stopped reporting'
-  - alert: LessThanAnInchOfRain
-        # (sum_over_time(netatmo_sensor_rain_amount_mm[7d]) *25.4 /300) < bool 1 and (max_over_time(netatmo_sensor_temperature_celsius{module="Outdoor"}[7d])*9/5 + 32)  > bool 65
-    expr: sum_over_time(netatmo_sensor_rain_amount_mm[7d]) *25.4 /300 < 1
-    for: 1h
-    labels:
-      realert: daily
-    annotations:
-      message: There has been less than an inch of rain in the last week.  Maybe water
-        the yard?
-  - alert: OfficeHumidityLow
-        # Check if humidity in the office is low and the humidifier power draw
-        # is low.  If so, the humidifier is probably out of water.
-    expr: >
-      (
-        sum(hass_sensor_unit_percent{entity="sensor.office_humidity_bme280"} < bool
-      30)
-        +
-        sum(electricity_usage_w{description="Humidifier"} < bool 1)
-      ) >= 2
-    for: 5m
-    annotations:
-      message: Humidity in the office is low and the humidifier is not running.  Check
-        water levels.
-  - alert: DryboxHumidityHigh
-    expr: hass_sensor_unit_percent{entity="sensor.drybox_humidity"} > 30
-    for: 24h
-    labels:
-      realert: daily
   - alert: PodStuckNotRunning
-    expr: kube_pod_status_phase{phase!="Running", phase!="Succeeded"} == 1
+    expr: >
+      (kube_pod_status_phase{phase!="Running", phase!="Succeeded"} == 1)
+      unless on(namespace,pod) kube_pod_owner{owner_kind="Job"}
     for: 15m
     annotations:
       message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in {{ $labels.phase }}


### PR DESCRIPTION
Remove stale alert rules for old Netatmo, CO2, office humidity, and drybox metrics.

Point Prometheus at Alertmanager without an explicit :443 authority, remove decommissioned ICMP targets, and drop the unused Vera scrape job.

Ignore Job-owned pods in PodStuckNotRunning so completed or failed Jobs do not page as stuck application pods.