### PR TITLE
Remove garagepi-eth Smokeping target

### DIFF
--- a/kubernetes/smokeping-prober/config.yaml
+++ b/kubernetes/smokeping-prober/config.yaml
@@ -17,7 +17,6 @@ targets:
   - infra1.oneill.net
   - pantrypi.oneill.net
   - garagepi.oneill.net
-  - garagepi-eth.oneill.net
   - deck.oneill.net
   - fs2.oneill.net
   interval: 1s


### PR DESCRIPTION
Drop the garagepi-eth DNS target from the repo-managed smokeping-prober config so the duplicate Ethernet endpoint is no longer probed.

Keep garagepi.oneill.net in the internal host group.

Operational note: the classic Smokeping PVC config is not tracked in this repo; /config/Targets and matching backup files were cleaned live and deployment/smokeping was restarted.