### PR TITLE
Replace temp probes with AtomS3 Lite units

### DIFF
--- a/esphome/common/device-classes/m5stack_atoms3lite_kmeteriso.yaml
+++ b/esphome/common/device-classes/m5stack_atoms3lite_kmeteriso.yaml
@@ -1,0 +1,80 @@
+---
+# M5Stack AtomS3 Lite with a KMeterISO Unit on the Grove I2C port.
+esphome:
+  name: ${devicename}
+  on_boot:
+  - priority: 600
+    then:
+    - light.turn_on:
+        id: ${device_id}_rgb_led
+        brightness: 60%
+        red: 100%
+        green: 0%
+        blue: 0%
+
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
+  flash_size: 8MB
+  cpu_frequency: 240MHz
+  framework:
+    type: esp-idf
+
+logger:
+
+wifi:
+  on_connect:
+  - script.execute: ${device_id}_flash_green_led
+
+i2c:
+  sda: GPIO2
+  scl: GPIO1
+  frequency: 100kHz
+
+light:
+- platform: esp32_rmt_led_strip
+  id: ${device_id}_rgb_led
+  internal: true
+  pin: GPIO35
+  num_leds: 4
+  rgb_order: GRB
+  chipset: ws2812
+  restore_mode: ALWAYS_OFF
+  default_transition_length: 0s
+
+script:
+- id: ${device_id}_flash_green_led
+  mode: restart
+  then:
+  - light.turn_on:
+      id: ${device_id}_rgb_led
+      brightness: 60%
+      red: 0%
+      green: 100%
+      blue: 0%
+  - delay: 5s
+  - light.turn_off: ${device_id}_rgb_led
+
+binary_sensor:
+- platform: gpio
+  id: ${device_id}_button
+  pin:
+    number: GPIO41
+    mode: INPUT_PULLUP
+    inverted: true
+  name: ${human_devicename} Button
+  entity_category: diagnostic
+  filters:
+  - delayed_off: 10ms
+  on_press:
+  - script.execute: ${device_id}_flash_green_led
+
+sensor:
+- platform: kmeteriso
+  temperature:
+    id: ${device_id}_temperature
+    name: ${human_devicename} Temperature
+  internal_temperature:
+    id: ${device_id}_internal_temperature
+    name: ${human_devicename} Internal Temperature
+  update_interval: 10s

--- a/esphome/temp-probe1.yaml
+++ b/esphome/temp-probe1.yaml
@@ -4,10 +4,10 @@ substitutions:
   device_id: temp_probe1
   human_devicename: K-Type Thermocouple 1
   icon: mdi:temperature
-  mac: 4C:11:AE:0D:D3:27
+  mac: AC:A7:04:00:3D:34
   ip: 172.20.7.109
 
 packages:
   wifi: !include common/wifi.yaml
   base: !include common/base.yaml
-  d1_mini_max6675: !include common/device-classes/d1_mini_max6675.yaml
+  device_class: !include common/device-classes/m5stack_atoms3lite_kmeteriso.yaml

--- a/esphome/temp-probe2.yaml
+++ b/esphome/temp-probe2.yaml
@@ -4,10 +4,10 @@ substitutions:
   device_id: temp_probe2
   human_devicename: K-Type Thermocouple 2
   icon: mdi:temperature
-  mac: D8:F1:5B:14:71:13
-  ip: 172.20.5.133
+  mac: AC:A7:04:00:2F:94
+  ip: 172.20.4.113
 
 packages:
   wifi: !include common/wifi.yaml
   base: !include common/base.yaml
-  d1_mini_max6675: !include common/device-classes/d1_mini_max6675.yaml
+  device_class: !include common/device-classes/m5stack_atoms3lite_kmeteriso.yaml

--- a/opentofu/esphome-hosts.tf
+++ b/opentofu/esphome-hosts.tf
@@ -127,14 +127,14 @@ locals {
       note     = "ESPHome: Szamar Power"
     }
     temp-probe1 = {
-      mac      = "4C:11:AE:0D:D3:27"
+      mac      = "AC:A7:04:00:3D:34"
       ip       = "172.20.7.109"
       hostname = "temp-probe1.oneill.net"
       note     = "ESPHome: K-Type Thermocouple 1"
     }
     temp-probe2 = {
-      mac      = "D8:F1:5B:14:71:13"
-      ip       = "172.20.5.133"
+      mac      = "AC:A7:04:00:2F:94"
+      ip       = "172.20.4.113"
       hostname = "temp-probe2.oneill.net"
       note     = "ESPHome: K-Type Thermocouple 2"
     }


### PR DESCRIPTION
Updates temp-probe1 and temp-probe2 for the replacement M5Stack AtomS3 Lite hardware with KMeterISO units.

Changes:
- Add a shared AtomS3 Lite/KMeterISO ESPHome device class with Grove I2C, button handling, and RGB LED boot/status behavior.
- Update temp-probe1 and temp-probe2 MAC/IP/package configuration.
- Regenerate the ESPHome UniFi host map for the new probe reservations.

Verification:
- scripts/gen-esphome-hosts --check
- esphome config temp-probe1.yaml
- esphome config temp-probe2.yaml
- esphome compile temp-probe1.yaml
- esphome compile temp-probe2.yaml
- pre-commit hooks on commit