### PR TITLE
Fix Matter Thread routing on pantrypi

### DIFF
--- a/ansible/roles/matter/defaults/main.yaml
+++ b/ansible/roles/matter/defaults/main.yaml
@@ -5,4 +5,5 @@ matter_otbr_image: "openthread/border-router:latest@sha256:bc5e517a5e1cb2994d9fd
 matter_server_image: "ghcr.io/home-assistant-libs/python-matter-server:8.1.0@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a"
 
 matter_data_dir: /etc/matter
-matter_thread_data_dir: /var/lib/thread
+# OTBR stores both Thread and border-router state below /data in the container.
+matter_otbr_data_dir: /var/lib/otbr

--- a/ansible/roles/matter/tasks/main.yaml
+++ b/ansible/roles/matter/tasks/main.yaml
@@ -7,7 +7,28 @@
   loop:
     - "{{ matter_data_dir }}"
     - "{{ matter_data_dir }}/server-data"
-    - "{{ matter_thread_data_dir }}"
+    - "{{ matter_otbr_data_dir }}"
+
+- name: Configure IPv6 route learning for Thread border routers
+  ansible.posix.sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    sysctl_file: /etc/sysctl.d/99-matter-thread-routes.conf
+    reload: true
+    state: present
+  loop:
+    # 2 accepts Router Advertisements even though IPv6 forwarding is enabled.
+    - name: "net.ipv6.conf.{{ matter_backbone_interface }}.accept_ra"
+      value: "2"
+    # 0 ignores RA default routers so the static IPv6 gateway stays authoritative.
+    - name: "net.ipv6.conf.{{ matter_backbone_interface }}.accept_ra_defrtr"
+      value: "0"
+    # 64 accepts Thread border-router Route Information Options for /64 OMR routes.
+    - name: "net.ipv6.conf.{{ matter_backbone_interface }}.accept_ra_rt_info_max_plen"
+      value: "64"
+    # 0 disables SLAAC address creation so the static IPv6 address is preserved.
+    - name: "net.ipv6.conf.{{ matter_backbone_interface }}.autoconf"
+      value: "0"
 
 - name: Deploy matter docker-compose file
   ansible.builtin.template:

--- a/ansible/roles/matter/templates/docker-compose.yaml.j2
+++ b/ansible/roles/matter/templates/docker-compose.yaml.j2
@@ -10,7 +10,7 @@ services:
     devices:
       - {{ matter_device }}:/dev/ttyACM0
     volumes:
-      - {{ matter_thread_data_dir }}:/data/thread
+      - {{ matter_otbr_data_dir }}:/data
       - /run/udev:/run/udev:ro
     environment:
       OT_RCP_DEVICE: "spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=460800&uart-flow-control"


### PR DESCRIPTION
Persist the Matter/Thread routing fix for pantrypi.

This keeps OTBR data under a full /data mount and configures eth0 to accept IPv6 RA route information from Thread border routers without accepting RA default routes or SLAAC addresses. That lets the Matter server reach Thread devices through the Apple TV border router while preserving the host static network configuration.

Validated with the pantrypi Matter playbook, syntax check, targeted pre-commit, Home Assistant entity state, and Plannotator review.