### PR TITLE
Use smartmontools service name

### DIFF
--- a/ansible/roles/common/handlers/main.yaml
+++ b/ansible/roles/common/handlers/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Restart smartd
   ansible.builtin.service:
-    name: smartd
+    name: smartmontools
     state: restarted
   when:
     - common_smartd_enabled is defined

--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -111,7 +111,7 @@
 
 - name: "Ensure smartd service is enabled and started"
   ansible.builtin.service:
-    name: smartd
+    name: smartmontools
     state: started
     enabled: true
   when:
@@ -120,7 +120,7 @@
 
 - name: "Disable smartd when no SMART-capable devices are found"
   ansible.builtin.service:
-    name: smartd
+    name: smartmontools
     state: stopped
     enabled: false
   failed_when: false


### PR DESCRIPTION
Use Debian Trixie's smartmontools systemd unit directly instead of the smartd daemon name in the common role.

This fixes SMART-capable hosts that need Ansible to enable or restart disk monitoring after smartmontools is installed.