### PR TITLE
Keep renovate eval workflow on main

### DIFF
--- a/.github/workflows/renovate-eval.yaml
+++ b/.github/workflows/renovate-eval.yaml
@@ -40,7 +40,9 @@ jobs:
       issues: write
       checks: read
       statuses: read
-    uses: claytono/github-actions/.github/workflows/claytono-renovate-eval-codex.yaml@main
+    # Intentionally tracks main so evaluator workflow changes take effect immediately.
+    # Renovate pinDigest updates for this reusable workflow are disabled in .renovaterc.
+    uses: claytono/github-actions/.github/workflows/claytono-renovate-eval-codex.yaml@main  # zizmor: ignore[unpinned-uses]
     with:
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       trigger: ${{ github.event_name == 'pull_request' && 'auto' || 'manual' }}

--- a/.renovaterc
+++ b/.renovaterc
@@ -288,6 +288,19 @@
       "matchManagers": [
         "github-actions"
       ],
+      "matchPackageNames": [
+        "claytono/github-actions"
+      ],
+      "matchUpdateTypes": [
+        "pinDigest"
+      ],
+      "enabled": false,
+      "description": "Do not pin the reusable Renovate evaluation workflow; it intentionally tracks main"
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
       "matchUpdateTypes": [
         "digest"
       ],


### PR DESCRIPTION
Disable Renovate pinDigest updates for claytono/github-actions so the reusable evaluator workflow keeps tracking main.

Document the intentional exception next to the workflow reference.
