### PR TITLE
Add xtal node metrics scrape

### DIFF
--- a/kubernetes/argocd/appset.yaml
+++ b/kubernetes/argocd/appset.yaml
@@ -40,3 +40,12 @@ spec:
         - CreateNamespace=true
         - ServerSideApply={{ if or (eq (index .path.segments 1) "external-secrets") (eq (index .path.segments 1) "cloudnative-pg") (eq (index .path.segments 1) "argocd") (eq (index .path.segments 1) "actions-runner-controller") }}true{{
           else }}false{{ end }}
+        - RespectIgnoreDifferences=true
+      ignoreDifferences:
+      # The Tailscale operator rewrites cluster-egress Services from the
+      # required placeholder externalName to generated proxy DNS names.
+      - group: ''
+        kind: Service
+        jqPathExpressions:
+        - '. | select(.metadata.annotations["tailscale.com/tailnet-fqdn"] != null
+          or .metadata.annotations["tailscale.com/tailnet-ip"] != null) | .spec.externalName'

--- a/kubernetes/prometheus/config/prometheus.yml
+++ b/kubernetes/prometheus/config/prometheus.yml
@@ -31,6 +31,10 @@ scrape_configs:
     - k3.oneill.net:9100
     - k4.oneill.net:9100
     - k5.oneill.net:9100
+  - targets:
+    - xtal-node-exporter.tailscale.svc.cluster.local:9100
+    labels:
+      instance: xtal:9100
 
 # scrape szamar via http on port 10445
 - job_name: hwinfo gaming pc

--- a/kubernetes/tailscale-operator/kustomization.yaml
+++ b/kubernetes/tailscale-operator/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
 - helm/templates/proxygrouppolicy.yaml
 - helm/templates/recorder.yaml
 - helm/templates/tailnet.yaml
+- xtal-node-exporter.yaml
 
 commonAnnotations:
   argoManaged: 'true'

--- a/kubernetes/tailscale-operator/xtal-node-exporter.yaml
+++ b/kubernetes/tailscale-operator/xtal-node-exporter.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: xtal-node-exporter
+  annotations:
+    tailscale.com/tailnet-fqdn: xtal.cow-banjo.ts.net
+
+spec:
+  type: ExternalName
+  # Required placeholder; the Tailscale operator replaces it with the generated
+  # cluster-egress proxy DNS name for the tailnet FQDN above.
+  externalName: placeholder
+  ports:
+  - name: metrics
+    port: 9100
+    protocol: TCP

--- a/opentofu/tailscale.tf
+++ b/opentofu/tailscale.tf
@@ -24,7 +24,7 @@ resource "tailscale_acl" "main" {
         },
 
         // Define access control lists for users, groups, autogroups, tags,
-        // Tailscale IP addresses, and subnet ranges.
+        // Tailscale IP addresses, users, tags, and subnet ranges.
         "acls": [
             // Allow users to access their own devices and general internet
             {
@@ -78,6 +78,14 @@ resource "tailscale_acl" "main" {
                 "action": "accept",
                 "src":    ["tag:k8s-operator"],
                 "dst":    ["tag:k8s:*"],
+            },
+
+            // Allow Kubernetes egress proxies to scrape xtal node_exporter
+            {
+                "action": "accept",
+                "src":    ["tag:k8s"],
+                "proto":  "tcp",
+                "dst":    ["claytono@github:9100"],
             },
         ],
 


### PR DESCRIPTION
Expose xtal node_exporter through the Tailscale operator and add it to Prometheus scraping.

- Add the ExternalName service and ArgoCD ignore for the operator-managed externalName

- Allow k8s-tagged Tailscale clients to reach xtal on port 9100
