### PR TITLE
Sync ezShare CPAP data to NFS

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -154,14 +154,13 @@
     },
     {
       "customType": "regex",
+      "description": "GitHub release versions in Kubernetes run scripts",
       "managerFilePatterns": [
-        "kubernetes/got-your-back/run"
+        "/^kubernetes\\/[^/]+\\/run$/"
       ],
       "matchStrings": [
-        "VERSION=(?<currentValue>\\d+\\.\\d+)"
-      ],
-      "depNameTemplate": "GAM-team/got-your-back",
-      "datasourceTemplate": "github-releases"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n[A-Z0-9_]*VERSION=(?<currentValue>\\d+(?:\\.\\d+)+)"
+      ]
     }
   ],
   "packageRules": [

--- a/ansible/host_vars/k5.yaml
+++ b/ansible/host_vars/k5.yaml
@@ -1,6 +1,9 @@
 ---
 host_ipv4: "172.19.74.76"
 
+common_additional_packages:
+  - firmware-mediatek
+
 manage_network: true
 interfaces_ether_interfaces:
   - device: enp1s0f0
@@ -14,3 +17,19 @@ interfaces_ether_interfaces:
       address: "{{ infrastructure_ipv6_prefix }}::74:{{ host_ipv4.split('.')[3] }}"
       prefix: "{{ infrastructure_ipv6_netmask }}"
       gateway: "{{ infrastructure_ipv6_gateway }}"
+  - device: wlxe84e06893618
+    bootproto: static
+    address: "192.168.4.5"
+    netmask: "255.255.255.0"
+    allowclass: allow-hotplug
+    wpaconf: /etc/wpa_supplicant/wpa_supplicant.conf
+
+wifi_ssid: "ez Share"
+wifi_psk: !vault |
+  $ANSIBLE_VAULT;1.1;AES256
+  38373962326564333065663563393461613534373262383130386230323634356563343163343066
+  3965326339313463633935346634653465653462636433620a363266393232646534303630663935
+  64353338656537643038376361346635343233303763623636373164323064303830393830326463
+  6638313137656561300a356564626462653366336533353532653632373165383965306366303338
+  3038
+wifi_country: "US"

--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -12,7 +12,9 @@
 
 - name: "Install wanted packages"
   ansible.builtin.apt:
-    name: "{{ common_packages_to_install }}"
+    name: >-
+      {{ common_packages_to_install
+         + (common_additional_packages | default([])) }}
     state: present
     autoremove: true
 

--- a/kubernetes/cpap-ezshare-sync/cronjob.yaml
+++ b/kubernetes/cpap-ezshare-sync/cronjob.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: ezshare-sync
+
+spec:
+  schedule: 0 * * * *
+  suspend: false
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          automountServiceAccountToken: false
+          nodeSelector:
+            feature.node.kubernetes.io/usb-ff_148f_7601.present: 'true'
+          containers:
+          - name: sync
+            image: debian:stable-slim@sha256:328d16499860ae6cb9b345e2e4cebca08c2a36e4f7278482c7bd1f39d71e5bfd
+            imagePullPolicy: IfNotPresent
+            command:
+            - /scripts/run
+            env:
+            - name: EZSHARE_URL
+              value: http://192.168.4.1
+            - name: SYNC_TARGET
+              value: /mirror/card
+            volumeMounts:
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+            - name: data
+              mountPath: /mirror
+            - name: tmp
+              mountPath: /tmp
+          volumes:
+          - name: script
+            configMap:
+              name: run-script
+              defaultMode: 0755
+          - name: data
+            persistentVolumeClaim:
+              claimName: data
+          - name: tmp
+            emptyDir: {}
+          restartPolicy: Never

--- a/kubernetes/cpap-ezshare-sync/kustomization.yaml
+++ b/kubernetes/cpap-ezshare-sync/kustomization.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: cpap-ezshare-sync
+
+resources:
+- namespace.yaml
+- pvc.yaml
+- cronjob.yaml
+
+commonAnnotations:
+  argoManaged: 'true'
+
+labels:
+
+- pairs:
+    app.kubernetes.io/name: ezshare-sync
+    app.kubernetes.io/instance: ezshare-sync
+  includeSelectors: true
+
+configMapGenerator:
+- name: run-script
+  files:
+  - run

--- a/kubernetes/cpap-ezshare-sync/namespace.yaml
+++ b/kubernetes/cpap-ezshare-sync/namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: cpap-ezshare-sync

--- a/kubernetes/cpap-ezshare-sync/pvc.yaml
+++ b/kubernetes/cpap-ezshare-sync/pvc.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+
+metadata:
+  name: data
+
+spec:
+  storageClassName: nfs
+  accessModes:
+  - ReadWriteOncePod
+  resources:
+    requests:
+      storage: 20Gi

--- a/kubernetes/cpap-ezshare-sync/run
+++ b/kubernetes/cpap-ezshare-sync/run
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+# renovate: datasource=github-releases depName=haimgel/ezshare-sync
+EZSHARE_SYNC_VERSION=1.1.2
+EZSHARE_URL=${EZSHARE_URL:-http://192.168.4.1}
+SYNC_TARGET=${SYNC_TARGET:-/mirror/card}
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends ca-certificates curl
+
+work_dir=$(mktemp -d /tmp/ezshare-sync.XXXXXX)
+trap 'rm -rf -- "$work_dir"' EXIT
+
+archive="ezshare-sync_${EZSHARE_SYNC_VERSION}_linux_amd64.tar.gz"
+release_url="https://github.com/haimgel/ezshare-sync/releases/download/v${EZSHARE_SYNC_VERSION}/${archive}"
+
+curl -fsSL \
+  --connect-timeout 10 \
+  --retry 5 \
+  --retry-all-errors \
+  -o "$work_dir/$archive" \
+  "$release_url"
+
+tar -xzf "$work_dir/$archive" -C "$work_dir" ezshare-sync
+chmod 0755 "$work_dir/ezshare-sync"
+
+mkdir -p -- "$SYNC_TARGET"
+
+sync_log="$work_dir/sync.log"
+set +e
+"$work_dir/ezshare-sync" -url "$EZSHARE_URL" -target "$SYNC_TARGET" \
+  2>&1 | tee "$sync_log"
+sync_status=${PIPESTATUS[0]}
+set -e
+
+error_count=$(grep -c 'ERROR:' "$sync_log" || true)
+ignored_count=$(grep -Ec \
+  'ERROR: Failed to sync directory /(\.Spotlight-V100|\.fseventsd):' \
+  "$sync_log" || true)
+
+if ((sync_status != 0 &&
+     error_count > 0 &&
+     error_count == ignored_count)) &&
+   grep -Eq \
+     "Sync complete: [0-9]+ files synced, [0-9]+ skipped, ${error_count} errors$" \
+     "$sync_log"; then
+  printf 'Ignoring %d macOS metadata directory error(s)\n' \
+    "$ignored_count" >&2
+  exit 0
+fi
+
+exit "$sync_status"

--- a/kubernetes/got-your-back/run
+++ b/kubernetes/got-your-back/run
@@ -1,5 +1,6 @@
 #!/bin/bash -xve
 
+# renovate: datasource=github-releases depName=GAM-team/got-your-back
 VERSION=1.95
 ARCH=$(uname -m)
 URL="https://github.com/GAM-team/got-your-back/releases/download/v${VERSION}/gyb-${VERSION}-linux-${ARCH}-glibc2.35.tar.xz"


### PR DESCRIPTION
- configure k5 Wi-Fi access to the ezShare card
- run hourly ezshare-sync downloads into an NFS-backed mirror
- track run-script releases with Renovate annotations
