### PR TITLE
Fix Authentik redirect URI drift

### DIFF
--- a/kubernetes/scripts/templates/provider-app-oidc.tf.j2
+++ b/kubernetes/scripts/templates/provider-app-oidc.tf.j2
@@ -16,9 +16,9 @@ resource "authentik_provider_oauth2" "{{ app }}" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "{{ callback_url }}", matching_mode = "strict" },
+    { url = "{{ callback_url }}", matching_mode = "strict", redirect_uri_type = "authorization" },
 {% for uri in extra_redirects %}
-    { url = "{{ uri }}", matching_mode = "strict" },
+    { url = "{{ uri }}", matching_mode = "strict", redirect_uri_type = "authorization" },
 {% endfor %}
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id

--- a/opentofu/modules/authentik/.terraform.lock.hcl
+++ b/opentofu/modules/authentik/.terraform.lock.hcl
@@ -5,7 +5,12 @@ provider "registry.opentofu.org/1password/onepassword" {
   version     = "3.2.1"
   constraints = "~> 3.0"
   hashes = [
+    "h1:2oZnlv8MoB+lr0PwRb+cVwjl5FGlYZ7fKH/swx/2Vwk=",
     "h1:Cgnzf730laGVmvSalQf3SM6bBwwm/OCZcCpOlsBBC4s=",
+    "h1:Cptwjxyu8HtBa01xURjnBBR7+rHRQ7kmrQpctYwi9nc=",
+    "h1:KzFIYHNLIU1VBpWgwtrl3MaejyVcTm0vockK3dzJoVQ=",
+    "h1:PccgMFFnAIYz9UzNpp10MCiPKusor9mallVpFdEAv8s=",
+    "h1:StnkXlda1e6zQq7njiuYOc7PetlMYDNBa4i8+lVQ8hQ=",
     "h1:hZrcwOpBicojsJA33Iv5ZvY/3rB4pf9WAuwrRWE4W5k=",
     "zh:56c142b07295608de4ef2b7915684578b384bc2b47519c6811e93184945cd161",
     "zh:785b52b0c7055deb249843063327bb25cbc952fb560681d2a84c4e32283a6eae",

--- a/opentofu/modules/authentik/generated-argocd.tf
+++ b/opentofu/modules/authentik/generated-argocd.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "argocd" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://argocd.k.oneill.net/api/dex/callback", matching_mode = "strict" },
+    { url = "https://argocd.k.oneill.net/api/dex/callback", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-audiobookshelf.tf
+++ b/opentofu/modules/authentik/generated-audiobookshelf.tf
@@ -16,9 +16,9 @@ resource "authentik_provider_oauth2" "audiobookshelf" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://audiobookshelf.k.oneill.net/auth/openid/callback", matching_mode = "strict" },
-    { url = "shelfplayer://callback", matching_mode = "strict" },
-    { url = "https://audiobookshelf.k.oneill.net/auth/openid/mobile-redirect", matching_mode = "strict" },
+    { url = "https://audiobookshelf.k.oneill.net/auth/openid/callback", matching_mode = "strict", redirect_uri_type = "authorization" },
+    { url = "shelfplayer://callback", matching_mode = "strict", redirect_uri_type = "authorization" },
+    { url = "https://audiobookshelf.k.oneill.net/auth/openid/mobile-redirect", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-autobrr.tf
+++ b/opentofu/modules/authentik/generated-autobrr.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "autobrr" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://autobrr.k.oneill.net/api/auth/oidc/callback", matching_mode = "strict" },
+    { url = "https://autobrr.k.oneill.net/api/auth/oidc/callback", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-dawarich.tf
+++ b/opentofu/modules/authentik/generated-dawarich.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "dawarich" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://dawarich.k.oneill.net/users/auth/openid_connect/callback", matching_mode = "strict" },
+    { url = "https://dawarich.k.oneill.net/users/auth/openid_connect/callback", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-felix-dashboard.tf
+++ b/opentofu/modules/authentik/generated-felix-dashboard.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "felix-dashboard" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://felix-dashboard.k.oneill.net/auth/callback", matching_mode = "strict" },
+    { url = "https://felix-dashboard.k.oneill.net/auth/callback", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-grafana.tf
+++ b/opentofu/modules/authentik/generated-grafana.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "grafana" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://grafana.k.oneill.net/login/generic_oauth", matching_mode = "strict" },
+    { url = "https://grafana.k.oneill.net/login/generic_oauth", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-grimmory.tf
+++ b/opentofu/modules/authentik/generated-grimmory.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "grimmory" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://grimmory.k.oneill.net/oauth2-callback", matching_mode = "strict" },
+    { url = "https://grimmory.k.oneill.net/oauth2-callback", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-homebox.tf
+++ b/opentofu/modules/authentik/generated-homebox.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "homebox" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://homebox.k.oneill.net/api/v1/users/login/oidc/callback", matching_mode = "strict" },
+    { url = "https://homebox.k.oneill.net/api/v1/users/login/oidc/callback", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-immich.tf
+++ b/opentofu/modules/authentik/generated-immich.tf
@@ -16,9 +16,9 @@ resource "authentik_provider_oauth2" "immich" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://immich.k.oneill.net/auth/login", matching_mode = "strict" },
-    { url = "https://immich.k.oneill.net/user-settings", matching_mode = "strict" },
-    { url = "app.immich:///oauth-callback", matching_mode = "strict" },
+    { url = "https://immich.k.oneill.net/auth/login", matching_mode = "strict", redirect_uri_type = "authorization" },
+    { url = "https://immich.k.oneill.net/user-settings", matching_mode = "strict", redirect_uri_type = "authorization" },
+    { url = "app.immich:///oauth-callback", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-karakeep.tf
+++ b/opentofu/modules/authentik/generated-karakeep.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "karakeep" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://karakeep.k.oneill.net/api/auth/callback/custom", matching_mode = "strict" },
+    { url = "https://karakeep.k.oneill.net/api/auth/callback/custom", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-komga.tf
+++ b/opentofu/modules/authentik/generated-komga.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "komga" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://komga.k.oneill.net/login/oauth2/code/authentik", matching_mode = "strict" },
+    { url = "https://komga.k.oneill.net/login/oauth2/code/authentik", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-pinepods.tf
+++ b/opentofu/modules/authentik/generated-pinepods.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "pinepods" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://pinepods.k.oneill.net/api/auth/callback", matching_mode = "strict" },
+    { url = "https://pinepods.k.oneill.net/api/auth/callback", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-qui.tf
+++ b/opentofu/modules/authentik/generated-qui.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "qui" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://qui.k.oneill.net/api/auth/oidc/callback", matching_mode = "strict" },
+    { url = "https://qui.k.oneill.net/api/auth/oidc/callback", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-semaphore.tf
+++ b/opentofu/modules/authentik/generated-semaphore.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "semaphore" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://semaphore.k.oneill.net/api/auth/oidc/authentik/redirect", matching_mode = "strict" },
+    { url = "https://semaphore.k.oneill.net/api/auth/oidc/authentik/redirect", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-shelfmark-comics.tf
+++ b/opentofu/modules/authentik/generated-shelfmark-comics.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "shelfmark-comics" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://shelfmark-comics.k.oneill.net/api/auth/oidc/callback", matching_mode = "strict" },
+    { url = "https://shelfmark-comics.k.oneill.net/api/auth/oidc/callback", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-shelfmark.tf
+++ b/opentofu/modules/authentik/generated-shelfmark.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "shelfmark" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://shelfmark.k.oneill.net/api/auth/oidc/callback", matching_mode = "strict" },
+    { url = "https://shelfmark.k.oneill.net/api/auth/oidc/callback", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/generated-speakr.tf
+++ b/opentofu/modules/authentik/generated-speakr.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "speakr" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://speakr.k.oneill.net/auth/sso/callback", matching_mode = "strict" },
+    { url = "https://speakr.k.oneill.net/auth/sso/callback", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }

--- a/opentofu/modules/authentik/proxmox.tf
+++ b/opentofu/modules/authentik/proxmox.tf
@@ -16,7 +16,7 @@ resource "authentik_provider_oauth2" "proxmox" {
   ]
   access_token_validity = "hours=1"
   allowed_redirect_uris = [
-    { url = "https://pve.oneill.net", matching_mode = "strict" },
+    { url = "https://pve.oneill.net", matching_mode = "strict", redirect_uri_type = "authorization" },
   ]
   signing_key = data.authentik_certificate_key_pair.self_signed.id
 }


### PR DESCRIPTION
Declare authorization redirect types in the OIDC generator and the manually managed Proxmox provider so Authentik 2026.5 state round-trips cleanly.
