### PR TITLE
Narrow Renovate Monday schedule

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -4,7 +4,7 @@
   ],
   "timezone": "America/New_York",
   "schedule": [
-    "after 2am and before 8am on monday"
+    "after 12am and before 2am on monday"
   ],
   "ignorePaths": [
     "ansible/galaxy/**"


### PR DESCRIPTION
Restrict the top-level Renovate schedule to Monday midnight through 3am Eastern so hosted runs cannot create the weekly batch later in the morning.
