### PR TITLE
Add yolo mode to renovate eval agents

### DIFF
--- a/.claude/skills/renovate-eval/README.md
+++ b/.claude/skills/renovate-eval/README.md
@@ -70,7 +70,8 @@ python3 .claude/skills/renovate-eval/renovate_eval.py render path/to/eval-data.j
 ### GitHub Actions
 
 This skill includes a composite GitHub Action in `action.yaml`. The action
-installs only the selected provider CLI.
+installs only the selected provider CLI and can install Superpowers for that
+provider.
 
 The `provider` input accepts `claude` or `codex`. If omitted, provider
 resolution order is explicit `provider` input, then `RENOVATE_EVAL_PROVIDER`,
@@ -80,6 +81,15 @@ CLI default model. `codex_reasoning_effort` defaults to empty so the composite
 action uses the Codex CLI default unless a caller overrides it. `agent_timeout`
 defaults to `600` seconds, and `0` disables the subprocess timeout. Callers that
 use higher reasoning effort or slower private runners can pass a larger timeout.
+The action passes `--yolo` by default through `yolo: true`; direct local script
+runs do not use yolo mode unless `--yolo` is passed.
+
+`install_superpowers` defaults to `true`. `superpowers_version` defaults to
+`latest`, which resolves the latest `obra/superpowers` GitHub release tag. Pass
+a release tag such as `v6.0.3`, a bare version such as `6.0.3`, or another git
+ref to pin the installed checkout. Claude uses the pinned checkout through
+`--plugin-dir`; Codex installs a temporary local marketplace backed by the same
+checkout.
 
 Provisioning working Codex subscription auth, persistent `CODEX_HOME`, and
 private runner state is out of scope for the action. That infrastructure is

--- a/.claude/skills/renovate-eval/action.yaml
+++ b/.claude/skills/renovate-eval/action.yaml
@@ -42,6 +42,20 @@ inputs:
     description: Codex CLI npm package version
     required: false
     default: latest
+  yolo:
+    description: Run the selected agent provider in yolo mode
+    required: false
+    default: 'true'
+  install_superpowers:
+    description: Install Superpowers for the selected agent provider
+    required: false
+    default: 'true'
+  superpowers_version:
+    description: >-
+      Superpowers release tag or git ref to install; latest resolves the latest
+      GitHub release
+    required: false
+    default: latest
   agent_timeout:
     description: Agent subprocess timeout in seconds; 0 disables the timeout
     required: false
@@ -104,6 +118,111 @@ runs:
     env:
       CODEX_VERSION: ${{ inputs.codex_version }}
     run: npm install -g "@openai/codex@$CODEX_VERSION"
+
+  - name: Install Superpowers
+    id: superpowers
+    shell: bash
+    env:
+      INPUT_INSTALL_SUPERPOWERS: ${{ inputs.install_superpowers }}
+      INPUT_SUPERPOWERS_VERSION: ${{ inputs.superpowers_version }}
+      INPUT_PROVIDER: ${{ steps.provider.outputs.provider }}
+    run: |
+      set -euo pipefail
+
+      case "$INPUT_INSTALL_SUPERPOWERS" in
+        true)
+          ;;
+        false|'')
+          echo "Superpowers install disabled"
+          exit 0
+          ;;
+        *)
+          echo "Unsupported install_superpowers value: $INPUT_INSTALL_SUPERPOWERS" >&2
+          exit 1
+          ;;
+      esac
+
+      superpowers_ref="$INPUT_SUPERPOWERS_VERSION"
+      if [[ -z "$superpowers_ref" || "$superpowers_ref" == "latest" ]]; then
+        latest_url=$(curl -fsSLI \
+          --retry 5 \
+          --retry-all-errors \
+          --retry-connrefused \
+          --retry-delay 2 \
+          --retry-max-time 60 \
+          --connect-timeout 10 \
+          --max-time 60 \
+          -o /dev/null \
+          -w '%{url_effective}' \
+          https://github.com/obra/superpowers/releases/latest)
+        superpowers_ref="${latest_url##*/}"
+      elif [[ "$superpowers_ref" =~ ^[0-9]+([.][0-9]+)+$ ]]; then
+        superpowers_ref="v$superpowers_ref"
+      fi
+
+      install_root=$(mktemp -d "${RUNNER_TEMP:-/tmp}/superpowers.XXXXXX")
+      checkout="$install_root/superpowers"
+      git -c advice.detachedHead=false clone \
+        --quiet \
+        --depth=1 \
+        --branch "$superpowers_ref" \
+        https://github.com/obra/superpowers \
+        "$checkout"
+
+      echo "Installed Superpowers from ref $superpowers_ref"
+
+      case "$INPUT_PROVIDER" in
+        claude)
+          if [[ ! -f "$checkout/.claude-plugin/plugin.json" ]]; then
+            echo "Superpowers checkout does not contain .claude-plugin/plugin.json" >&2
+            exit 1
+          fi
+          echo "claude_plugin_dir=$checkout" >> "$GITHUB_OUTPUT"
+          ;;
+        codex)
+          if [[ ! -f "$checkout/.codex-plugin/plugin.json" ]]; then
+            echo "Superpowers checkout does not contain .codex-plugin/plugin.json" >&2
+            exit 1
+          fi
+
+          marketplace="$install_root/codex-marketplace"
+          mkdir -p "$marketplace/.agents/plugins" "$marketplace/plugins"
+          ln -s "$checkout" "$marketplace/plugins/superpowers"
+          cat > "$marketplace/.agents/plugins/marketplace.json" <<'JSON'
+      {
+        "name": "renovate-eval-superpowers",
+        "interface": {
+          "displayName": "Renovate Eval Superpowers"
+        },
+        "plugins": [
+          {
+            "name": "superpowers",
+            "source": {
+              "source": "local",
+              "path": "./plugins/superpowers"
+            },
+            "policy": {
+              "installation": "AVAILABLE",
+              "authentication": "ON_INSTALL",
+              "products": [
+                "CODEX"
+              ]
+            },
+            "category": "Developer Tools"
+          }
+        ]
+      }
+      JSON
+          codex plugin remove superpowers@renovate-eval-superpowers --json >/dev/null 2>&1 || true
+          codex plugin marketplace remove renovate-eval-superpowers >/dev/null 2>&1 || true
+          codex plugin marketplace add "$marketplace" --json
+          codex plugin add superpowers --marketplace renovate-eval-superpowers --json
+          ;;
+        *)
+          echo "Unsupported provider for Superpowers install: $INPUT_PROVIDER" >&2
+          exit 1
+          ;;
+      esac
 
   - name: Install GitHub CLI
     shell: bash
