### PR TITLE
Add renovate eval Codex runners

### DIFF
--- a/kubernetes/codex-runners/helm/dotfiles-autoscalingrunnerset.yaml
+++ b/kubernetes/codex-runners/helm/dotfiles-autoscalingrunnerset.yaml
@@ -1,0 +1,105 @@
+---
+# Source: gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+apiVersion: actions.github.com/v1alpha1
+kind: AutoscalingRunnerSet
+metadata:
+  name: codex-dotfiles
+  namespace: codex-runners
+  labels:
+    app.kubernetes.io/component: "autoscaling-runner-set"
+    app.kubernetes.io/name: codex-dotfiles
+    app.kubernetes.io/instance: codex-dotfiles
+    app.kubernetes.io/version: "0.14.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: gha-rs
+    actions.github.com/scale-set-name: codex-dotfiles
+    actions.github.com/scale-set-namespace: codex-runners
+  annotations:
+    actions.github.com/values-hash: 268c4a34713d69b6d50844cce8c81990ed36f486a90f308aff22fec7c2a8bcc
+    actions.github.com/cleanup-manager-role-binding: codex-runners-gha-rs-manager
+    actions.github.com/cleanup-manager-role-name: codex-runners-gha-rs-manager
+spec:
+  githubConfigUrl: https://github.com/claytono/dotfiles
+  githubConfigSecret: codex-runner-github
+  runnerScaleSetName: codex-dotfiles
+  runnerScaleSetLabels:
+    - codex
+  maxRunners: 8
+  minRunners: 0
+  template:
+    metadata:
+      labels:
+        codex-runner: "true"
+        codex-runner-repo: dotfiles
+    spec:
+      dnsConfig:
+        nameservers:
+          - 1.1.1.1
+          - 1.0.0.1
+      dnsPolicy: None
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1001
+        runAsUser: 1001
+        supplementalGroups:
+          - 27
+      restartPolicy: Never
+      serviceAccountName: codex-runner
+      initContainers:
+        - command:
+            - python3
+            - /etc/codex-auth-tools/copy-auth-json.py
+          env:
+            - name: AUTH_SOURCE
+              value: /auth/auth.json
+            - name: CODEX_HOME
+              value: /home/runner/.codex
+          image: ghcr.io/astral-sh/uv@sha256:05bc724e74da13ad6238b9721a0e2f0f649dd2ed86b0453e7e88e63831b38dfe
+          name: copy-codex-auth
+          volumeMounts:
+            - mountPath: /auth
+              name: codex-auth
+              readOnly: true
+            - mountPath: /home/runner/.codex
+              name: codex-home
+            - mountPath: /etc/codex-auth-tools
+              name: codex-auth-tools
+              readOnly: true
+      containers:
+        - name: runner
+          command:
+            - /home/runner/run.sh
+          image: ghcr.io/actions/actions-runner:2.335.1@sha256:08c30b0a7105f64bddfc485d2487a22aa03932a791402393352fdf674bda2c29
+          env:
+            - name: CODEX_HOME
+              value: /home/runner/.codex
+            - name: USER
+              value: runner
+            - name: ACTIONS_RUNNER_HOOK_JOB_STARTED
+              value: /etc/arc/hooks/job-started.sh
+          volumeMounts:
+            - mountPath: /home/runner/.codex
+              name: codex-home
+            - mountPath: /etc/arc/hooks
+              name: runner-hooks
+              readOnly: true
+      volumes:
+        - emptyDir: {}
+          name: codex-home
+        - name: codex-auth
+          persistentVolumeClaim:
+            claimName: codex-auth
+        - configMap:
+            defaultMode: 365
+            name: codex-auth-tools
+          name: codex-auth-tools
+        - configMap:
+            defaultMode: 493
+            items:
+              - key: job-started.sh
+                path: job-started.sh
+              - key: install-runner-prerequisites.sh
+                path: job-started.d/10-install-runner-prerequisites.sh
+            name: codex-runner-hooks
+          name: runner-hooks

