### PR TITLE
Tune xtal node exporter alerting

### DIFF
--- a/kubernetes/prometheus/config/rules.yml
+++ b/kubernetes/prometheus/config/rules.yml
@@ -9,8 +9,21 @@ groups:
 - name: alert.rules
   rules:
   - alert: NodeDown
-    expr: up{job="node resources"} == 0
+    expr: up{job="node resources", instance!="xtal:9100"} == 0
     for: 5m
+  - alert: XtalNodeExporterDown
+    expr: >
+      (up{job="node resources", instance="xtal:9100"} == 0)
+      and on()
+      (
+        histogram_count(
+          increase(smokeping_response_duration_seconds{host="xtal.oneill.net"}[5m])
+        ) > 0
+      )
+    for: 35m
+    annotations:
+      message: xtal is reachable by LAN ICMP, but node_exporter over Tailscale has
+        not been scraped for 35 minutes
   - alert: ICMPUnreachable
     expr: probe_success == 0
     for: 20m


### PR DESCRIPTION
## Summary
- Exclude `xtal:9100` from the generic `NodeDown` alert.
- Add `XtalNodeExporterDown`, gated by existing Smokeping reachability for `xtal.oneill.net`.
- Require 35 minutes of reachable-but-not-scraping before notifying.

## Intent / Non-goal
- This PR is intentionally about the actionable case: the laptop is reachable on the LAN, but the node_exporter scrape path through Tailscale is broken.
- It intentionally stops paging on generic laptop host-down behavior for `xtal`; as a laptop, sleep/off-network/unreachable states have been noisy and are not the signal this alert should represent.
- If we want visibility into full `xtal` unreachable periods later, that should be a separate low-urgency Smokeping-based alert, not restored generic `NodeDown` coverage.

## Backtest
- Screenshot window on 2026-06-22: old 5m behavior produced 13.50 alert-minutes; new 35m rule produced 0.00.
- Last 24h ending 2026-06-22 11:30 EDT: old 5m behavior produced 112.00 alert-minutes; new 35m rule produced 0.00.

## Verification
- `kubectl -n default exec -i deploy/prometheus -- promtool check rules /dev/stdin < kubernetes/prometheus/config/rules.yml`
- `kubectl apply -k kubernetes/prometheus --dry-run=server`
- `kubectl apply -k kubernetes/prometheus`
- `kubectl -n default rollout status deploy/prometheus --timeout=120s`
- Prometheus rules API shows `XtalNodeExporterDown` loaded with duration 2100 seconds and inactive.
- Commit hooks passed, including kubeconform and kyverno validation.