### PR TITLE
Add authenticated cross-seed completion hook

### DIFF
--- a/kubernetes/qbittorrent/deploy.yaml
+++ b/kubernetes/qbittorrent/deploy.yaml
@@ -61,6 +61,11 @@ spec:
             secretKeyRef:
               name: qbittorrent
               key: api-key
+        - name: CROSS_SEED_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: qbittorrent
+              key: cross-seed-api-key
       - name: qbittorrent-log
         image: ghcr.io/qbittorrent/docker-qbittorrent-nox:5.2.3-lt2-1@sha256:f269c2aae56f1bf8caddd77a59e7ba2a278919d8401213266b8fe154c6ac1043
         imagePullPolicy: Always

--- a/kubernetes/qbittorrent/externalsecret.yaml
+++ b/kubernetes/qbittorrent/externalsecret.yaml
@@ -14,3 +14,7 @@ spec:
     remoteRef:
       key: qbittorrent
       property: qbittorrent-api-key
+  - secretKey: cross-seed-api-key
+    remoteRef:
+      key: qbittorrent
+      property: cross-seed-api-key

--- a/kubernetes/qbittorrent/kustomization.yaml
+++ b/kubernetes/qbittorrent/kustomization.yaml
@@ -18,6 +18,7 @@ configMapGenerator:
 - name: qbittorrent-scripts
   files:
   - scripts/check-health.sh
+  - scripts/cross-seed-hook.sh
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/kubernetes/qbittorrent/scripts/cross-seed-hook.sh
+++ b/kubernetes/qbittorrent/scripts/cross-seed-hook.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+: "${CROSS_SEED_API_KEY:?CROSS_SEED_API_KEY is required}"
+
+info_hash=${1:?info hash is required}
+tags=${2:-}
+
+old_ifs=$IFS
+IFS=,
+for tag in $tags; do
+  tag=$(printf '%s' "$tag" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+  if [ "$tag" = cross-seed ]; then
+    exit 0
+  fi
+done
+IFS=$old_ifs
+
+curl \
+  --fail \
+  --silent \
+  --show-error \
+  --max-time 30 \
+  --request POST \
+  --header "X-Api-Key: ${CROSS_SEED_API_KEY}" \
+  --data-urlencode "infoHash=${info_hash}" \
+  --output /dev/null \
+  http://cross-seed:2468/api/webhook


### PR DESCRIPTION
Mount a reusable qBittorrent completion script that authenticates to cross-seed with a secret-backed API key.

Skip torrents carrying the exact cross-seed tag so completed injections do not trigger another early inject job.
