### PR TITLE
Rename BedJet power plug

### DIFF
--- a/esphome/eightsleep-power.yaml
+++ b/esphome/eightsleep-power.yaml
@@ -1,8 +1,8 @@
 ---
 substitutions:
-  devicename: bedjet-power
-  device_id: bedjet_power
-  human_devicename: BedJet Power
+  devicename: eightsleep-power
+  device_id: eightsleep_power
+  human_devicename: Eight Sleep Power
   icon: mdi:power-socket-us
   mac: C8:2B:96:06:40:6D
   ip: 172.20.7.189

--- a/opentofu/esphome-hosts.tf
+++ b/opentofu/esphome-hosts.tf
@@ -18,11 +18,11 @@ locals {
       hostname = "bedjet.oneill.net"
       note     = "ESPHome: Bed Jet"
     }
-    bedjet-power = {
+    eightsleep-power = {
       mac      = "C8:2B:96:06:40:6D"
       ip       = "172.20.7.189"
-      hostname = "bedjet-power.oneill.net"
-      note     = "ESPHome: BedJet Power"
+      hostname = "eightsleep-power.oneill.net"
+      note     = "ESPHome: Eight Sleep Power"
     }
     freezer = {
       mac      = "EC:FA:BC:4F:E2:AA"


### PR DESCRIPTION
Rename the ESPHome power plug from `bedjet-power` to `eightsleep-power` and regenerate the ESPHome host inventory so UniFi and Cloudflare records use `eightsleep-power.oneill.net`.

Validation run locally:
- `scripts/gen-esphome-hosts --check`
- `cd esphome && ./scripts/esphome compile eightsleep-power.yaml`

The live device, Home Assistant entities, Lovelace card, Grafana panels, and targeted OpenTofu resources were already migrated during implementation.