### PR TITLE
Add qBittorrent API health probes

### DIFF
--- a/kubernetes/qbittorrent/deploy.yaml
+++ b/kubernetes/qbittorrent/deploy.yaml
@@ -8,6 +8,7 @@ metadata:
     app: qbittorrent
   annotations:
     goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","controlledValues":"RequestsOnly","maxAllowed":{"memory":"2Gi"}}]}'
+    reloader.stakater.com/auto: 'true'
 
 spec:
   strategy:
@@ -30,11 +31,28 @@ spec:
         ports:
         - containerPort: 8080
         - containerPort: 51414
+        startupProbe:
+          exec:
+            command:
+            - /scripts/check-health.sh
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 60
+        readinessProbe:
+          exec:
+            command:
+            - /scripts/check-health.sh
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
         volumeMounts:
         - mountPath: /config
           name: config
         - mountPath: /downloads
           name: downloads
+        - mountPath: /scripts
+          name: scripts
+          readOnly: true
         env:
         - name: PUID
           value: '10001'
@@ -42,6 +60,11 @@ spec:
           value: '10001'
         - name: TZ
           value: America/New_York
+        - name: QBITTORRENT_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: qbittorrent
+              key: api-key
       volumes:
       - name: config
         persistentVolumeClaim:
@@ -50,3 +73,7 @@ spec:
           server: fs2.oneill.net
           path: /volume2/shared/downloads
         name: downloads
+      - name: scripts
+        configMap:
+          name: qbittorrent-scripts
+          defaultMode: 0555

--- a/kubernetes/qbittorrent/externalsecret.yaml
+++ b/kubernetes/qbittorrent/externalsecret.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+  name: qbittorrent
+
+spec:
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  data:
+  - secretKey: api-key
+    remoteRef:
+      key: qbittorrent
+      property: qbittorrent-api-key

--- a/kubernetes/qbittorrent/kustomization.yaml
+++ b/kubernetes/qbittorrent/kustomization.yaml
@@ -9,9 +9,18 @@ commonAnnotations:
 
 resources:
 - deploy.yaml
+- externalsecret.yaml
 - pvc.yaml
 - service.yaml
 - ingress.yaml
+
+configMapGenerator:
+- name: qbittorrent-scripts
+  files:
+  - scripts/check-health.sh
+
+generatorOptions:
+  disableNameSuffixHash: true
 
 labels:
 

--- a/kubernetes/qbittorrent/scripts/check-health.sh
+++ b/kubernetes/qbittorrent/scripts/check-health.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -eu
+
+: "${QBITTORRENT_API_KEY:?QBITTORRENT_API_KEY is required}"
+
+curl \
+  --fail \
+  --silent \
+  --show-error \
+  --max-time 2 \
+  --header "Authorization: Bearer ${QBITTORRENT_API_KEY}" \
+  --output /dev/null \
+  http://127.0.0.1:8080/api/v2/transfer/info


### PR DESCRIPTION
Probe an authenticated Web API endpoint during startup and readiness.

- Mount a reusable health-check script from a stable-name ConfigMap.
- Read the qBittorrent API key through External Secrets.
- Allow up to five minutes for the large torrent session to load.
