### PR TITLE
Configure kubelet pods without swap

### DIFF
--- a/ansible/roles/kubeadm/templates/kubeadm.conf.j2
+++ b/ansible/roles/kubeadm/templates/kubeadm.conf.j2
@@ -38,4 +38,4 @@ kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
 failSwapOn: false
 memorySwap:
-  swapBehavior: LimitedSwap
+  swapBehavior: NoSwap


### PR DESCRIPTION
## Summary

- keep host ZRAM enabled with `failSwapOn: false`
- configure kubelet-managed Pods with `swapBehavior: NoSwap`
- allow in-place memory request resizing without swap-related eviction fallback

## Live validation

- applied the equivalent one-off change sequentially to `k3`, `k4`, `k5`, `k2`, then `k1`
- cordoned each node without draining; every kubelet renewed its lease and no existing container restart count increased
- updated `kube-system/kubelet-config`; backup is `kubelet-config-pre-noswap-20260713t1552z`
- verified `/dev/zram0` remains active on every node
- verified existing-container memory resize from 64 MiB to 96 MiB with unchanged Pod UID, container ID, and restart count
- verified CPU resize from 10m to 50m with unchanged Pod UID, container ID, and restart count

## Validation

- `git diff --check`
- targeted pre-commit hooks
- `ansible-playbook site.yaml --syntax-check`