### PR TITLE
Add qBittorrent operational telemetry

### DIFF
--- a/kubernetes/blackbox-exporter/config.yaml
+++ b/kubernetes/blackbox-exporter/config.yaml
@@ -5,3 +5,11 @@ modules:
     timeout: 5s
     icmp:
       preferred_ip_protocol: ip4
+  qbittorrent_api:
+    prober: http
+    timeout: 3s
+    http:
+      preferred_ip_protocol: ip4
+      authorization:
+        type: Bearer
+        credentials_file: /secrets/qbittorrent-api-key

--- a/kubernetes/blackbox-exporter/deploy.yaml
+++ b/kubernetes/blackbox-exporter/deploy.yaml
@@ -22,13 +22,30 @@ spec:
       - name: blackbox-exporter
         image: prom/blackbox-exporter:v0.28.0@sha256:e753ff9f3fc458d02cca5eddab5a77e1c175eee484a8925ac7d524f04366c2fc
         imagePullPolicy: Always
-        args: [--config.file=/config/config.yaml]
+        args:
+        - --config.file=/config/config.yaml
+        - --web.config.file=/web-config/web-config.yaml
         volumeMounts:
         - name: config
           mountPath: /config
+        - name: web-config
+          mountPath: /web-config
+          readOnly: true
+        - name: qbittorrent-api-key
+          mountPath: /secrets
+          readOnly: true
         ports:
         - containerPort: 9115
       volumes:
       - name: config
         configMap:
           name: config
+      - name: web-config
+        secret:
+          secretName: blackbox-exporter-web-config
+      - name: qbittorrent-api-key
+        secret:
+          secretName: qbittorrent
+          items:
+          - key: api-key
+            path: qbittorrent-api-key

--- a/kubernetes/blackbox-exporter/externalsecret.yaml
+++ b/kubernetes/blackbox-exporter/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+  name: exporter-web-config
+
+spec:
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  data:
+  - secretKey: password
+    remoteRef:
+      key: blackbox-exporter-password
+      property: password
+  target:
+    template:
+      engineVersion: v2
+      data:
+        web-config.yaml: |-
+          basic_auth_users:
+            prometheus: {{ htpasswd "prometheus" .password "bcrypt" | replace "prometheus:" "" | quote }}

--- a/kubernetes/blackbox-exporter/kustomization.yaml
+++ b/kubernetes/blackbox-exporter/kustomization.yaml
@@ -11,6 +11,7 @@ commonAnnotations:
 
 resources:
 - deploy.yaml
+- externalsecret.yaml
 - service.yaml
 
 labels:

--- a/kubernetes/prometheus/config/prometheus.yml
+++ b/kubernetes/prometheus/config/prometheus.yml
@@ -46,6 +46,9 @@ scrape_configs:
 
 - job_name: blackbox
   metrics_path: /probe
+  basic_auth:
+    username: prometheus
+    password_file: /secrets/blackbox-exporter-password
   params:
     module: [icmp]
   static_configs:
@@ -59,6 +62,56 @@ scrape_configs:
     target_label: instance
   - target_label: __address__
     replacement: blackbox-exporter:9115  # The blackbox exporter's real hostname:port.
