### PR TITLE
Update ESPHome to 2026.4.5

### DIFF
--- a/esphome/common/device-classes/crowpanel-p4-10.yaml
+++ b/esphome/common/device-classes/crowpanel-p4-10.yaml
@@ -18,6 +18,7 @@ psram:
   speed: 200MHz
 
 esp32:
+  board: esp32-p4_r3
   variant: esp32p4
   flash_size: 16MB
   cpu_frequency: 360MHz

--- a/esphome/scripts/esphome
+++ b/esphome/scripts/esphome
@@ -6,7 +6,7 @@
 set -Eeuo pipefail
 
 # ESPHome version
-ESPHOME_VERSION="2026.3.3"
+ESPHOME_VERSION="2026.4.5"
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
Bump the ESPHome wrapper to the checked-out 2026.4.5 release and set the CrowPanel ESP32-P4 board explicitly for that version.
