### PR TITLE
Repair VPA admission certificate handling

### DIFF
--- a/kubernetes/vpa/helm/templates/admission-controller-deployment.yaml
+++ b/kubernetes/vpa/helm/templates/admission-controller-deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/version: "1.6.0"
     app.kubernetes.io/managed-by: Helm
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -46,6 +46,7 @@ spec:
             - --register-webhook=false
             - --webhook-service=vpa-webhook
             - --feature-gates=InPlaceOrRecreate=true
+            - --reload-cert=true
           volumeMounts:
             - name: tls-certs
               mountPath: "/etc/tls-certs"
@@ -97,6 +98,15 @@ spec:
                 path: serverCert.pem
               - key: tls.key
                 path: serverKey.pem
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: admission-controller
+                app.kubernetes.io/instance: vpa
+                app.kubernetes.io/name: vpa
+            topologyKey: kubernetes.io/hostname
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane

--- a/kubernetes/vpa/helm/templates/admission-controller-pdb.yaml
+++ b/kubernetes/vpa/helm/templates/admission-controller-pdb.yaml
@@ -1,0 +1,14 @@
+---
+# Source: vpa/templates/admission-controller-pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: "vpa-admission-controller-pdb"
+  namespace: vpa
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: admission-controller
+      app.kubernetes.io/name: vpa
+

--- a/kubernetes/vpa/helm/templates/webhooks/mutating.yaml
+++ b/kubernetes/vpa/helm/templates/webhooks/mutating.yaml
@@ -20,7 +20,7 @@ webhooks:
       name: vpa-webhook
       namespace: vpa
       port: 443
-  failurePolicy: Ignore
+  failurePolicy: Fail
   matchPolicy: Equivalent
   name: vpa.k8s.io
   namespaceSelector: 
@@ -29,6 +29,7 @@ webhooks:
       operator: NotIn
       values:
       - vpa
+      - cert-manager
   objectSelector: 
     {}
   reinvocationPolicy: Never

--- a/kubernetes/vpa/kustomization.yaml
+++ b/kubernetes/vpa/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - helm/templates/clusterroles.yaml
 - helm/templates/recommender-deployment.yaml
 - helm/templates/recommender-service-account.yaml
+- helm/templates/admission-controller-pdb.yaml
 - helm/templates/admission-controller-deployment.yaml
 - helm/templates/admission-controller-service-account.yaml
 - helm/templates/admission-controller-service.yaml
@@ -27,6 +28,7 @@ commonAnnotations:
   argoManaged: 'true'
 
 labels:
+
 - pairs:
     app: vpa
 

--- a/kubernetes/vpa/values.yaml
+++ b/kubernetes/vpa/values.yaml
@@ -21,26 +21,42 @@ updater:
 
 admissionController:
   enabled: true  # Apply recommendations to NEW pods
+  replicaCount: 2
+  podDisruptionBudget:
+    minAvailable: 1
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: admission-controller
+            app.kubernetes.io/instance: vpa
+            app.kubernetes.io/name: vpa
+        topologyKey: kubernetes.io/hostname
   generateCertificate: false  # Use cert-manager instead of Helm hooks
   secretName: vpa-webhook-tls
   extraArgs:
     feature-gates: "InPlaceOrRecreate=true"
+    reload-cert: "true"
   tlsSecretKeys:
-    - key: ca.crt
-      path: caCert.pem
-    - key: tls.crt
-      path: serverCert.pem
-    - key: tls.key
-      path: serverKey.pem
+  - key: ca.crt
+    path: caCert.pem
+  - key: tls.crt
+    path: serverCert.pem
+  - key: tls.key
+    path: serverKey.pem
   tolerations:
-    - key: node-role.kubernetes.io/control-plane
-      operator: Exists
-      effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
   mutatingWebhookConfiguration:
+    # Reject pod creation if VPA mutation fails instead of silently admitting
+    # an unmodified pod without resource requests.
+    failurePolicy: Fail
     annotations:
       cert-manager.io/inject-ca-from: vpa/vpa-webhook-cert
     namespaceSelector:
       matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: [vpa]
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values: [vpa, cert-manager]

--- a/kubernetes/vpa/webhook-certificate.yaml
+++ b/kubernetes/vpa/webhook-certificate.yaml
@@ -1,29 +1,33 @@
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
+
 metadata:
   name: vpa-webhook-cert
   namespace: vpa
+
 spec:
   secretName: vpa-webhook-tls
-  duration: 8760h  # 1 year
+  # Keep webhook leaves shorter than the CA renewal overlap so they are
+  # reissued from the replacement CA before the previous CA expires.
+  duration: 2160h  # 90 days
   renewBefore: 720h  # 30 days
   subject:
     organizations:
-      - vpa
+    - vpa
   isCA: false
   privateKey:
     algorithm: RSA
     encoding: PKCS1
     size: 2048
   usages:
-    - server auth
-    - client auth
+  - server auth
+  - client auth
   dnsNames:
-    - vpa-webhook
-    - vpa-webhook.vpa
-    - vpa-webhook.vpa.svc
-    - vpa-webhook.vpa.svc.cluster.local
+  - vpa-webhook
+  - vpa-webhook.vpa
+  - vpa-webhook.vpa.svc
+  - vpa-webhook.vpa.svc.cluster.local
   issuerRef:
     name: my-ca-issuer
     kind: ClusterIssuer


### PR DESCRIPTION
Use short-lived webhook certificates so leaves renew through CA rotations before the old signer expires. Fail pod admission when VPA mutation cannot run instead of silently creating unmodified pods.
