### PR TITLE
Update Renovate version constraints

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -427,7 +427,7 @@
     },
     {
       "description": "MariaDB: LTS versions at least 6 months old (auto-managed)",
-      "allowedVersions": "/^(11\\.8|11\\.4|10\\.11|10\\.6)\\./",
+      "allowedVersions": "/^(11\\.8|11\\.4|10\\.11)\\./",
       "matchDatasources": [
         "docker"
       ],


### PR DESCRIPTION
This PR updates auto-managed version constraints in `.renovaterc` based on current data from endoflife.date and PyPI.

**Rules applied:**
- **MariaDB**: LTS versions at least 6 months old
- **PostgreSQL**: Major versions at least 6 months old
- **Home Assistant**: One month behind latest stable
- **ESPHome**: One month behind latest stable

Auto-generated by `scripts/update-renovate-versions.py`