### PR TITLE
Redirect MinusPod root and add Homepage card

### DIFF
--- a/kubernetes/minuspod/ingress.yaml
+++ b/kubernetes/minuspod/ingress.yaml
@@ -7,6 +7,13 @@ metadata:
   annotations:
     ak-type: simple
     cert-manager.io/cluster-issuer: letsencrypt
+    gethomepage.dev/enabled: 'true'
+    gethomepage.dev/name: MinusPod
+    gethomepage.dev/description: Podcast Ad Removal
+    gethomepage.dev/group: Media
+    gethomepage.dev/icon: mdi-podcast
+    gethomepage.dev/pod-selector: app.kubernetes.io/name=minuspod
+    traefik.ingress.kubernetes.io/router.middlewares: minuspod-redirect-root@kubernetescrd,authentik-ak-forward-auth-simple@kubernetescrd
 
 spec:
   tls:

--- a/kubernetes/minuspod/kustomization.yaml
+++ b/kubernetes/minuspod/kustomization.yaml
@@ -12,9 +12,7 @@ resources:
 - deploy.yaml
 - service.yaml
 - ingress.yaml
-
-components:
-- ../components/authentik
+- middleware-redirect-root.yaml
 
 commonAnnotations:
   argoManaged: 'true'

--- a/kubernetes/minuspod/middleware-redirect-root.yaml
+++ b/kubernetes/minuspod/middleware-redirect-root.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+
+metadata:
+  name: redirect-root
+
+spec:
+  redirectRegex:
+    regex: ^https://minuspod\.k\.oneill\.net/?(\?.*)?$
+    replacement: https://minuspod.k.oneill.net/ui/${1}
+    permanent: true


### PR DESCRIPTION
- Redirect the internal MinusPod root URL to the canonical UI path before Authentik.
- Add MinusPod to Homepage's Media group.