@@ -184,8 +303,10 @@ runs:
       INPUT_CODEX_EVALUATOR_MODEL: ${{ inputs.codex_evaluator_model }}
       INPUT_CODEX_AUDITOR_MODEL: ${{ inputs.codex_auditor_model }}
       INPUT_CODEX_REASONING_EFFORT: ${{ inputs.codex_reasoning_effort }}
+      INPUT_YOLO: ${{ inputs.yolo }}
       INPUT_AGENT_TIMEOUT: ${{ inputs.agent_timeout }}
       INPUT_CI_TIMEOUT: ${{ inputs.ci_timeout }}
+      RENOVATE_EVAL_CLAUDE_PLUGIN_DIR: ${{ steps.superpowers.outputs.claude_plugin_dir }}
       ACTION_PATH: ${{ github.action_path }}
     run: |
       set -euo pipefail
@@ -210,6 +331,17 @@ runs:
       if [[ -n "$INPUT_CODEX_REASONING_EFFORT" ]]; then
         ARGS+=(--codex-reasoning-effort "$INPUT_CODEX_REASONING_EFFORT")
       fi
+      case "$INPUT_YOLO" in
+        true)
+          ARGS+=(--yolo)
+          ;;
+        false|'')
+          ;;
+        *)
+          echo "Unsupported yolo value: $INPUT_YOLO" >&2
+          exit 1
+          ;;
+      esac
       if [[ -n "$INPUT_AGENT_TIMEOUT" ]]; then
         ARGS+=(--agent-timeout "$INPUT_AGENT_TIMEOUT")
       fi

--- a/.claude/skills/renovate-eval/lib/agent_runner.py
+++ b/.claude/skills/renovate-eval/lib/agent_runner.py
@@ -48,6 +48,7 @@ def run_agent(
     session_id: str = "",
     resume: bool = False,
     disable_tools: bool = False,
+    yolo: bool = False,
     timeout: int | None = 600,
 ) -> dict[str, Any]:
     """Run an agent provider and return a normalized output dict."""
