### PR TITLE
Constrain RPi image Renovate tags

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -146,11 +146,11 @@
         "scripts/rpi-image-customize"
       ],
       "matchStrings": [
-        "IMAGE_TAG=\"(?<currentValue>\\d{4}-\\d{2}-\\d{2}-raspios-[^-]+-arm64)\""
+        "IMAGE_TAG=\"(?<currentValue>\\d{4}-\\d{2}-\\d{2}-raspios-trixie-arm64)\""
       ],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "RPi-Distro/pi-gen",
-      "versioningTemplate": "regex:^(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})-raspios-[^-]+-arm64$"
+      "versioningTemplate": "regex:^(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})-raspios-trixie-arm64$"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
Limit the custom Renovate manager for scripts/rpi-image-customize to raspios-trixie-arm64 tags so it does not propose oldstable Bookworm images from a different Raspberry Pi download tree.