+
+- job_name: qbittorrent-api-pod
+  scrape_interval: 10s
+  scrape_timeout: 5s
+  metrics_path: /probe
+  basic_auth:
+    username: prometheus
+    password_file: /secrets/blackbox-exporter-password
+  params:
+    module: [qbittorrent_api]
+  kubernetes_sd_configs:
+  - role: pod
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_pod_phase]
+    action: keep
+    regex: Running
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_name, __meta_kubernetes_pod_container_port_number]
+    action: keep
+    regex: default;qbittorrent;qbittorrent;8080
+  - source_labels: [__meta_kubernetes_pod_ip]
+    target_label: __param_target
+    replacement: http://${1}:8080/api/v2/transfer/info
+  - target_label: instance
+    replacement: qbittorrent-pod
+  - target_label: endpoint
+    replacement: direct
+  - target_label: __address__
+    replacement: blackbox-exporter:9115
+
+- job_name: qbittorrent-api-ingress
+  scrape_interval: 10s
+  scrape_timeout: 5s
+  metrics_path: /probe
+  basic_auth:
+    username: prometheus
+    password_file: /secrets/blackbox-exporter-password
+  params:
+    module: [qbittorrent_api]
+  static_configs:
+  - targets:
+    - https://qbittorrent.k.oneill.net/api/v2/transfer/info
+    labels:
+      endpoint: ingress
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: __param_target
+  - target_label: instance
+    replacement: qbittorrent-ingress
+  - target_label: __address__
+    replacement: blackbox-exporter:9115
 
 - job_name: hass
   scrape_interval: 2s

--- a/kubernetes/prometheus/config/rules.yml
+++ b/kubernetes/prometheus/config/rules.yml
@@ -25,8 +25,11 @@ groups:
       message: xtal is reachable by LAN ICMP, but node_exporter over Tailscale has
         not been scraped for 35 minutes
   - alert: ICMPUnreachable
-    expr: probe_success == 0
+    expr: probe_success{job="blackbox"} == 0
     for: 20m
+  - alert: QBittorrentAPIUnreachable
+    expr: probe_success{job=~"qbittorrent-api-(pod|ingress)"} == 0
+    for: 5m
   - alert: ExporterDown
     expr: up{job!="node resources", job!="hwinfo gaming pc", resticprofile!~".+"}
       == 0

--- a/kubernetes/prometheus/externalsecret.yaml
+++ b/kubernetes/prometheus/externalsecret.yaml
@@ -17,3 +17,7 @@ spec:
     remoteRef:
       key: karakeep
       property: prometheus_auth_token
+  - secretKey: blackbox-exporter-password
+    remoteRef:
+      key: blackbox-exporter-password
+      property: password

--- a/kubernetes/qui/deploy.yaml
+++ b/kubernetes/qui/deploy.yaml
@@ -28,6 +28,8 @@ spec:
         image: ghcr.io/autobrr/qui:v1.23.0@sha256:b1abd18f1d544cd5c63a3b8d9c8a91d097143e04df416567a8cb52040f380ca8
         ports:
         - containerPort: 7476
+        - containerPort: 9074
+          name: metrics
         envFrom:
         - secretRef:
             name: qui-oidc
@@ -42,6 +44,12 @@ spec:
           value: https://auth.k.oneill.net/application/o/qui/
         - name: QUI__OIDC_REDIRECT_URL
           value: https://qui.k.oneill.net/api/auth/oidc/callback
+        - name: QUI__METRICS_ENABLED
+          value: 'true'
+        - name: QUI__METRICS_HOST
+          value: 0.0.0.0
+        - name: QUI__METRICS_PORT
+          value: '9074'
         volumeMounts:
         - mountPath: /config
           name: config

--- a/kubernetes/qui/kustomization.yaml
+++ b/kubernetes/qui/kustomization.yaml
@@ -10,6 +10,7 @@ commonAnnotations:
 resources:
 - deploy.yaml
 - service.yaml
+- service-metrics.yaml
 - ingress.yaml
 - externalsecret.yaml
 - pvc-config.yaml

--- a/kubernetes/qui/service-metrics.yaml
+++ b/kubernetes/qui/service-metrics.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: qui-metrics
+  labels:
+    app: qui
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: /metrics
+    prometheus.io/port: '9074'
+
+spec:
+  ports:
+  - port: 9074
+    targetPort: metrics
+    protocol: TCP
+    name: metrics
+  selector:
+    app: qui


### PR DESCRIPTION
Enable qui aggregate metrics and scrape them with Prometheus.

Probe the authenticated qBittorrent Web API through both the pod IP and ingress so API hangs can be distinguished from routing failures.
