### PR TITLE
Keep Codex runners on uv Debian image

### DIFF
--- a/kubernetes/codex-runners/README.md
+++ b/kubernetes/codex-runners/README.md
@@ -60,7 +60,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: reauth
-    image: ghcr.io/astral-sh/uv@sha256:05bc724e74da13ad6238b9721a0e2f0f649dd2ed86b0453e7e88e63831b38dfe
+    image: ghcr.io/astral-sh/uv:debian@sha256:12bcf9d33038200b3c7da0fa2b0f416482cf26ea764d0554fadf861d5d789833
     command:
     - sleep
     - infinity

--- a/kubernetes/codex-runners/cronjob-auth-refresh.yaml
+++ b/kubernetes/codex-runners/cronjob-auth-refresh.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: refresh
-            image: ghcr.io/astral-sh/uv@sha256:0f36cb9361a3346885ca3677e3767016687b5a170c1a6b88465ec14aefec90aa
+            image: ghcr.io/astral-sh/uv:debian@sha256:12bcf9d33038200b3c7da0fa2b0f416482cf26ea764d0554fadf861d5d789833
             env:
             - name: CODEX_HOME
               value: /codex-home

--- a/kubernetes/codex-runners/helm/dotfiles-autoscalingrunnerset.yaml
+++ b/kubernetes/codex-runners/helm/dotfiles-autoscalingrunnerset.yaml
@@ -15,7 +15,7 @@ metadata:
     actions.github.com/scale-set-name: codex-dotfiles
     actions.github.com/scale-set-namespace: codex-runners
   annotations:
-    actions.github.com/values-hash: 289dd68e9bfdf5c8f99c8783755a7cccdfd54afff21f31130e563cd1ef1a323
+    actions.github.com/values-hash: 4cf6abeb6bae9e1e743141f8a0c006afa00710ee9b051fc4d68f0ee89800ffe
     actions.github.com/cleanup-manager-role-binding: codex-runners-gha-rs-manager
     actions.github.com/cleanup-manager-role-name: codex-runners-gha-rs-manager
 spec:
@@ -55,7 +55,7 @@ spec:
               value: /auth/auth.json
             - name: CODEX_HOME
               value: /home/runner/.codex
-          image: ghcr.io/astral-sh/uv@sha256:0f36cb9361a3346885ca3677e3767016687b5a170c1a6b88465ec14aefec90aa
+          image: ghcr.io/astral-sh/uv:debian@sha256:12bcf9d33038200b3c7da0fa2b0f416482cf26ea764d0554fadf861d5d789833
           name: copy-codex-auth
           volumeMounts:
             - mountPath: /auth

--- a/kubernetes/codex-runners/helm/github-actions-autoscalingrunnerset.yaml
+++ b/kubernetes/codex-runners/helm/github-actions-autoscalingrunnerset.yaml
@@ -15,7 +15,7 @@ metadata:
     actions.github.com/scale-set-name: codex-github-actions
     actions.github.com/scale-set-namespace: codex-runners
   annotations:
-    actions.github.com/values-hash: b57a62a697e75b0b6f143057d06d8a88efc301cd986ac3fc4f10ffeaa2d6f98
+    actions.github.com/values-hash: a46b0653a6b9cf62182bec35bb184c73350911d29418e08a10a68384d5f7f0b
     actions.github.com/cleanup-manager-role-binding: codex-runners-gha-rs-manager
     actions.github.com/cleanup-manager-role-name: codex-runners-gha-rs-manager
 spec:
@@ -55,7 +55,7 @@ spec:
               value: /auth/auth.json
             - name: CODEX_HOME
               value: /home/runner/.codex
-          image: ghcr.io/astral-sh/uv@sha256:0f36cb9361a3346885ca3677e3767016687b5a170c1a6b88465ec14aefec90aa
+          image: ghcr.io/astral-sh/uv:debian@sha256:12bcf9d33038200b3c7da0fa2b0f416482cf26ea764d0554fadf861d5d789833
           name: copy-codex-auth
           volumeMounts:
             - mountPath: /auth

