### PR TITLE
Resize Hetzner box to 10 TB

### DIFF
--- a/opentofu/hetzner.tf
+++ b/opentofu/hetzner.tf
@@ -51,7 +51,7 @@ resource "random_password" "kopia_password" {
 
 resource "hcloud_storage_box" "backups" {
   location         = "fsn1" # Falkenstein, Germany
-  storage_box_type = "bx41" # 10 TB class
+  storage_box_type = "bx31" # 10 TB class
   name             = "homelab-backups"
   password         = random_password.storage_box_parent.result
   access_settings = {


### PR DESCRIPTION
Switch the managed Hetzner Storage Box from bx41 to bx31 so OpenTofu tracks the intended 10 TB plan after the live resize.