--- a/kubernetes/codex-runners/helm/github-actions-autoscalingrunnerset.yaml
+++ b/kubernetes/codex-runners/helm/github-actions-autoscalingrunnerset.yaml
@@ -1,0 +1,105 @@
+---
+# Source: gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+apiVersion: actions.github.com/v1alpha1
+kind: AutoscalingRunnerSet
+metadata:
+  name: codex-github-actions
+  namespace: codex-runners
+  labels:
+    app.kubernetes.io/component: "autoscaling-runner-set"
+    app.kubernetes.io/name: codex-github-actions
+    app.kubernetes.io/instance: codex-github-actions
+    app.kubernetes.io/version: "0.14.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: gha-rs
+    actions.github.com/scale-set-name: codex-github-actions
+    actions.github.com/scale-set-namespace: codex-runners
+  annotations:
+    actions.github.com/values-hash: 3019c8c7267c71f3187a65067955ae9e6dda3561a8a70ed2ba83087e6583f8d
+    actions.github.com/cleanup-manager-role-binding: codex-runners-gha-rs-manager
+    actions.github.com/cleanup-manager-role-name: codex-runners-gha-rs-manager
+spec:
+  githubConfigUrl: https://github.com/claytono/github-actions
+  githubConfigSecret: codex-runner-github
+  runnerScaleSetName: codex-github-actions
+  runnerScaleSetLabels:
+    - codex
+  maxRunners: 8
+  minRunners: 0
+  template:
+    metadata:
+      labels:
+        codex-runner: "true"
+        codex-runner-repo: github-actions
+    spec:
+      dnsConfig:
+        nameservers:
+          - 1.1.1.1
+          - 1.0.0.1
+      dnsPolicy: None
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1001
+        runAsUser: 1001
+        supplementalGroups:
+          - 27
+      restartPolicy: Never
+      serviceAccountName: codex-runner
+      initContainers:
+        - command:
+            - python3
+            - /etc/codex-auth-tools/copy-auth-json.py
+          env:
+            - name: AUTH_SOURCE
+              value: /auth/auth.json
+            - name: CODEX_HOME
+              value: /home/runner/.codex
+          image: ghcr.io/astral-sh/uv@sha256:05bc724e74da13ad6238b9721a0e2f0f649dd2ed86b0453e7e88e63831b38dfe
+          name: copy-codex-auth
+          volumeMounts:
+            - mountPath: /auth
+              name: codex-auth
+              readOnly: true
+            - mountPath: /home/runner/.codex
+              name: codex-home
+            - mountPath: /etc/codex-auth-tools
+              name: codex-auth-tools
+              readOnly: true
+      containers:
+        - name: runner
+          command:
+            - /home/runner/run.sh
+          image: ghcr.io/actions/actions-runner:2.335.1@sha256:08c30b0a7105f64bddfc485d2487a22aa03932a791402393352fdf674bda2c29
+          env:
+            - name: CODEX_HOME
+              value: /home/runner/.codex
+            - name: USER
+              value: runner
+            - name: ACTIONS_RUNNER_HOOK_JOB_STARTED
+              value: /etc/arc/hooks/job-started.sh
+          volumeMounts:
+            - mountPath: /home/runner/.codex
+              name: codex-home
+            - mountPath: /etc/arc/hooks
+              name: runner-hooks
+              readOnly: true
+      volumes:
+        - emptyDir: {}
+          name: codex-home
+        - name: codex-auth
+          persistentVolumeClaim:
+            claimName: codex-auth
+        - configMap:
+            defaultMode: 365
+            name: codex-auth-tools
+          name: codex-auth-tools
+        - configMap:
+            defaultMode: 493
+            items:
+              - key: job-started.sh
+                path: job-started.sh
+              - key: install-runner-prerequisites.sh
+                path: job-started.d/10-install-runner-prerequisites.sh
+            name: codex-runner-hooks
+          name: runner-hooks

