### PR TITLE
Upgrade Argo CD without NetworkPolicies

### DIFF
--- a/kubernetes/argocd/Chart.yaml
+++ b/kubernetes/argocd/Chart.yaml
@@ -4,5 +4,5 @@ name: argocd-meta
 version: 0.1.0
 dependencies:
 - name: argo-cd
-  version: 9.7.1
+  version: 10.1.2
   repository: https://argoproj.github.io/argo-helm

--- a/kubernetes/argocd/values.yaml
+++ b/kubernetes/argocd/values.yaml
@@ -1,4 +1,8 @@
 ---
+global:
+  networkPolicy:
+    create: false
+
 server:
   containerPorts:
     server: 8443


### PR DESCRIPTION
Upgrade the Argo CD chart dependency to 10.1.2 while explicitly leaving chart-provided NetworkPolicies disabled. This preserves the current traffic behavior and keeps the rendered manifests unchanged.
