### PR TITLE
Tighten Renovate eval report signal

### DIFF
--- a/.claude/skills/renovate-eval/prompts/auditor.md
+++ b/.claude/skills/renovate-eval/prompts/auditor.md
@@ -36,6 +36,11 @@ Check each of these against the embedded rubric:
   cross-referencing requirements?
 - **No deferrals:** Does the report follow the evaluator's rule 4 requirement to
   investigate rather than defer to the reader?
+- **Signal-to-noise:** Does the rendered report omit upstream changes that the
+  evidence says are disabled, unconfigured, pre-existing, hypothetical, or not
+  deployment-relevant? Treat evidence-only dismissals in the rendered report as
+  FEEDBACK unless they are needed to explain an actual hazard, merge blocker, or
+  operator action.
 
 Your job is to check whether the evaluator followed the rubric, not to
 substitute your own judgment for what the rubric says. If the rubric says X and
@@ -61,6 +66,25 @@ These checks verify the report is internally sound:
   - "High confidence" but Sources section is thin relative to the scope of
     claims made
   - Verdict contradicts the report's own risk discussion
+- **No release-note dumping:** Flag repeated upstream issues across multiple
+  sections, "does not affect this deployment" bullets in the rendered report,
+  and verdicts raised by evidence-only dismissals rather than actual deployed
+  behavior changes.
+
+  Common failure patterns that MUST be FEEDBACK:
+
+  - Bullets whose main point is an evidence-only dismissal, for example phrases
+    like "disabled by default", "not configured", "absent from the env block",
+    "not scraped today", "not automatically consumed", or "does not change
+    runtime behavior here". These phrases are examples, not an exhaustive or
+    hard-coded list.
+  - A section that explains how to enable a feature the PR did not enable and
+    the deployment does not currently use, unless the feature is a realistic
+    follow-up action explicitly tied to the verdict.
+  - The same upstream issue or endpoint-format change repeated in more than one
+    rendered section.
+  - A Caution or Risk verdict justified by dismissed or unconfigured upstream
+    changes instead of a deployed behavior change.
 
 ## 3. Evidence Judgment
 

--- a/.claude/skills/renovate-eval/prompts/eval-data-schema.md
+++ b/.claude/skills/renovate-eval/prompts/eval-data-schema.md
@@ -68,14 +68,15 @@ components. This renders as the first section under "The Deep Dive."
 ### performance_stability (string or null)
 
 Performance improvements, stability fixes, resource usage changes. Link each
-item to its PR or issue. Set to `null` if not applicable (section is omitted
-from rendered report).
+item to its PR or issue. Include only deployment-relevant effects; put
+non-applicable dismissals in the evidence file. Set to `null` if not applicable.
 
 ### features_ux (string or null)
 
-For EACH new feature: (1) what it does, (2) whether the user's config uses it,
-(3) how to enable it with specific config keys/commands. Set to `null` if not
-applicable.
+For EACH deployment-relevant new feature: (1) what it does, (2) whether the
+user's config uses it, (3) how to enable it with specific config keys/commands.
+Do not include disabled or unconfigured features unless they are a realistic
+operator action for this deployment. Set to `null` if not applicable.
 
 ### security (string or null)
 
@@ -84,20 +85,23 @@ on their config. Set to `null` if not applicable.
 
 ### key_fixes (string or null)
 
-Cross-reference bug fixes against actual config and usage patterns. Link each
-item to its PR or issue. Set to `null` if not applicable.
+Cross-reference bug fixes against actual config and usage patterns. Do not
+repeat items already covered in another section. Set to `null` if not
+applicable.
 
 ### newer_versions (string or null)
 
 Analysis of versions newer than what this PR proposes. Flag regressions in the
-proposed version that are fixed later. Set to `null` if not applicable (but
-document in evidence file why it was omitted).
+proposed version that are fixed later. Always include CVEs or security
+advisories introduced by the proposed version and fixed later, even when config
+relevance is unknown. Set to `null` if not applicable (but document in evidence
+file why it was omitted).
 
 ### hazards (required, string)
 
-ALWAYS required. List every breaking change, deprecation, and migration with
-deployment-specific impact assessment. If there are genuinely no hazards, write
-"None identified" with a brief explanation.
+ALWAYS required. List only breaking changes, deprecations, and migrations that
+affect configured or observed deployment paths. If there are genuinely no
+hazards, write "None identified" with a brief explanation.
 
 ### sources (required, non-empty array)
 

--- a/.claude/skills/renovate-eval/prompts/evaluator.md
+++ b/.claude/skills/renovate-eval/prompts/evaluator.md
@@ -77,6 +77,20 @@ your own independent research:
    `http.Client{Timeout: -1}` in `pkg/api/client.go:42`" not just "fixes a bug
    in the HTTP client."
 
+   **Report inclusion gate:** Only include an upstream item in `eval-data.json`
+   if it is introduced or resolved by this PR AND affects the deployed config, a
+   configured integration, or a concrete operator action. If an item is
+   disabled, unconfigured, pre-existing, hypothetical, or only useful as a
+   dismissal, document it in `eval-evidence.md` and omit it from the rendered
+   report.
+
+   This gate does NOT suppress introduced security vulnerabilities: if the
+   proposed version introduces a CVE or security advisory that was not present
+   in the current version, include it in `security` or `newer_versions` and let
+   it influence `renovate:risk` even when config relevance is unknown. If you
+   can prove the deployment cannot reach the vulnerable path, state that in the
+   impact assessment, but still report the introduced vulnerability.
+
    **CRITICAL: Verify before claiming.** When you assert that a feature is or is
    not configured (e.g., "no cron config present"), you MUST have read the
    actual config file and searched for the relevant keys. Do not guess based on
@@ -98,6 +112,10 @@ your own independent research:
    vulnerabilities. You may note pre-existing issues as context, but they must
    not drive the verdict or label.
 
+   Use `renovate:caution` only for deployment-relevant behavioral changes worth
+   validating. Disabled defaults, absent scrape config, speculative hardware
+   swaps, and irrelevant upstream fixes must not raise the label.
+
 6. **Check dependency interactions:** If related or bundled dependencies
    changed, assess version compatibility. If a bundled dependency is NOT
    changing, explicitly state that.
@@ -110,6 +128,9 @@ your own independent research:
    - If a newer version fixes bugs or regressions _introduced_ in the proposed
      version range (not present in the current version), flag this prominently —
      this should influence the verdict toward `renovate:risk`
+   - If a newer version fixes a CVE or security advisory _introduced_ in the
+     proposed version range, always flag it regardless of config relevance. This
+     should influence the verdict toward `renovate:risk`
    - Pre-existing issues (present in BOTH the current deployed version and the
      proposed version) do NOT change the risk level of this PR and must NOT
      influence the label. A CVE that exists in both versions is not a reason to


### PR DESCRIPTION
Tightens the Renovate eval prompts so rendered reports focus on deployment-relevant findings and operator actions.

This keeps evidence-only dismissals, disabled upstream features, and unconfigured behavior in the evidence file instead of letting them inflate report sections or risk labels.

Verified with:
- uv run pytest tests/ --cov --cov-report=term-missing