--- a/kubernetes/codex-runners/helm/go-unifi-mcp-autoscalingrunnerset.yaml
+++ b/kubernetes/codex-runners/helm/go-unifi-mcp-autoscalingrunnerset.yaml
@@ -1,0 +1,105 @@
+---
+# Source: gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+apiVersion: actions.github.com/v1alpha1
+kind: AutoscalingRunnerSet
+metadata:
+  name: codex-go-unifi-mcp
+  namespace: codex-runners
+  labels:
+    app.kubernetes.io/component: "autoscaling-runner-set"
+    app.kubernetes.io/name: codex-go-unifi-mcp
+    app.kubernetes.io/instance: codex-go-unifi-mcp
+    app.kubernetes.io/version: "0.14.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: gha-rs
+    actions.github.com/scale-set-name: codex-go-unifi-mcp
+    actions.github.com/scale-set-namespace: codex-runners
+  annotations:
+    actions.github.com/values-hash: 0362f0eb2d80c832d292e27aa1e75ee79b93c2cc8c5eece5bd9795a03fe9297
+    actions.github.com/cleanup-manager-role-binding: codex-runners-gha-rs-manager
+    actions.github.com/cleanup-manager-role-name: codex-runners-gha-rs-manager
+spec:
+  githubConfigUrl: https://github.com/claytono/go-unifi-mcp
+  githubConfigSecret: codex-runner-github
+  runnerScaleSetName: codex-go-unifi-mcp
+  runnerScaleSetLabels:
+    - codex
+  maxRunners: 8
+  minRunners: 0
+  template:
+    metadata:
+      labels:
+        codex-runner: "true"
+        codex-runner-repo: go-unifi-mcp
+    spec:
+      dnsConfig:
+        nameservers:
+          - 1.1.1.1
+          - 1.0.0.1
+      dnsPolicy: None
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1001
+        runAsUser: 1001
+        supplementalGroups:
+          - 27
+      restartPolicy: Never
+      serviceAccountName: codex-runner
+      initContainers:
+        - command:
+            - python3
+            - /etc/codex-auth-tools/copy-auth-json.py
+          env:
+            - name: AUTH_SOURCE
+              value: /auth/auth.json
+            - name: CODEX_HOME
+              value: /home/runner/.codex
+          image: ghcr.io/astral-sh/uv@sha256:05bc724e74da13ad6238b9721a0e2f0f649dd2ed86b0453e7e88e63831b38dfe
+          name: copy-codex-auth
+          volumeMounts:
+            - mountPath: /auth
+              name: codex-auth
+              readOnly: true
+            - mountPath: /home/runner/.codex
+              name: codex-home
+            - mountPath: /etc/codex-auth-tools
+              name: codex-auth-tools
+              readOnly: true
+      containers:
+        - name: runner
+          command:
+            - /home/runner/run.sh
+          image: ghcr.io/actions/actions-runner:2.335.1@sha256:08c30b0a7105f64bddfc485d2487a22aa03932a791402393352fdf674bda2c29
+          env:
+            - name: CODEX_HOME
+              value: /home/runner/.codex
+            - name: USER
+              value: runner
+            - name: ACTIONS_RUNNER_HOOK_JOB_STARTED
+              value: /etc/arc/hooks/job-started.sh
+          volumeMounts:
+            - mountPath: /home/runner/.codex
+              name: codex-home
+            - mountPath: /etc/arc/hooks
+              name: runner-hooks
+              readOnly: true
+      volumes:
+        - emptyDir: {}
+          name: codex-home
+        - name: codex-auth
+          persistentVolumeClaim:
+            claimName: codex-auth
+        - configMap:
+            defaultMode: 365
+            name: codex-auth-tools
+          name: codex-auth-tools
+        - configMap:
+            defaultMode: 493
+            items:
+              - key: job-started.sh
+                path: job-started.sh
+              - key: install-runner-prerequisites.sh
+                path: job-started.d/10-install-runner-prerequisites.sh
+            name: codex-runner-hooks
+          name: runner-hooks

--- a/kubernetes/codex-runners/kustomization.yaml
+++ b/kubernetes/codex-runners/kustomization.yaml
@@ -19,6 +19,9 @@ resources:
 # BEGIN generated runner scale sets
 - helm/manager-role.yaml
 - helm/manager-role-binding.yaml
+- helm/dotfiles-autoscalingrunnerset.yaml
+- helm/github-actions-autoscalingrunnerset.yaml
+- helm/go-unifi-mcp-autoscalingrunnerset.yaml
 - helm/infra-autoscalingrunnerset.yaml
 # END generated runner scale sets
 

--- a/kubernetes/codex-runners/repos.yaml
+++ b/kubernetes/codex-runners/repos.yaml
@@ -1,3 +1,6 @@
 ---
 repos:
+- claytono/dotfiles
+- claytono/github-actions
+- claytono/go-unifi-mcp
 - claytono/infra


### PR DESCRIPTION
Add ARC scale sets for dotfiles, github-actions, and go-unifi-mcp so Renovate evaluation workflows can run on the shared codex runner label.
