### PR TITLE
Expose Felix webhooks over Tailscale

### DIFF
--- a/kubernetes/felix/deployment.yaml
+++ b/kubernetes/felix/deployment.yaml
@@ -103,7 +103,7 @@ spec:
           readOnly: true
       containers:
       - name: hermes
-        image: docker.io/nousresearch/hermes-agent:v2026.6.5@sha256:9ad3b04ec916ea2c2da22358fd43b024c788d74073210695af88bfc2e63869b4
+        image: docker.io/nousresearch/hermes-agent:v2026.6.19@sha256:9f367c7756ef087661a361536a89f438d57a122b958dc23d82d456b1433e6e9e
         args:
         - gateway
         - run

--- a/kubernetes/felix/deployment.yaml
+++ b/kubernetes/felix/deployment.yaml
@@ -110,6 +110,8 @@ spec:
         ports:
         - name: gateway
           containerPort: 8642
+        - name: webhook
+          containerPort: 8644
         - name: dashboard
           containerPort: 9119
         env:

--- a/kubernetes/felix/kustomization.yaml
+++ b/kubernetes/felix/kustomization.yaml
@@ -11,11 +11,13 @@ resources:
 - namespace.yaml
 - deployment.yaml
 - service.yaml
+- service-webhook.yaml
 - service-dashboard.yaml
 - service-www.yaml
 - ingress.yaml
 - ingress-dashboard.yaml
 - ingress-www.yaml
+- tailscale-ingress-webhook.yaml
 - externalsecret.yaml
 - pvc.yaml
 - postgres.yaml

--- a/kubernetes/felix/service-webhook.yaml
+++ b/kubernetes/felix/service-webhook.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: felix-webhook
+
+spec:
+  selector:
+    app.kubernetes.io/name: felix
+    app.kubernetes.io/instance: felix
+  ports:
+  - name: webhook
+    protocol: TCP
+    port: 8644
+    targetPort: webhook

--- a/kubernetes/felix/tailscale-ingress-webhook.yaml
+++ b/kubernetes/felix/tailscale-ingress-webhook.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+
+metadata:
+  name: felix-webhook-tailscale
+  namespace: felix
+  annotations:
+    tailscale.com/tags: tag:felix
+
+spec:
+  ingressClassName: tailscale
+  tls:
+  - hosts:
+    - felix-webhook
+  rules:
+  - http:
+      paths:
+      - path: /webhooks
+        pathType: Prefix
+        backend:
+          service:
+            name: felix-webhook
+            port:
+              number: 8644

--- a/opentofu/tailscale.tf
+++ b/opentofu/tailscale.tf
@@ -21,6 +21,7 @@ resource "tailscale_acl" "main" {
             "tag:healthchecks": ["tag:k8s-operator"],
             "tag:netdata": ["tag:k8s-operator"],
             "tag:byparr": ["tag:k8s-operator"],
+            "tag:felix": ["tag:k8s-operator"],
         },
 
         // Define access control lists for users, groups, autogroups, tags,


### PR DESCRIPTION
Includes the Hermes agent upgrade from the Renovate branch and exposes the enabled Felix webhook adapter over Tailscale only.

Adds a dedicated felix-webhook service on port 8644, a Tailscale ingress at felix-webhook.cow-banjo.ts.net, and the Tailscale ACL tag owner needed for tag:felix.