--- a/kubernetes/codex-runners/helm/go-unifi-mcp-autoscalingrunnerset.yaml
+++ b/kubernetes/codex-runners/helm/go-unifi-mcp-autoscalingrunnerset.yaml
@@ -15,7 +15,7 @@ metadata:
     actions.github.com/scale-set-name: codex-go-unifi-mcp
     actions.github.com/scale-set-namespace: codex-runners
   annotations:
-    actions.github.com/values-hash: 7886494d92029d52c7bedb58452c10e2df6bc433abcfe85e55e5efbfafd1623
+    actions.github.com/values-hash: f741f1ee0e7ea4c07a9597a47a70e90fcaf7ad957c2951312a63a5f4925c735
     actions.github.com/cleanup-manager-role-binding: codex-runners-gha-rs-manager
     actions.github.com/cleanup-manager-role-name: codex-runners-gha-rs-manager
 spec:
@@ -55,7 +55,7 @@ spec:
               value: /auth/auth.json
             - name: CODEX_HOME
               value: /home/runner/.codex
-          image: ghcr.io/astral-sh/uv@sha256:0f36cb9361a3346885ca3677e3767016687b5a170c1a6b88465ec14aefec90aa
+          image: ghcr.io/astral-sh/uv:debian@sha256:12bcf9d33038200b3c7da0fa2b0f416482cf26ea764d0554fadf861d5d789833
           name: copy-codex-auth
           volumeMounts:
             - mountPath: /auth

--- a/kubernetes/codex-runners/helm/infra-autoscalingrunnerset.yaml
+++ b/kubernetes/codex-runners/helm/infra-autoscalingrunnerset.yaml
@@ -15,7 +15,7 @@ metadata:
     actions.github.com/scale-set-name: codex-infra
     actions.github.com/scale-set-namespace: codex-runners
   annotations:
-    actions.github.com/values-hash: 5ea9da7e47e88ea313185850564869f57fd7003dc4259d6fca1a3ff81eb354d
+    actions.github.com/values-hash: d13b09791d44b4ccad5c302623332c117871a7988019c53b38a84f9351eeaac
     actions.github.com/cleanup-manager-role-binding: codex-runners-gha-rs-manager
     actions.github.com/cleanup-manager-role-name: codex-runners-gha-rs-manager
 spec:
@@ -55,7 +55,7 @@ spec:
               value: /auth/auth.json
             - name: CODEX_HOME
               value: /home/runner/.codex
-          image: ghcr.io/astral-sh/uv@sha256:0f36cb9361a3346885ca3677e3767016687b5a170c1a6b88465ec14aefec90aa
+          image: ghcr.io/astral-sh/uv:debian@sha256:12bcf9d33038200b3c7da0fa2b0f416482cf26ea764d0554fadf861d5d789833
           name: copy-codex-auth
           volumeMounts:
             - mountPath: /auth

--- a/kubernetes/codex-runners/values.yaml
+++ b/kubernetes/codex-runners/values.yaml
@@ -34,7 +34,7 @@ template:
       - 1.0.0.1
     initContainers:
     - name: copy-codex-auth
-      image: ghcr.io/astral-sh/uv@sha256:0f36cb9361a3346885ca3677e3767016687b5a170c1a6b88465ec14aefec90aa
+      image: ghcr.io/astral-sh/uv:debian@sha256:12bcf9d33038200b3c7da0fa2b0f416482cf26ea764d0554fadf861d5d789833
       command:
       - python3
       - /etc/codex-auth-tools/copy-auth-json.py


### PR DESCRIPTION
Pin the uv:debian tag for runner auth init containers and refresh jobs so Renovate preserves the Python-bearing image family.

Regenerate the runner scale-set manifests and update the recovery documentation.
