### PR TITLE
Add UnPoller Helm deployment

### DIFF
--- a/kubernetes/unpoller/Chart.yaml
+++ b/kubernetes/unpoller/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: unpoller-meta
+version: 0.1.0
+dependencies:
+- name: unpoller
+  version: 2.1.0
+  repository: https://unpoller.github.io/helm-chart

--- a/kubernetes/unpoller/externalsecret.yaml
+++ b/kubernetes/unpoller/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+  name: unpoller
+  labels:
+    app: unpoller
+
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  target:
+    name: unpoller
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+  - extract:
+      key: unifipoller

--- a/kubernetes/unpoller/helm/templates/deployment.yaml
+++ b/kubernetes/unpoller/helm/templates/deployment.yaml
@@ -1,0 +1,60 @@
+---
+# Source: unpoller/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unpoller-config
+  labels:
+    app.kubernetes.io/name: unpoller
+    app.kubernetes.io/instance: unpoller
+    app.kubernetes.io/version: "v2.21.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: unpoller
+      app.kubernetes.io/instance: unpoller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: unpoller
+        app.kubernetes.io/instance: unpoller
+        app.kubernetes.io/version: "v2.21.0"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      serviceAccountName: default
+      securityContext:
+        {}
+      containers:
+        - name: unpoller
+          securityContext:
+            {}
+          image: "ghcr.io/unpoller/unpoller:v3.3.1@sha256:9dcccdc931a6830735f6978caf8cd67699b0dc33e37cf9ef4638611791c4df62"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9130
+              name: tcp
+              protocol: TCP
+            - containerPort: 9130
+              name: udp
+              protocol: UDP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: tcp
+          readinessProbe:
+            httpGet:
+              path: /
+              port: tcp
+          resources:
+            {}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/unpoller/up.conf
+              subPath: up.conf
+      volumes:
+        - name: config-volume
+          secret:
+            secretName: unpoller-config
+

--- a/kubernetes/unpoller/helm/templates/unpoller-config-secret.yaml
+++ b/kubernetes/unpoller/helm/templates/unpoller-config-secret.yaml
@@ -1,0 +1,19 @@
+---
+# Source: unpoller/templates/unpoller-config-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: unpoller-config
+  labels:
+    app.kubernetes.io/name: unpoller
+    app.kubernetes.io/instance: unpoller
+    app.kubernetes.io/version: "v2.21.0"
+    app.kubernetes.io/managed-by: Helm
+stringData:
+  up.conf: |
+    [unifi.defaults]
+      url = "https://udmp.oneill.net"
+      # Non-default: the UDMP hostname presents a valid certificate.
+      verify_ssl = true
+    [influxdb]
+      disable = true

--- a/kubernetes/unpoller/kustomization.yaml
+++ b/kubernetes/unpoller/kustomization.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: default
+
+commonAnnotations:
+  argoManaged: 'true'
+
+resources:
+- helm/templates/deployment.yaml
+- helm/templates/unpoller-config-secret.yaml
+- service.yaml
+- externalsecret.yaml
+
+# The upstream chart does not expose values for credentials from an existing
+# Secret. Patch only the runtime wiring that cannot be expressed in values.
+patches:
+
+- target:
+    kind: Deployment
+    name: unpoller-config
+  patch: |-
+    - op: add
+      path: /metadata/annotations
+      value:
+        reloader.stakater.com/auto: 'true'
+    - op: add
+      path: /spec/template/spec/containers/0/env
+      value:
+        - name: UP_UNIFI_DEFAULT_USER
+          valueFrom:
+            secretKeyRef:
+              name: unpoller
+              key: username
+        - name: UP_UNIFI_DEFAULT_PASS
+          valueFrom:
+            secretKeyRef:
+              name: unpoller
+              key: password
+        - name: UP_UNIFI_DEFAULT_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: unpoller
+              key: api_key
+              optional: true

--- a/kubernetes/unpoller/render
+++ b/kubernetes/unpoller/render
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$BASEDIR"
+
+source "$BASEDIR/../scripts/chart-version"
+
+rm -rf helm tmp
+mkdir tmp helm
+
+# Template using Chart.yaml
+helm_template unpoller unpoller \
+	--values values.yaml \
+	--output-dir tmp
+
+mv tmp/*/* helm
+rmdir tmp/*
+rmdir tmp
+rm -rf helm/tests
+rm -f helm/templates/pod-monitor.yaml

--- a/kubernetes/unpoller/service.yaml
+++ b/kubernetes/unpoller/service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: unpoller
+  labels:
+    app.kubernetes.io/name: unpoller
+    app.kubernetes.io/instance: unpoller
+  annotations:
+    prometheus.io/scrape: 'true'
+
+spec:
+  selector:
+    app.kubernetes.io/name: unpoller
+    app.kubernetes.io/instance: unpoller
+  ports:
+  - name: unpoller
+    protocol: TCP
+    port: 9130
+    targetPort: 9130

--- a/kubernetes/unpoller/values.yaml
+++ b/kubernetes/unpoller/values.yaml
@@ -1,0 +1,21 @@
+---
+fullnameOverride: unpoller-config
+
+image:
+  tag: v3.3.1@sha256:9dcccdc931a6830735f6978caf8cd67699b0dc33e37cf9ef4638611791c4df62
+
+serviceAccount:
+  create: false
+
+dashboards:
+  create: false
+  grafana:
+    create: false
+
+upConfig: |-
+  [unifi.defaults]
+    url = "https://udmp.oneill.net"
+    # Non-default: the UDMP hostname presents a valid certificate.
+    verify_ssl = true
+  [influxdb]
+    disable = true


### PR DESCRIPTION
Capture UnPoller as a GitOps-managed Kubernetes app using the official Helm chart render pattern.

Keep credentials in the existing 1Password-backed ExternalSecret, preserve the live app=unpoller selector, and expose the Prometheus scrape service used by the current cluster.
