### PR TITLE
Harden acme-sh cronjobs

### DIFF
--- a/kubernetes/acme-sh/acme-common.sh
+++ b/kubernetes/acme-sh/acme-common.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+ACME_HOME="${ACME_HOME:-/acme.sh}"
+ACME_SH="${ACME_SH:-/usr/local/bin/acme.sh}"
+export HOME="$ACME_HOME"
+UDMP_SSH_KEY_SOURCE="${UDMP_SSH_KEY_SOURCE:-/var/run/secrets/acme-sh-ssh/id_rsa}"
+UDMP_SSH_DIR="${TMPDIR:-/tmp}/acme-sh-ssh"
+UDMP_SSH_KEY="${UDMP_SSH_DIR}/id_rsa"
+
+prepare_udmp_ssh_key() {
+  if [ ! -r "$UDMP_SSH_KEY_SOURCE" ]; then
+    echo "UDMP SSH key is not readable at ${UDMP_SSH_KEY_SOURCE}"
+    return 1
+  fi
+
+  mkdir -p "$UDMP_SSH_DIR"
+  cp "$UDMP_SSH_KEY_SOURCE" "$UDMP_SSH_KEY"
+  chmod 0700 "$UDMP_SSH_DIR"
+  chmod 0400 "$UDMP_SSH_KEY"
+
+  export DEPLOY_SSH_CMD="ssh -T -i ${UDMP_SSH_KEY}"
+}

--- a/kubernetes/acme-sh/acme-renew.sh
+++ b/kubernetes/acme-sh/acme-renew.sh
@@ -1,10 +1,14 @@
 #!/bin/sh
 set -e
 
+. /scripts/acme-common.sh
+
 echo "Starting acme.sh renewal check..."
+
+prepare_udmp_ssh_key
 
 # Run cron to handle renewal and deployment for all certificates
 echo "Running cron for renewal and deployment..."
-/usr/local/bin/acme.sh --cron
+"$ACME_SH" --cron
 
 echo "Renewal check completed successfully"

--- a/kubernetes/acme-sh/acme-udmp.sh
+++ b/kubernetes/acme-sh/acme-udmp.sh
@@ -1,20 +1,22 @@
 #!/bin/sh
 set -e
 
+. /scripts/acme-common.sh
+
 echo "Starting acme.sh certificate management for UDM Pro"
 
 # Register account with ZeroSSL (will succeed if not already registered)
 echo "Ensuring account is registered with ZeroSSL..."
-/usr/local/bin/acme.sh --register-account \
+"$ACME_SH" --register-account \
   --eab-kid "$ACME_EAB_KID" \
   --eab-hmac-key "$ACME_EAB_HMAC_KEY" \
   -m clayton@oneill.net || true
 
 # Check if certificate exists, issue if not
 echo "Checking certificate status..."
-if ! /usr/local/bin/acme.sh --info -d udmp.oneill.net | grep "^Le_" > /dev/null; then
+if ! "$ACME_SH" --info -d udmp.oneill.net | grep "^Le_" > /dev/null; then
   echo "Certificate does not exist, issuing new certificate..."
-  if ! /usr/local/bin/acme.sh --issue --dns dns_cf -d udmp.oneill.net -d router.oneill.net -k 2048; then
+  if ! "$ACME_SH" --issue --dns dns_cf -d udmp.oneill.net -d router.oneill.net -k 2048; then
     echo "Certificate issuance failed"
     exit 1
   fi
@@ -24,15 +26,14 @@ fi
 
 # Check if deploy hook is set, deploy if not
 echo "Checking deploy hook status..."
-if ! /usr/local/bin/acme.sh --info -d udmp.oneill.net | grep "^Le_DeployHook=" > /dev/null; then
+if ! "$ACME_SH" --info -d udmp.oneill.net | grep "^Le_DeployHook=" > /dev/null; then
   echo "Deploy hook not set, configuring SSH deployment..."
+
+  prepare_udmp_ssh_key
 
   # Set up SSH deploy environment variables
   export DEPLOY_SSH_USER="root"
   export DEPLOY_SSH_SERVER="udmp.oneill.net"
-
-  # Set SSH key path for root user
-  export HOME=/root
 
   # Use UnifiOS standard paths (as per official unifi deploy hook)
   export DEPLOY_SSH_FULLCHAIN="/data/unifi-core/config/unifi-core.crt"
@@ -43,7 +44,7 @@ if ! /usr/local/bin/acme.sh --info -d udmp.oneill.net | grep "^Le_DeployHook=" >
   export DEPLOY_SSH_MULTI_CALL="yes"
 
   # Deploy certificate via SSH
-  if ! /usr/local/bin/acme.sh --deploy -d udmp.oneill.net --deploy-hook ssh; then
+  if ! "$ACME_SH" --deploy -d udmp.oneill.net --deploy-hook ssh; then
     echo "Certificate deployment failed"
     exit 1
   fi

--- a/kubernetes/acme-sh/cronjob-renew.yaml
+++ b/kubernetes/acme-sh/cronjob-renew.yaml
@@ -11,9 +11,16 @@ spec:
     spec:
       template:
         spec:
+          automountServiceAccountToken: false
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
           containers:
           - name: acme-sh
