### PR TITLE
Switch qBittorrent to official image

### DIFF
--- a/kubernetes/cross-seed/deploy.yaml
+++ b/kubernetes/cross-seed/deploy.yaml
@@ -71,7 +71,7 @@ spec:
           mountPath: /config
         - name: torrents
           mountPath: /torrents
-          subPath: qBittorrent/BT_backup
+          subPath: qBittorrent/data/BT_backup
           readOnly: true
         - name: downloads
           mountPath: /downloads

--- a/kubernetes/qbit-manage/deploy.yaml
+++ b/kubernetes/qbit-manage/deploy.yaml
@@ -47,7 +47,7 @@ spec:
           readOnly: false
         - name: qbittorrent-config
           mountPath: /torrents
-          subPath: qBittorrent/BT_backup
+          subPath: qBittorrent/data/BT_backup
           readOnly: true
 
       volumes:

--- a/kubernetes/qbittorrent/deploy.yaml
+++ b/kubernetes/qbittorrent/deploy.yaml
@@ -22,22 +22,20 @@ spec:
       labels:
         app: qbittorrent
     spec:
+      terminationGracePeriodSeconds: 1800
       containers:
       - name: qbittorrent
         # Before upgrading qBittorrent, verify the target version is supported by
         # the qbit_manage image pinned in ../qbit-manage/deploy.yaml.
-        image: ghcr.io/linuxserver/qbittorrent:5.2.3@sha256:b024436f8ca665d16d9a997d26fd27fdf867ee5566ba09f32764e7b2976d3e02
+        image: ghcr.io/qbittorrent/docker-qbittorrent-nox:5.2.3-lt2-1@sha256:f269c2aae56f1bf8caddd77a59e7ba2a278919d8401213266b8fe154c6ac1043
         imagePullPolicy: Always
+        securityContext:
+          runAsGroup: 10001
+          runAsNonRoot: true
+          runAsUser: 10001
         ports:
         - containerPort: 8080
         - containerPort: 51414
-        startupProbe:
-          exec:
-            command:
-            - /scripts/check-health.sh
-          periodSeconds: 5
-          timeoutSeconds: 3
-          failureThreshold: 60
         readinessProbe:
           exec:
             command:
@@ -54,10 +52,8 @@ spec:
           name: scripts
           readOnly: true
         env:
-        - name: PUID
-          value: '10001'
-        - name: PGID
-          value: '10001'
+        - name: QBT_LEGAL_NOTICE
+          value: confirm
         - name: TZ
           value: America/New_York
         - name: QBITTORRENT_API_KEY
@@ -65,6 +61,27 @@ spec:
             secretKeyRef:
               name: qbittorrent
               key: api-key
+      - name: qbittorrent-log
+        image: ghcr.io/qbittorrent/docker-qbittorrent-nox:5.2.3-lt2-1@sha256:f269c2aae56f1bf8caddd77a59e7ba2a278919d8401213266b8fe154c6ac1043
+        imagePullPolicy: Always
+        securityContext:
+          runAsGroup: 10001
+          runAsNonRoot: true
+          runAsUser: 10001
+        command:
+        - /sbin/tini
+        - -g
+        - --
+        - tail
+        args:
+        - -n
+        - "0"
+        - -F
+        - /config/qBittorrent/logs/qbittorrent.log
+        volumeMounts:
+        - mountPath: /config
+          name: config
+          readOnly: true
       volumes:
       - name: config
         persistentVolumeClaim:


### PR DESCRIPTION
- Run the official libtorrent 2 image as the existing non-root UID.
- Remove the restart-causing startup probe and allow graceful shutdowns.
- Stream the qBittorrent file log through a non-root stdout sidecar that forwards termination signals.
- Migrate qbit-manage and cross-seed mounts to the official data layout.
