### PR TITLE
Upgrade Dawarich with SMTP settings

### DIFF
--- a/kubernetes/dawarich/deploy-sidekiq.yaml
+++ b/kubernetes/dawarich/deploy-sidekiq.yaml
@@ -24,18 +24,39 @@ spec:
     spec:
       containers:
       - name: sidekiq
-        image: freikin/dawarich:1.7.7@sha256:f7eea22def731ef98f0644b191c477917790bb0e5449b0014bac2f349ce178a7
+        image: freikin/dawarich:1.7.8@sha256:dea326d03e728cd3b8d051b72d293cf375d0db6c00e22c55f338daedfdfdb3a4
         command: [bundle, exec, sidekiq]
         args: []
         env:
         - name: RAILS_ENV
           value: production
+        - name: DOMAIN
+          value: dawarich.k.oneill.net
+        - name: SMTP_SERVER
+          value: smtp.k.oneill.net
+        - name: SMTP_PORT
+          value: "587"
+        - name: SMTP_DOMAIN
+          value: oneill.net
+        - name: SMTP_USERNAME
+          value: relay@oneill.net
+        - name: SMTP_FROM
+          value: dawarich@oneill.net
+        - name: SMTP_AUTHENTICATION
+          value: plain
+        - name: SMTP_STARTTLS
+          value: "true"
         # Secret environment variables
         - name: SECRET_KEY_BASE
           valueFrom:
             secretKeyRef:
               name: dawarich-secrets
               key: SECRET_KEY_BASE
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: dawarich-smtp
+              key: SMTP_PASSWORD
         - name: JWT_SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/kubernetes/dawarich/deploy-web.yaml
+++ b/kubernetes/dawarich/deploy-web.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: web
-        image: freikin/dawarich:1.7.7@sha256:f7eea22def731ef98f0644b191c477917790bb0e5449b0014bac2f349ce178a7
+        image: freikin/dawarich:1.7.8@sha256:dea326d03e728cd3b8d051b72d293cf375d0db6c00e22c55f338daedfdfdb3a4
         command: [web-entrypoint.sh]
         args: [bin/rails, server, -p, '3000', -b, '::']
         ports:
@@ -43,12 +43,33 @@ spec:
           value: production
         - name: PHOTON_API_HOST
           value: photon.komoot.io
+        - name: DOMAIN
+          value: dawarich.k.oneill.net
+        - name: SMTP_SERVER
+          value: smtp.k.oneill.net
+        - name: SMTP_PORT
+          value: "587"
+        - name: SMTP_DOMAIN
+          value: oneill.net
+        - name: SMTP_USERNAME
+          value: relay@oneill.net
+        - name: SMTP_FROM
+          value: dawarich@oneill.net
+        - name: SMTP_AUTHENTICATION
+          value: plain
+        - name: SMTP_STARTTLS
+          value: "true"
         # Secret environment variables
         - name: SECRET_KEY_BASE
           valueFrom:
             secretKeyRef:
               name: dawarich-secrets
               key: SECRET_KEY_BASE
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: dawarich-smtp
+              key: SMTP_PASSWORD
         - name: JWT_SECRET_KEY
           valueFrom:
             secretKeyRef:
@@ -97,6 +118,8 @@ spec:
           value: https://dawarich.k.oneill.net/users/auth/openid_connect/callback
         - name: OIDC_PROVIDER_NAME
           value: Authentik
+        - name: ALLOW_EMAIL_PASSWORD_LOGIN
+          value: "false"
         volumeMounts:
         - name: public
           mountPath: /var/app/public

--- a/kubernetes/dawarich/externalsecret.yaml
+++ b/kubernetes/dawarich/externalsecret.yaml
@@ -57,6 +57,27 @@ apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 
 metadata:
+  name: dawarich-smtp
+  namespace: dawarich
+
+spec:
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  target:
+    name: dawarich-smtp
+    creationPolicy: Owner
+  data:
+  - secretKey: SMTP_PASSWORD
+    remoteRef:
+      key: smtp-relay
+      property: relay-password
+
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
   name: dawarich-valkey-config
   namespace: dawarich
 


### PR DESCRIPTION
Update Dawarich web and Sidekiq to 1.7.8.

Add SMTP relay configuration for Dawarich mailers and digest jobs using the existing relay secret, and keep Authentik-only login by setting ALLOW_EMAIL_PASSWORD_LOGIN=false.