-            image: neilpang/acme.sh:3.1.2@sha256:3c6b40e30e2c0c79863ba6ef5545d93350a040371213058099066ccd85b46aad
+            image: neilpang/acme.sh:3.1.3@sha256:3e7593e957e16edf357655bcd89164b81cd1634849df90e6dcb54891be9cc86b
             command: [/bin/sh, /scripts/acme-renew.sh]
             securityContext:
               allowPrivilegeEscalation: false
@@ -21,6 +28,8 @@ spec:
                 drop:
                 - ALL
               readOnlyRootFilesystem: false
+              seccompProfile:
+                type: RuntimeDefault
             volumeMounts:
             - name: acme-data
               mountPath: /acme.sh
@@ -28,7 +37,7 @@ spec:
               mountPath: /scripts
               readOnly: true
             - name: ssh-key
-              mountPath: /root/.ssh
+              mountPath: /var/run/secrets/acme-sh-ssh
               readOnly: true
             - name: ssh-config
               mountPath: /etc/ssh/ssh_config
@@ -55,7 +64,7 @@ spec:
               items:
               - key: udmp-ssh-key
                 path: id_rsa
-                mode: 0600
+                mode: 0440
           - name: ssh-config
             configMap:
               name: acme-sh-ssh-config

--- a/kubernetes/acme-sh/cronjob-synology.yaml
+++ b/kubernetes/acme-sh/cronjob-synology.yaml
@@ -11,9 +11,16 @@ spec:
     spec:
       template:
         spec:
+          automountServiceAccountToken: false
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
           containers:
           - name: acme-sh
-            image: neilpang/acme.sh:3.1.2@sha256:3c6b40e30e2c0c79863ba6ef5545d93350a040371213058099066ccd85b46aad
+            image: neilpang/acme.sh:3.1.3@sha256:3e7593e957e16edf357655bcd89164b81cd1634849df90e6dcb54891be9cc86b
             command: [/bin/sh, /scripts/acme-synology.sh]
             securityContext:
               allowPrivilegeEscalation: false
@@ -21,6 +28,8 @@ spec:
                 drop:
                 - ALL
               readOnlyRootFilesystem: false
+              seccompProfile:
+                type: RuntimeDefault
             env:
             - name: CF_Token
               valueFrom:

--- a/kubernetes/acme-sh/cronjob-udmp.yaml
+++ b/kubernetes/acme-sh/cronjob-udmp.yaml
@@ -11,9 +11,16 @@ spec:
     spec:
       template:
         spec:
+          automountServiceAccountToken: false
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
           containers:
           - name: acme-sh
-            image: neilpang/acme.sh:3.1.2@sha256:3c6b40e30e2c0c79863ba6ef5545d93350a040371213058099066ccd85b46aad
+            image: neilpang/acme.sh:3.1.3@sha256:3e7593e957e16edf357655bcd89164b81cd1634849df90e6dcb54891be9cc86b
             command: [/bin/sh, /scripts/acme-udmp.sh]
             securityContext:
               allowPrivilegeEscalation: false
@@ -21,6 +28,8 @@ spec:
                 drop:
                 - ALL
               readOnlyRootFilesystem: false
+              seccompProfile:
+                type: RuntimeDefault
             env:
             - name: CF_Token
               valueFrom:
@@ -50,7 +59,7 @@ spec:
               mountPath: /scripts
               readOnly: true
             - name: ssh-key
-              mountPath: /root/.ssh
+              mountPath: /var/run/secrets/acme-sh-ssh
               readOnly: true
             - name: ssh-config
               mountPath: /etc/ssh/ssh_config
@@ -77,7 +86,7 @@ spec:
               items:
               - key: udmp-ssh-key
                 path: id_rsa
-                mode: 0600
+                mode: 0440
           - name: ssh-config
             configMap:
               name: acme-sh-ssh-config

--- a/kubernetes/acme-sh/kustomization.yaml
+++ b/kubernetes/acme-sh/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
 configMapGenerator:
 - name: acme-sh-script
   files:
+  - acme-common.sh
   - acme-synology.sh
   - acme-udmp.sh
   - acme-renew.sh


### PR DESCRIPTION
Updates the acme-sh CronJobs to the Renovate 3.1.3 image pin from #2220 and runs the main containers as the upstream acme UID/GID 1000.

Local testing initially found the existing /acme.sh PVC still had root-owned files, so I repaired that ownership during validation. Per follow-up, the desired manifests do not carry a recurring permission-fix init container.

The shared ACME helper now sets HOME=/acme.sh immediately, and the UDM SSH key mounts from the Secret read-only and is copied into /tmp/acme-sh-ssh with strict permissions, avoiding /root and avoiding persistence on the PVC.

Validation: sh -n for acme-sh scripts; kubectl kustomize kubernetes/acme-sh; kubectl apply -k kubernetes/acme-sh --dry-run=server; kubectl apply -k kubernetes/acme-sh; triggered live no-init acme-synology-setup, acme-udmp-setup, and acme-renew Jobs from their CronJob templates; no-op no-init UDM SSH smoke test from the UDM CronJob template; UDM setup job after the HOME change; commit hooks.