@@ -56,11 +57,14 @@ def run_agent(
         return _run_claude(
             role=role,
             prompt=prompt,
+            artifact_dir=artifact_dir,
+            repo_root=repo_root,
             output_json=output_json,
             model=model,
             session_id=session_id,
             resume=resume,
             disable_tools=disable_tools,
+            yolo=yolo,
             timeout=timeout,
         )
     return _run_codex(
@@ -74,6 +78,7 @@ def run_agent(
         session_id=session_id,
         resume=resume,
         disable_tools=disable_tools,
+        yolo=yolo,
         timeout=timeout,
     )
 
@@ -82,24 +87,32 @@ def _run_claude(
     *,
     role: str,
     prompt: str,
+    artifact_dir: str,
+    repo_root: str,
     output_json: str,
     model: str,
     session_id: str,
     resume: bool,
     disable_tools: bool,
+    yolo: bool,
     timeout: int | None,
 ) -> dict[str, Any]:
     if not model:
         raise RuntimeError(f"claude {role} requires a model")
 
-    cmd = [
-        "claude",
-        "-p",
-        "--model",
-        model,
-        "--permission-mode",
-        "bypassPermissions",
-    ]
+    artifact_dir = os.path.realpath(artifact_dir)
+    repo_root = os.path.realpath(repo_root)
+
+    cmd = ["claude", "-p", "--model", model]
+    if not disable_tools:
+        cmd.extend(["--add-dir", artifact_dir])
+        plugin_dirs = os.environ.get("RENOVATE_EVAL_CLAUDE_PLUGIN_DIR", "").strip()
+        if plugin_dirs:
+            for plugin_dir in plugin_dirs.split(os.pathsep):
+                if plugin_dir:
+                    cmd.extend(["--plugin-dir", os.path.realpath(plugin_dir)])
+    if yolo:
+        cmd.extend(["--permission-mode", "bypassPermissions"])
     if disable_tools:
         cmd.extend(["--tools", ""])
     cmd.extend(["--output-format", "json"])
@@ -112,6 +125,7 @@ def _run_claude(
         capture_output=True,
         text=True,
         timeout=timeout,
+        cwd=repo_root,
     )
 
     Path(output_json).write_text(result.stdout)
@@ -143,10 +157,13 @@ def _run_codex(
     session_id: str,
     resume: bool,
     disable_tools: bool,
+    yolo: bool,
     timeout: int | None,
 ) -> dict[str, Any]:
+    artifact_dir = os.path.realpath(artifact_dir)
     last_message = os.path.join(artifact_dir, f"{role}-last-message.md")
     raw_jsonl = os.path.join(artifact_dir, f"{role}-output.jsonl")
+    codex_cwd = repo_root
 
     cmd = ["codex", "exec"]
     if disable_tools:
@@ -164,13 +181,16 @@ def _run_codex(
         )
         for feature in CODEX_MINIMAL_MODE_DISABLED_FEATURES:
             cmd.extend(["--disable", feature])
-    else:
+    elif yolo:
         cmd.append("--dangerously-bypass-approvals-and-sandbox")
+    else:
+        codex_cwd = artifact_dir
+        cmd.extend(["--sandbox", "workspace-write", "--skip-git-repo-check"])
 
     cmd.extend(
         [
             "--cd",
-            repo_root,
+            codex_cwd,
             "--json",
             "--output-last-message",
             last_message,

--- a/.claude/skills/renovate-eval/lib/auditor.py
+++ b/.claude/skills/renovate-eval/lib/auditor.py
@@ -9,6 +9,10 @@ from pathlib import Path
 
 from .agent_runner import run_agent
 from .common import log
+from .evaluator import (
+    INITIAL_SUPERPOWERS_RESEARCH_BLOCK,
+    TARGETED_REVISION_SUPERPOWERS_BLOCK,
+)
 
 
 def _read_file(path: str) -> str:
@@ -49,6 +53,7 @@ def build_round_one_prompt(
     artifact_dir: str,
     report: str,
     evidence: str,
+    yolo: bool = False,
 ) -> str:
     """Build the auditor prompt for round 1."""
     auditor_md = _read_file(os.path.join(script_dir, "prompts", "auditor.md"))
@@ -64,6 +69,12 @@ def build_round_one_prompt(
 
     # Strip Output section from evaluator.md for the rubric
     evaluator_rubric = _strip_output_section(evaluator_md)
+    runtime_requirements = "\n\n".join(
+        (
+            INITIAL_SUPERPOWERS_RESEARCH_BLOCK.strip(),
+            TARGETED_REVISION_SUPERPOWERS_BLOCK.strip(),
+        )
+    )
 
     return f"""{preamble}
 
@@ -72,7 +83,11 @@ def build_round_one_prompt(
 The evaluator was given the following instructions. This is the authoritative
 reference for what rules the evaluator should have followed.
 
+Evaluator yolo mode was {"enabled" if yolo else "disabled"} for this run.
+
 {evaluator_rubric}
+
+{runtime_requirements}
 
 ---
 
@@ -135,6 +150,7 @@ def run_auditor(
     provider: str = "claude",
     reasoning_effort: str = "",
     session_id: str = "",
+    yolo: bool = False,
     timeout: int | None = 300,
 ) -> dict:
     """Run the auditor. Returns the parsed audit result."""
@@ -151,6 +167,7 @@ def run_auditor(
             artifact_dir=artifact_dir,
             report=report,
             evidence=evidence,
+            yolo=yolo,
         )
     else:
         if not session_id:
@@ -175,6 +192,7 @@ def run_auditor(
         session_id=session_id,
         resume=round_num > 1,
         disable_tools=True,
+        yolo=yolo,
         timeout=timeout,
     )
 

--- a/.claude/skills/renovate-eval/lib/evaluator.py
+++ b/.claude/skills/renovate-eval/lib/evaluator.py
@@ -10,12 +10,73 @@ from pathlib import Path
 from .agent_runner import run_agent
 
 
+INITIAL_SUPERPOWERS_RESEARCH_BLOCK = """
+## Required Superpowers Usage
+
+You MUST use relevant Superpowers skills if they are available.
+
+Use subagents when they are useful and subagent tools are available, especially
+for independent research slices that can run before writing the evaluation.
+
+Subagents must follow the execution-mode write policy above. They must not write
+`eval-data.json` or `eval-evidence.md`; the evaluator synthesizes their findings
+and writes the final artifacts.
+
+Document in `eval-evidence.md` whether Superpowers was available, which
+Superpowers skill(s) you used, and whether subagents were used. If Superpowers
+or subagent tools are unavailable, note that in `eval-evidence.md` and continue
+manually.
+"""
+
+
+TARGETED_REVISION_SUPERPOWERS_BLOCK = """
+## Targeted Revision Superpowers Usage
+
+This is a revision pass. Do not redo broad research already captured in
+`eval-evidence.md`.
+
+You MUST use relevant Superpowers skills if they are available.
+
+Use subagents when they are useful for auditor or validation feedback that needs
+independent verification and subagent tools are available.
+
+Subagents must follow the execution-mode write policy above. They must not write
+`eval-data.json` or `eval-evidence.md`; the evaluator synthesizes their findings
+and writes the final artifacts.
+
+Document in `eval-evidence.md` whether Superpowers was available, which
+Superpowers skill(s) you used during the revision, and whether targeted
+subagent checks were used. If no feedback item needs independent verification,
+say that in `eval-evidence.md`. If Superpowers or subagent tools are
+unavailable, note that in `eval-evidence.md` and continue manually.
+"""
+
+
 def _read_file(path: str) -> str:
     """Read file contents, return empty string if missing."""
     try:
         return Path(path).read_text()
     except FileNotFoundError:
         return ""
+
+
+def _execution_mode_block(yolo: bool) -> str:
+    if yolo:
+        return """## Execution Mode Write Policy
+
+Yolo mode is enabled. Temporary scratch files, caches, or probes are allowed
+when needed for research. Do not mutate repository files, deploy, restart,
+apply resources, push, merge, create or modify PR/GitHub state, or change
+persistent external resources.
+"""
+
+    return """## Execution Mode Write Policy
+
+Yolo mode is disabled. Do not create, modify, or delete any files except the
+specified output files. Do not mutate repository files, deploy, restart, apply
+resources, push, merge, create or modify PR/GitHub state, or change persistent
+external resources.
+"""
 
 
 def build_round_one_prompt(
@@ -25,6 +86,7 @@ def build_round_one_prompt(
     repo_root: str,
     context: str,
     instructions: str = "",
+    yolo: bool = False,
 ) -> str:
     """Build the evaluator prompt for round 1."""
     evaluator_md = _read_file(os.path.join(script_dir, "prompts", "evaluator.md"))
@@ -49,15 +111,19 @@ def build_round_one_prompt(
 
 You are running in **{context}** mode.
 
+{_execution_mode_block(yolo)}
+
 ## Data Files
 
 Read these files for your research:
+- **Repository root:** {repo_root}
 - **PR data:** {artifact_dir}/pr-data.md (metadata, file list with change counts — read this first)
 - **Full diff:** {artifact_dir}/pr-diff.patch (read selectively based on file list — skip large vendored/generated sections)
 - **CI status:** {artifact_dir}/ci-status.md
 - **Output schema:** {script_dir}/prompts/eval-data-schema.md
 {repo_context_line}
 {instructions_block}
+{INITIAL_SUPERPOWERS_RESEARCH_BLOCK}
 
 ## Output Files
 
@@ -71,6 +137,7 @@ def build_revision_prompt(
     script_dir: str,
     artifact_dir: str,
     instructions: str = "",
+    yolo: bool = False,
 ) -> str:
     """Build the revision prompt for round 2+."""
     instructions_block = ""
@@ -91,7 +158,8 @@ def build_revision_prompt(
         feedback_file = audit_fb
         feedback_source = "auditor"
 
-    return f"""The {feedback_source} reviewed your output and found issues. Read the feedback at
+    return (
+        f"""The {feedback_source} reviewed your output and found issues. Read the feedback at
 {feedback_file} and revise your evaluation data.
 
 Read the revision guidelines at {script_dir}/prompts/revision.md for how
@@ -99,7 +167,10 @@ to approach this revision.
 
 Run the validation subcommand after making changes:
 python3 {script_dir}/renovate_eval.py validate {artifact_dir}/eval-data.json
+{_execution_mode_block(yolo)}
 {instructions_block}"""
+        + TARGETED_REVISION_SUPERPOWERS_BLOCK
+    )
 
 
 def run_evaluator(
@@ -116,6 +187,7 @@ def run_evaluator(
     session_id: str = "",
     is_revision: bool = False,
     cost_suffix: str = "",
+    yolo: bool = False,
     timeout: int | None = 600,
 ) -> dict:
     """Run the evaluator. Returns the parsed claude JSON output.
@@ -132,6 +204,7 @@ def run_evaluator(
             repo_root=repo_root,
             context=context,
             instructions=instructions,
+            yolo=yolo,
         )
     else:
         if not session_id:
@@ -142,6 +215,7 @@ def run_evaluator(
             script_dir=script_dir,
             artifact_dir=artifact_dir,
             instructions=instructions,
+            yolo=yolo,
         )
 
     output = run_agent(
@@ -155,6 +229,7 @@ def run_evaluator(
         reasoning_effort=reasoning_effort,
         session_id=session_id,
         resume=round_num > 1 or is_revision,
+        yolo=yolo,
         timeout=timeout,
     )
 

--- a/.claude/skills/renovate-eval/prompts/evaluator.md
+++ b/.claude/skills/renovate-eval/prompts/evaluator.md
@@ -1,12 +1,16 @@
 # Renovate PR Evaluator
 
-## CRITICAL: Read-Only Constraint
+## CRITICAL: Write and Side-Effect Constraint
 
-You are strictly read-only. Do NOT create, modify, or delete any files or
-resources EXCEPT the two output files specified at the end of this prompt. Do
-NOT deploy, restart, or change anything. Do NOT run destructive commands. Only
-read files, run read-only commands (git log, curl, etc.), and write the two
-specified output files.
+Do NOT mutate repository files or persistent resources. Do NOT deploy, restart,
+apply resources, push, merge, create or modify PR/GitHub state, or run
+destructive commands.
+
+When yolo mode is disabled, do NOT create, modify, or delete any files or
+resources EXCEPT the two output files specified at the end of this prompt. When
+yolo mode is explicitly enabled by this prompt, temporary scratch files, caches,
+or probes are allowed for research, but all persistent side-effect bans still
+apply. Only the evaluator writes the final specified output files.
 
 ## Your Role
 

--- a/.claude/skills/renovate-eval/renovate_eval.py
+++ b/.claude/skills/renovate-eval/renovate_eval.py
@@ -42,8 +42,10 @@ def cmd_evaluate(args: argparse.Namespace) -> None:
         text=True,
         timeout=10,
     ).stdout.strip()
-    artifact_dir = tempfile.mkdtemp(
-        prefix=f"renovate-eval-{args.pr}.", dir=os.environ.get("TMPDIR", "/tmp")
+    artifact_dir = os.path.realpath(
+        tempfile.mkdtemp(
+            prefix=f"renovate-eval-{args.pr}.", dir=os.environ.get("TMPDIR", "/tmp")
+        )
     )
     report_dir = os.path.join(os.environ.get("TMPDIR", "/tmp"), "renovate-eval")
 
@@ -103,6 +105,7 @@ def _run_evaluate(
         args.auditor_model if provider == "claude" else args.codex_auditor_model
     )
     codex_reasoning_effort = args.codex_reasoning_effort if provider == "codex" else ""
+    yolo = bool(args.yolo)
     agent_timeout = None if args.agent_timeout == 0 else args.agent_timeout
 
     print("=== Renovate PR Evaluation ===")
@@ -116,6 +119,7 @@ def _run_evaluate(
         print(
             f"Codex reasoning effort: {codex_reasoning_effort or '(provider default)'}"
         )
+    print(f"Yolo mode: {'enabled' if yolo else 'disabled'}")
     if agent_timeout is None:
         print("Agent timeout: none")
     else:
@@ -204,6 +208,7 @@ def _run_evaluate(
                     instructions=args.instructions,
                     session_id=eval_session_id,
                     is_revision=use_revision,
+                    yolo=yolo,
                     cost_suffix=f"-a{validation_attempt}"
                     if validation_attempt > 1
                     else "",
@@ -325,6 +330,7 @@ def _run_evaluate(
                 provider=provider,
                 reasoning_effort=codex_reasoning_effort,
                 session_id=audit_session_id if auditor_has_run else "",
+                yolo=yolo,
                 timeout=agent_timeout,
             )
         except Exception as e:
@@ -477,6 +483,7 @@ def _run_evaluate(
         "rounds": final_round,
         "status": status,
         "provider": provider,
+        "yolo": yolo,
     }
     with open(os.path.join(artifact_dir, "result.json"), "w") as f:
         json.dump(result, f, indent=2)
@@ -836,6 +843,14 @@ def main() -> None:
         "--codex-reasoning-effort",
         default=os.environ.get("RENOVATE_EVAL_CODEX_REASONING_EFFORT", ""),
         choices=["", "low", "medium", "high", "xhigh"],
+    )
+    p_eval.add_argument(
+        "--yolo",
+        action="store_true",
+        help=(
+            "Run the selected agent provider in yolo mode. "
+            "Use only in externally sandboxed environments."
+        ),
     )
     p_eval.add_argument(
         "--agent-timeout",

--- a/.claude/skills/renovate-eval/tests/test_action.py
+++ b/.claude/skills/renovate-eval/tests/test_action.py
@@ -1,0 +1,38 @@
+"""Static checks for the composite GitHub Action."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ACTION_YAML = Path(__file__).resolve().parents[1] / "action.yaml"
+
+
+def test_action_installs_superpowers_by_default():
+    action = ACTION_YAML.read_text()
+
+    assert "install_superpowers:" in action
+    assert "default: 'true'" in action
+    assert "superpowers_version:" in action
+    assert "default: latest" in action
+    assert "https://github.com/obra/superpowers/releases/latest" in action
+    assert "git -c advice.detachedHead=false clone" in action
+    assert '--branch "$superpowers_ref"' in action
+
+
+def test_action_wires_superpowers_for_claude_and_codex():
+    action = ACTION_YAML.read_text()
+
+    assert "claude_plugin_dir=$checkout" in action
+    assert (
+        "RENOVATE_EVAL_CLAUDE_PLUGIN_DIR: "
+        "${{ steps.superpowers.outputs.claude_plugin_dir }}" in action
+    )
+    assert ".claude-plugin/plugin.json" in action
+    assert ".codex-plugin/plugin.json" in action
+    assert "renovate-eval-superpowers" in action
+    assert 'codex plugin marketplace add "$marketplace" --json' in action
+    assert (
+        "codex plugin add superpowers --marketplace renovate-eval-superpowers --json"
+        in action
+    )

--- a/.claude/skills/renovate-eval/tests/test_agent_runner.py
+++ b/.claude/skills/renovate-eval/tests/test_agent_runner.py
@@ -93,6 +93,7 @@ def test_run_claude_writes_output(monkeypatch, tmp_dir):
     def mock_run(cmd, **kwargs):
         called["cmd"] = cmd
         called["input"] = kwargs["input"]
+        called["cwd"] = kwargs["cwd"]
         return subprocess.CompletedProcess(cmd, 0, json.dumps(output), "")
 
     monkeypatch.setattr("lib.agent_runner.subprocess.run", mock_run)
@@ -109,10 +110,83 @@ def test_run_claude_writes_output(monkeypatch, tmp_dir):
     )
 
     assert called["cmd"][:4] == ["claude", "-p", "--model", "opus"]
+    assert called["cmd"][called["cmd"].index("--add-dir") + 1] == os.path.realpath(
+        tmp_dir
+    )
+    assert "--permission-mode" not in called["cmd"]
     assert called["input"] == "prompt"
+    assert called["cwd"] == "/repo"
     assert result["provider"] == "claude"
     with open(output_json) as f:
         assert json.load(f)["session_id"] == "abc"
+
+
+def test_run_claude_uses_superpowers_plugin_dir(monkeypatch, tmp_dir):
+    output = {"session_id": "abc", "result": "ok", "usage": {}}
+    called = {}
+    plugin_dir = os.path.join(tmp_dir, "superpowers")
+    second_plugin_dir = os.path.join(tmp_dir, "other-plugin")
+
+    def mock_run(cmd, **kwargs):
+        called["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, json.dumps(output), "")
+
+    monkeypatch.setattr("lib.agent_runner.subprocess.run", mock_run)
+    monkeypatch.setenv(
+        "RENOVATE_EVAL_CLAUDE_PLUGIN_DIR",
+        os.pathsep.join([plugin_dir, second_plugin_dir]),
+    )
+
+    run_agent(
+        provider="claude",
+        role="evaluator",
+        prompt="prompt",
+        artifact_dir=tmp_dir,
+        repo_root="/repo",
+        output_json=os.path.join(tmp_dir, "claude-output.json"),
+        model="opus",
+    )
+
+    plugin_dirs = [
+        called["cmd"][i + 1]
+        for i, arg in enumerate(called["cmd"])
+        if arg == "--plugin-dir"
+    ]
+    assert plugin_dirs == [
+        os.path.realpath(plugin_dir),
+        os.path.realpath(second_plugin_dir),
+    ]
+
+
+def test_run_claude_yolo_mode_uses_bypass_permissions(monkeypatch, tmp_dir):
+    output = {"session_id": "abc", "result": "ok", "usage": {}}
+    called = {}
+
+    def mock_run(cmd, **kwargs):
+        called["cmd"] = cmd
+        called["cwd"] = kwargs["cwd"]
+        return subprocess.CompletedProcess(cmd, 0, json.dumps(output), "")
+
+    monkeypatch.setattr("lib.agent_runner.subprocess.run", mock_run)
+
+    run_agent(
+        provider="claude",
+        role="evaluator",
+        prompt="prompt",
+        artifact_dir=tmp_dir,
+        repo_root="/repo",
+        output_json=os.path.join(tmp_dir, "claude-output.json"),
+        model="opus",
+        yolo=True,
+    )
+
+    assert called["cmd"][called["cmd"].index("--permission-mode") + 1] == (
+        "bypassPermissions"
+    )
+    assert called["cmd"][called["cmd"].index("--add-dir") + 1] == os.path.realpath(
+        tmp_dir
+    )
+    assert called["cwd"] == "/repo"
 
 
 def test_run_claude_disable_tools_and_resume(monkeypatch, tmp_dir):
@@ -121,6 +195,7 @@ def test_run_claude_disable_tools_and_resume(monkeypatch, tmp_dir):
 
     def mock_run(cmd, **kwargs):
         called["cmd"] = cmd
+        called["cwd"] = kwargs["cwd"]
         return subprocess.CompletedProcess(cmd, 0, json.dumps(output), "")
 
     monkeypatch.setattr("lib.agent_runner.subprocess.run", mock_run)
@@ -139,8 +214,11 @@ def test_run_claude_disable_tools_and_resume(monkeypatch, tmp_dir):
     )
 
     assert "--tools" in called["cmd"]
+    assert "--add-dir" not in called["cmd"]
+    assert "--plugin-dir" not in called["cmd"]
     assert called["cmd"][called["cmd"].index("--tools") + 1] == ""
     assert called["cmd"][-2:] == ["--resume", "session-123"]
+    assert called["cwd"] == "/repo"
 
 
 def test_run_codex_uses_thread_id_and_last_message(monkeypatch, tmp_dir):
@@ -181,13 +259,12 @@ def test_run_codex_uses_thread_id_and_last_message(monkeypatch, tmp_dir):
         output_json=output_json,
     )
 
-    assert called["cmd"][:5] == [
-        "codex",
-        "exec",
-        "--dangerously-bypass-approvals-and-sandbox",
-        "--cd",
-        "/repo",
-    ]
+    assert called["cmd"][:2] == ["codex", "exec"]
+    assert "--dangerously-bypass-approvals-and-sandbox" not in called["cmd"]
+    assert called["cmd"][called["cmd"].index("--sandbox") + 1] == "workspace-write"
+    assert "--skip-git-repo-check" in called["cmd"]
+    assert "--add-dir" not in called["cmd"]
+    assert called["cmd"][called["cmd"].index("--cd") + 1] == os.path.realpath(tmp_dir)
     assert called["cmd"][-1] == "-"
     assert called["input"] == "prompt"
     assert result["session_id"] == "thread-123"
@@ -198,6 +275,36 @@ def test_run_codex_uses_thread_id_and_last_message(monkeypatch, tmp_dir):
     assert saved["provider"] == "codex"
     assert saved["usage"]["input_tokens"] == 100
     assert saved["usage"]["cache_read_input_tokens"] == 25
+
+
+def test_run_yolo_mode_uses_codex_bypass(monkeypatch, tmp_dir):
+    raw = json.dumps({"type": "thread.started", "thread_id": "thread-123"})
+    called = {}
+
+    def mock_run(cmd, **kwargs):
+        called["cmd"] = cmd
+        last_message = cmd[cmd.index("--output-last-message") + 1]
+        with open(last_message, "w") as f:
+            f.write("final answer")
+        return subprocess.CompletedProcess(cmd, 0, raw, "")
+
+    monkeypatch.setattr("lib.agent_runner.subprocess.run", mock_run)
+
+    run_agent(
+        provider="codex",
+        role="evaluator",
+        prompt="prompt",
+        artifact_dir=tmp_dir,
+        repo_root="/repo",
+        output_json=os.path.join(tmp_dir, "codex-output.json"),
+        yolo=True,
+    )
+
+    assert "--dangerously-bypass-approvals-and-sandbox" in called["cmd"]
+    assert "--sandbox" not in called["cmd"]
+    assert "--skip-git-repo-check" not in called["cmd"]
+    assert "--add-dir" not in called["cmd"]
+    assert called["cmd"][called["cmd"].index("--cd") + 1] == "/repo"
 
 
 def test_run_codex_minimal_mode_disables_tool_surfaces(monkeypatch, tmp_dir):
@@ -223,6 +330,7 @@ def test_run_codex_minimal_mode_disables_tool_surfaces(monkeypatch, tmp_dir):
         output_json=output_json,
         model="gpt-5.2",
         disable_tools=True,
+        yolo=True,
     )
 
     assert "--dangerously-bypass-approvals-and-sandbox" not in called["cmd"]

--- a/.claude/skills/renovate-eval/tests/test_auditor.py
+++ b/.claude/skills/renovate-eval/tests/test_auditor.py
@@ -62,14 +62,23 @@ class TestBuildRoundOnePrompt:
             artifact_dir="/tmp/art",
             report="# Report content",
             evidence="## Evidence",
+            yolo=True,
         )
         assert "Preamble" in prompt
         assert "## Research" in prompt
         assert "## Output" not in prompt
+        assert "Evaluator yolo mode was enabled" in prompt
         assert "Format spec" in prompt
         assert "# Report content" in prompt
         assert "## Evidence" in prompt
         assert "Audit instructions" in prompt
+        assert "Required Superpowers Usage" in prompt
+        assert "Targeted Revision Superpowers Usage" in prompt
+        assert (
+            "You MUST use relevant Superpowers skills if they are available" in prompt
+        )
+        assert "Superpowers skill(s) you used" in prompt
+        assert "dispatching-parallel-agents" not in prompt
 
 
 class TestBuildRevisionPrompt:

--- a/.claude/skills/renovate-eval/tests/test_evaluator.py
+++ b/.claude/skills/renovate-eval/tests/test_evaluator.py
@@ -62,6 +62,48 @@ class TestBuildRoundOnePrompt:
         )
         assert "Focus on security" in prompt
 
+    def test_includes_superpowers_guidance(self, tmp_dir):
+        prompts_dir = os.path.join(tmp_dir, "prompts")
+        os.makedirs(prompts_dir)
+        with open(os.path.join(prompts_dir, "evaluator.md"), "w") as f:
+            f.write("evaluator")
+
+        prompt = build_round_one_prompt(
+            script_dir=tmp_dir,
+            artifact_dir="/tmp/art",
+            repo_root="/tmp/repo",
+            context="local",
+        )
+
+        assert "- **Repository root:** /tmp/repo" in prompt
+        assert "Yolo mode is disabled" in prompt
+        assert "Required Superpowers Usage" in prompt
+        assert (
+            "You MUST use relevant Superpowers skills if they are available" in prompt
+        )
+        assert "Use subagents when they are useful" in prompt
+        assert "Subagents must follow the execution-mode write policy above" in prompt
+        assert "Superpowers skill(s) you used" in prompt
+        assert "dispatching-parallel-agents" not in prompt
+
+    def test_yolo_prompt_allows_temp_research_files(self, tmp_dir):
+        prompts_dir = os.path.join(tmp_dir, "prompts")
+        os.makedirs(prompts_dir)
+        with open(os.path.join(prompts_dir, "evaluator.md"), "w") as f:
+            f.write("evaluator")
+
+        prompt = build_round_one_prompt(
+            script_dir=tmp_dir,
+            artifact_dir="/tmp/art",
+            repo_root="/tmp/repo",
+            context="local",
+            yolo=True,
+        )
+
+        assert "Yolo mode is enabled" in prompt
+        assert "Temporary scratch files, caches, or probes are allowed" in prompt
+        assert "Do not mutate repository files" in prompt
+
 
 class TestBuildRevisionPrompt:
     def test_uses_audit_result(self, tmp_dir):
@@ -76,6 +118,14 @@ class TestBuildRevisionPrompt:
         )
         assert "auditor" in prompt
         assert "audit-result.json" in prompt
