### PR TITLE
Add Autobrr Slack alerting

### DIFF
--- a/kubernetes/alertmanager/config.yaml
+++ b/kubernetes/alertmanager/config.yaml
@@ -16,7 +16,7 @@ route:
     # The labels by which incoming alerts are grouped together. For example,
     # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
     # be batched into a single group.
-    # group_by: ['alertname', 'cluster', 'service']
+  group_by: ['...']
 
     # A default receiver
     # If an alert isn't caught by a route, send it to default.
@@ -30,12 +30,18 @@ route:
   - match:
       realert: daily
     repeat_interval: 1d
-  - match:
-      severity: email
-    receiver: default
 
 receivers:
 - name: default
+  slack_configs:
+  - api_url_file: /secrets/SLACK_WEBHOOK_URL
+    channel: '#alerts'
+    send_resolved: true
+    color: '{{ if eq .Status "firing" }}danger{{ else }}good{{ end }}'
+    title: '{{ template "slack.alertmanager.title" . }}'
+    title_link: '{{ template "slack.default.titlelink" . }}'
+    text: '{{ template "slack.alertmanager.text" . }}'
+- name: email
   email_configs:
   - to: clayton.oneill@gmail.com
     send_resolved: true

--- a/kubernetes/alertmanager/externalsecret.yaml
+++ b/kubernetes/alertmanager/externalsecret.yaml
@@ -14,3 +14,7 @@ spec:
     remoteRef:
       key: smtp-relay
       property: relay-password
+  - secretKey: SLACK_WEBHOOK_URL
+    remoteRef:
+      key: alertmanager
+      property: SLACK_WEBHOOK_URL

--- a/kubernetes/alertmanager/templates/slack.tmpl
+++ b/kubernetes/alertmanager/templates/slack.tmpl
@@ -1,4 +1,7 @@
-{{ define "slack.devops.text" }}
-{{range .Alerts}}{{.Annotations.DESCRIPTION}}
-{{end}}
+{{ define "slack.alertmanager.title" -}}
+[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}]{{ with .CommonLabels.alertname }} {{ . }}{{ end }}
+{{- end }}
+
+{{ define "slack.alertmanager.text" -}}
+{{ printf "*Status:* %s" (.Status | toUpper) }}{{ range .Alerts }}{{ with .Annotations.message }}{{ printf "\n%s" . }}{{ else }}{{ with .Labels.alertname }}{{ printf "\n%s" . }}{{ end }}{{ end }}{{ with .Labels.instance }}{{ printf "\nInstance: %s" . }}{{ end }}{{ with .Labels.feed }}{{ printf "\nFeed: %s" . }}{{ end }}{{ with .Labels.network }}{{ printf "\nNetwork: %s" . }}{{ end }}{{ end }}
 {{ end }}

--- a/kubernetes/autobrr/deploy.yaml
+++ b/kubernetes/autobrr/deploy.yaml
@@ -24,6 +24,8 @@ spec:
         image: ghcr.io/autobrr/autobrr:v1.78.0@sha256:5641009f9d83b602bb455426e28a67d928960d26f173bccc886cbbb024cbfbab
         ports:
         - containerPort: 7474
+        - name: metrics
+          containerPort: 9074
         envFrom:
         - secretRef:
             name: autobrr-oidc

--- a/kubernetes/autobrr/kustomization.yaml
+++ b/kubernetes/autobrr/kustomization.yaml
@@ -10,6 +10,7 @@ commonAnnotations:
 resources:
 - deploy.yaml
 - service.yaml
+- service-metrics.yaml
 - ingress.yaml
 - externalsecret.yaml
 - pvc-config.yaml
@@ -21,6 +22,9 @@ configMapGenerator:
   - AUTOBRR__OIDC_DISABLE_BUILT_IN_LOGIN=false
   - AUTOBRR__OIDC_ISSUER=https://auth.k.oneill.net/application/o/autobrr/
   - AUTOBRR__OIDC_REDIRECT_URL=https://autobrr.k.oneill.net/api/auth/oidc/callback
+  - AUTOBRR__METRICS_ENABLED=true
+  - AUTOBRR__METRICS_HOST=0.0.0.0
+  - AUTOBRR__METRICS_PORT=9074
 
 labels:
 

--- a/kubernetes/autobrr/service-metrics.yaml
+++ b/kubernetes/autobrr/service-metrics.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: autobrr-metrics
+  labels:
+    app: autobrr
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: /metrics
+    prometheus.io/port: '9074'
+
+spec:
+  ports:
+  - port: 9074
+    targetPort: metrics
+    protocol: TCP
+    name: metrics
+  selector:
+    app: autobrr

--- a/kubernetes/prometheus/config/rules.yml
+++ b/kubernetes/prometheus/config/rules.yml
@@ -18,6 +18,21 @@ groups:
     expr: up{job!="node resources", job!="hwinfo gaming pc", resticprofile!~".+"}
       == 0
     for: 15m
+  - alert: AutobrrIRCUnhealthy
+    expr: >
+      autobrr_irc_enabled_total{app_kubernetes_io_name="autobrr"}
+      - autobrr_irc_healthy_total{app_kubernetes_io_name="autobrr"} > 0
+    for: 10m
+    annotations:
+      message: Autobrr has {{ $value }} enabled IRC network(s) unhealthy
+  - alert: AutobrrFeedOverdue
+    expr: >
+      time() - autobrr_feed_next_run_timestamp_seconds{app_kubernetes_io_name="autobrr"}
+      > 900
+    for: 10m
+    annotations:
+      message: Autobrr feed/indexer {{ $labels.feed }} has been more than 15 minutes
+        past its next scheduled run for 10 minutes
   - alert: Outdoor_Sensor_Battery_Low
     expr: >
       (hass_sensor_voltage_v{entity=~"sensor.*(soil|rain).*battery.*"} < 1.2)


### PR DESCRIPTION
Route the default Alertmanager receiver to Slack using a webhook sourced from the alertmanager 1Password item, while keeping email configured as an unused receiver.

Expose Autobrr's metrics endpoint through the Kubernetes service so Prometheus can scrape it, then alert when Autobrr reports unhealthy IRC networks or overdue feed/indexer runs.
