### PR TITLE
Calibrate renovate eval labels

### DIFF
--- a/.claude/renovate-eval.md
+++ b/.claude/renovate-eval.md
@@ -1,5 +1,11 @@
 # Renovate Eval Context
 
+## Role of This File
+
+This file provides repository context, discovery hints, available tools, and
+action-menu behavior. It does not redefine the shared `renovate:safe`,
+`renovate:caution`, `renovate:breaking`, or `renovate:risk` label semantics.
+
 ## Repo Layout
 
 - Kubernetes apps: `kubernetes/<app>/` with Helm values at `values.yaml` and
@@ -10,7 +16,11 @@
 - OpenTofu: `opentofu/*.tf`
 - Pre-commit hooks: `.pre-commit-config.yaml`
 
-## Deployment
+## Normal Validation and Deployment Actions
+
+These commands describe this repository's normal validation and deployment
+workflows. Needing one of these normal workflows is not, by itself, evidence for
+`renovate:caution`; the label still depends on the shared rubric.
 
 - Kubernetes deploys via ArgoCD on PR merge -- no manual deploy needed
 - Ansible deploys via Semaphore on merge to main

--- a/.claude/skills/renovate-eval/README.md
+++ b/.claude/skills/renovate-eval/README.md
@@ -87,13 +87,13 @@ managed separately.
 
 ## Labels
 
-| Label                | Meaning                                      |
-| -------------------- | -------------------------------------------- |
-| `renovate:safe`      | No concerns, straightforward update          |
-| `renovate:caution`   | Behavioral changes worth validating          |
-| `renovate:breaking`  | Breaking changes, needs config rework        |
-| `renovate:risk`      | Known issues, regressions, or low confidence |
-| `renovate:evaluated` | PR has been evaluated (always added)         |
+| Label                | Meaning                                                                 |
+| -------------------- | ----------------------------------------------------------------------- |
+| `renovate:safe`      | Routine for actual usage; normal validation may still be required       |
+| `renovate:caution`   | Concrete concern requiring targeted validation beyond normal validation |
+| `renovate:breaking`  | Breaking or incompatible change needing remediation                     |
+| `renovate:risk`      | Known issues, regressions, low confidence, or thin evidence             |
+| `renovate:evaluated` | PR has been evaluated (always added)                                    |
 
 ## Key Design Decisions
 

--- a/.claude/skills/renovate-eval/prompts/auditor.md
+++ b/.claude/skills/renovate-eval/prompts/auditor.md
@@ -23,6 +23,10 @@ Check each of these against the embedded rubric:
 
 - **Verdict calibration:** Does the verdict label match the Verdict Mapping
   criteria in the Report Format Specification?
+- **Normal-validation boundary:** If the verdict is `renovate:caution`, does the
+  report identify the specific behavior introduced by this PR, why the
+  repository's actual usage reaches that behavior, and what targeted validation
+  is needed beyond normal validation?
 - **CVE handling:** Does the report follow the evaluator's Security analysis
   rules and rule 5 ("Evaluate the change, not the current state")?
 - **Evidence-based overrides:** If the evaluator claims a risk doesn't apply,
@@ -85,6 +89,10 @@ These checks verify the report is internally sound:
     rendered section.
   - A Caution or Risk verdict justified by dismissed or unconfigured upstream
     changes instead of a deployed behavior change.
+  - A Caution verdict justified only by normal validation needs, routine
+    restarts, ordinary state/config presence, internal bug fixes, generic
+    runtime changes, security fixes without a separate introduced concern, or a
+    newer version existing without an introduced-regression link.
 
 ## 3. Evidence Judgment
 

--- a/.claude/skills/renovate-eval/prompts/eval-data-schema.md
+++ b/.claude/skills/renovate-eval/prompts/eval-data-schema.md
@@ -53,12 +53,16 @@ include one.
 
 One of:
 
-- `renovate:safe` — no concerns, straightforward update. Security patches that
-  fix CVEs without introducing behavioral changes are safe — the change reduces
-  risk without adding any.
-- `renovate:caution` — behavioral changes worth validating
-- `renovate:breaking` — breaking changes, needs config rework
-- `renovate:risk` — known issues, regressions, or low confidence
+- `renovate:safe` — routine for this repository's actual usage; normal
+  validation may still be required. Security patches or CVE fixes that do not
+  introduce a separate concrete concern remain safe because they reduce risk
+  rather than adding it.
+- `renovate:caution` — concrete, evidenced repo-relevant concern requiring
+  targeted validation beyond normal validation.
+- `renovate:breaking` — breaking or incompatible change; may require config,
+  code, workflow, or operational changes before merge.
+- `renovate:risk` — known issues, regressions, low confidence, or insufficient
+  evidence for a non-trivial change.
 
 ### update_scope (required, string)
 