+        assert "Targeted Revision Superpowers Usage" in prompt
+        assert "Required Superpowers Usage" not in prompt
+        assert "Do not redo broad research" in prompt
+        assert (
+            "You MUST use relevant Superpowers skills if they are available" in prompt
+        )
+        assert "targeted\nsubagent checks were used" in prompt
+        assert "dispatching-parallel-agents" not in prompt
 
     def test_prefers_validation_feedback(self, tmp_dir):
         with open(os.path.join(tmp_dir, "validation-feedback.json"), "w") as f:
@@ -89,6 +139,20 @@ class TestBuildRevisionPrompt:
         )
         assert "validation" in prompt
         assert "validation-feedback.json" in prompt
+
+    def test_yolo_revision_prompt_has_targeted_write_policy(self, tmp_dir):
+        with open(os.path.join(tmp_dir, "audit-result.json"), "w") as f:
+            f.write("{}")
+
+        prompt = build_revision_prompt(
+            script_dir="/tmp/scripts",
+            artifact_dir=tmp_dir,
+            yolo=True,
+        )
+
+        assert "Targeted Revision Superpowers Usage" in prompt
+        assert "Yolo mode is enabled" in prompt
+        assert "Temporary scratch files, caches, or probes are allowed" in prompt
 
 
 class TestRunEvaluator:


### PR DESCRIPTION
- Add a provider-agnostic --yolo option and wire the action default through it.
- Prompt the evaluator to use subagents and Superpowers, with targeted revision research.
- Keep local non-yolo Claude runs able to write artifacts without bypassing permissions.
- Cover the runner, prompt, and auditor wiring with focused tests.
