### PR TITLE
Update Renovate version constraints

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -434,7 +434,7 @@
     },
     {
       "description": "ESPHome: One month behind latest (auto-managed)",
-      "allowedVersions": "/^2026\\.3\\./",
+      "allowedVersions": "/^2026\\.4\\./",
       "matchDatasources": [
         "pypi"
       ],


### PR DESCRIPTION
This PR updates auto-managed version constraints in `.renovaterc` based on current data from endoflife.date and PyPI.

**Rules applied:**
- **MariaDB**: LTS versions at least 6 months old
- **PostgreSQL**: Major versions at least 6 months old
- **Home Assistant**: One month behind latest stable
- **ESPHome**: One month behind latest stable

Auto-generated by `scripts/update-renovate-versions.py`