### PR TITLE
Increase Frank compaction reserve

### DIFF
--- a/kubernetes/frank/openclaw.json
+++ b/kubernetes/frank/openclaw.json
@@ -68,6 +68,9 @@
     "defaults": {
       "model": "openai-codex/gpt-5.5",
       "thinkingDefault": "xhigh",
+      "compaction": {
+        "reserveTokensFloor": 40000
+      },
       "sandbox": {
         "mode": "off",
         "workspaceAccess": "rw"


### PR DESCRIPTION
Set OpenClaw's compaction reserve token floor for Frank to 40000 so long Slack/task transcripts trigger compaction earlier instead of hitting the context limit reset path.
