### PR TITLE
Upgrade Dawarich with JWT secret

### DIFF
--- a/kubernetes/dawarich/deploy-sidekiq.yaml
+++ b/kubernetes/dawarich/deploy-sidekiq.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: sidekiq
-        image: freikin/dawarich:1.6.1@sha256:a884f69f19ce0f66992f3872d24544d1e587e133b8a003e072711aafc1e02429
+        image: freikin/dawarich:1.7.7@sha256:f7eea22def731ef98f0644b191c477917790bb0e5449b0014bac2f349ce178a7
         command: [bundle, exec, sidekiq]
         args: []
         env:
@@ -36,6 +36,11 @@ spec:
             secretKeyRef:
               name: dawarich-secrets
               key: SECRET_KEY_BASE
+        - name: JWT_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: dawarich-jwt-secrets
+              key: JWT_SECRET_KEY
         # Database credentials from CNPG
         - name: DATABASE_HOST
           value: dawarich-postgres-rw

--- a/kubernetes/dawarich/deploy-web.yaml
+++ b/kubernetes/dawarich/deploy-web.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: web
-        image: freikin/dawarich:1.6.1@sha256:a884f69f19ce0f66992f3872d24544d1e587e133b8a003e072711aafc1e02429
+        image: freikin/dawarich:1.7.7@sha256:f7eea22def731ef98f0644b191c477917790bb0e5449b0014bac2f349ce178a7
         command: [web-entrypoint.sh]
         args: [bin/rails, server, -p, '3000', -b, '::']
         ports:
@@ -49,6 +49,11 @@ spec:
             secretKeyRef:
               name: dawarich-secrets
               key: SECRET_KEY_BASE
+        - name: JWT_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: dawarich-jwt-secrets
+              key: JWT_SECRET_KEY
         # Database credentials from CNPG
         - name: DATABASE_HOST
           value: dawarich-postgres-rw

--- a/kubernetes/dawarich/externalsecret.yaml
+++ b/kubernetes/dawarich/externalsecret.yaml
@@ -29,6 +29,34 @@ apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 
 metadata:
+  name: dawarich-jwt-secrets
+  namespace: dawarich
+
+spec:
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  refreshPolicy: CreatedOnce
+  target:
+    name: dawarich-jwt-secrets
+    creationPolicy: Owner
+  # Password generators emit a field named `password`; rewrite it to the
+  # Dawarich env var name so the target Secret key is self-describing.
+  dataFrom:
+  - rewrite:
+    - regexp:
+        source: password
+        target: JWT_SECRET_KEY
+    sourceRef:
+      generatorRef:
+        kind: Password
+        name: dawarich-jwt-secret-key
+
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
   name: dawarich-valkey-config
   namespace: dawarich
 

--- a/kubernetes/dawarich/password-generators.yaml
+++ b/kubernetes/dawarich/password-generators.yaml
@@ -18,6 +18,21 @@ apiVersion: generators.external-secrets.io/v1alpha1
 kind: Password
 
 metadata:
+  name: dawarich-jwt-secret-key
+  namespace: dawarich
+
+spec:
+  length: 64
+  allowRepeat: true
+  noUpper: false
+  digits: 10
+  symbols: 0
+
+---
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+
+metadata:
   name: dawarich-valkey
   namespace: dawarich
 


### PR DESCRIPTION
Update the Dawarich web and Sidekiq images to 1.7.7.

Add a generated External Secrets password for JWT_SECRET_KEY and expose it to both Dawarich containers so the upgrade does not rely on the old unset JWT behavior.