--- a/.claude/skills/renovate-eval/prompts/evaluator.md
+++ b/.claude/skills/renovate-eval/prompts/evaluator.md
@@ -112,9 +112,33 @@ your own independent research:
    vulnerabilities. You may note pre-existing issues as context, but they must
    not drive the verdict or label.
 
-   Use `renovate:caution` only for deployment-relevant behavioral changes worth
-   validating. Disabled defaults, absent scrape config, speculative hardware
-   swaps, and irrelevant upstream fixes must not raise the label.
+   Normal validation does not raise the label. Every repository has a normal
+   dependency-update workflow, which may include tests, builds, smoke tests,
+   plans, renders, review, staging deploys, rollout checks, or other
+   project-specific gates. Do not use `renovate:caution` merely because that
+   normal workflow should be run.
+
+   Use `renovate:safe` when the PR appears routine for the repository's actual
+   usage: no known regression, no compatibility concern, no migration concern,
+   no relevant behavior/default/API/security/access change, and no targeted
+   validation need beyond the repository's normal workflow. Security patches or
+   CVE fixes that do not introduce a separate concrete concern remain
+   `renovate:safe`; they reduce risk rather than adding it.
+
+   Use `renovate:caution` only when the PR introduces a concrete, evidenced
+   concern that is relevant to the repository's actual usage and requires
+   targeted validation beyond the normal dependency-update workflow.
+
+   Caution-worthy concerns include: data/state/schema migration; changed
+   defaults affecting actual usage; API, CLI, protocol, auth, output, or
+   file-format compatibility change; permission, access, credential, or
+   trust-boundary expansion; runtime/platform/dependency change with known
+   compatibility concerns; operational behavior changes with plausible impact
+   such as lifecycle, concurrency, retry, timeout, scheduling, or resource
+   usage; or a known issue/regression in the proposed version relevant to actual
+   usage. If compatibility cannot be established because evidence is missing,
+   thin, or inconclusive for a non-trivial change, use `renovate:risk` instead
+   of `renovate:caution`.
 
 6. **Check dependency interactions:** If related or bundled dependencies
    changed, assess version compatibility. If a bundled dependency is NOT

--- a/.claude/skills/renovate-eval/prompts/report-format.md
+++ b/.claude/skills/renovate-eval/prompts/report-format.md
@@ -94,12 +94,16 @@ highest-risk-wins for the label.
 
 ## Verdict Mapping
 
-- 🟢 **Safe** (`renovate:safe`) — no concerns, straightforward update. Security
-  patches that fix CVEs without introducing behavioral changes are safe — the
-  change reduces risk without adding any.
-- 🟡 **Caution** (`renovate:caution`) — behavioral changes worth validating
-- 🟠 **Breaking** (`renovate:breaking`) — breaking changes, needs config rework
-- 🔴 **Risk** (`renovate:risk`) — known issues, regressions, or low confidence
+- 🟢 **Safe** (`renovate:safe`) — routine for this repository's actual usage;
+  normal validation may still be required. Security patches or CVE fixes that do
+  not introduce a separate concrete concern remain safe because they reduce risk
+  rather than adding it.
+- 🟡 **Caution** (`renovate:caution`) — concrete, evidenced repo-relevant
+  concern requiring targeted validation beyond normal validation.
+- 🟠 **Breaking** (`renovate:breaking`) — breaking or incompatible change; may
+  require config, code, workflow, or operational changes before merge.
+- 🔴 **Risk** (`renovate:risk`) — known issues, regressions, low confidence, or
+  insufficient evidence for a non-trivial change.
 
 Use Unicode emoji (not shortcodes like `:green_circle:`).
 


### PR DESCRIPTION
Clarify that normal validation does not raise renovate risk labels and preserve the safe handling for security-only fixes. Keep repo-specific validation context in the repo config, and add prompt regression coverage for the shared rubric.
