### PR TITLE
Add tomato plant soil monitoring

### DIFF
--- a/kubernetes/hass/config/configuration.yaml
+++ b/kubernetes/hass/config/configuration.yaml
@@ -534,6 +534,31 @@ mqtt:
       manufacturer: Ecowitt
       via_device: rtl_433
 
+  - name: Soil Moisture (0f41c5)
+    unique_id: wh51_0f41c5_moisture
+    default_entity_id: sensor.tomato_plant_soil_moisture_0f41c5
+    state_topic: rtl_433/devices/Fineoffset-WH51/0f41c5
+    value_template: '{{ value_json.moisture }}'
+    unit_of_measurement: '%'
+    device_class: moisture
+    expire_after: 3600
+    json_attributes_topic: rtl_433/devices/Fineoffset-WH51/0f41c5
+    json_attributes_template: >-
+      {{
+        {
+          "battery_ok": value_json.battery_ok,
+          "battery_mV": value_json.battery_mV,
+          "boost": value_json.boost,
+          "ad_raw": value_json.ad_raw
+        } | tojson
+      }}
+    device:
+      identifiers: [wh51_0f41c5]
+      name: Tomato Plant
+      model: WH51
+      manufacturer: Ecowitt
+      via_device: rtl_433
+
   - name: Front Yard Containers Soil Moisture (0f170c)
     unique_id: wh51_0f170c_moisture
     default_entity_id: sensor.wh51_soil_moisture_0f170c_front_yard_containers_moisture
@@ -646,6 +671,17 @@ mqtt:
     expire_after: 3600
     device:
       identifiers: [wh51_0f1792]
+
+  - name: Soil Battery (0f41c5)
+    unique_id: wh51_0f41c5_battery
+    default_entity_id: sensor.tomato_plant_soil_battery_0f41c5
+    state_topic: rtl_433/devices/Fineoffset-WH51/0f41c5
+    value_template: '{{ (value_json.battery_mV / 1000) | round(3) }}'
+    unit_of_measurement: V
+    device_class: voltage
+    expire_after: 3600
+    device:
+      identifiers: [wh51_0f41c5]
 
   - name: Front Yard Containers Soil Battery (0f170c)
     unique_id: wh51_0f170c_battery
@@ -778,6 +814,18 @@ mqtt:
     expire_after: 3600
     device:
       identifiers: [wh51_0f1792]
+
+  - name: Soil Battery Low (0f41c5)
+    unique_id: wh51_0f41c5_battery_low
+    default_entity_id: binary_sensor.tomato_plant_soil_battery_low_0f41c5
+    state_topic: rtl_433/devices/Fineoffset-WH51/0f41c5
+    value_template: "{{ '1' if (value_json.battery_ok | float(0)) > 0 else '0' }}"
+    payload_on: '0'
+    payload_off: '1'
+    device_class: battery
+    expire_after: 3600
+    device:
+      identifiers: [wh51_0f41c5]
 
   - name: Front Yard Containers Soil Battery Low (0f170c)
     unique_id: wh51_0f170c_battery_low

--- a/kubernetes/hass/config/packages/bhyve_valve_metrics.yaml
+++ b/kubernetes/hass/config/packages/bhyve_valve_metrics.yaml
@@ -31,3 +31,8 @@ template:
     unique_id: deck_2_verbena_valve_open
     state: "{{ is_state('valve.deck_2_verbena_zone', 'open') }}"
     availability: "{{ states('valve.deck_2_verbena_zone') in ['open', 'opening', 'closing', 'closed'] }}"
+
+  - name: Deck 2 Tomato Plant Valve Open
+    unique_id: deck_2_tomato_plant_valve_open
+    state: "{{ is_state('valve.deck_2_left_side_soaker_hose_zone', 'open') }}"
+    availability: "{{ states('valve.deck_2_left_side_soaker_hose_zone') in ['open', 'opening', 'closing', 'closed'] }}"


### PR DESCRIPTION
Add MQTT entities for the tomato plant WH51 sensor and expose the Deck 2 tomato valve state for dashboards and watering automation metrics.