### PR TITLE
Reduce cross-seed full search frequency

### DIFF
--- a/kubernetes/cross-seed/config.js
+++ b/kubernetes/cross-seed/config.js
@@ -198,7 +198,7 @@ module.exports = {
      * "2w"
      * "3 days"
      */
-    searchCadence: "1d",
+    searchCadence: "2w",
     /**
      * Fail snatch requests that haven't responded after this long.
      * Set to null for an infinite timeout.


### PR DESCRIPTION
Run full cross-seed searches every two weeks as recommended when RSS searches are enabled.

Keep the 30-minute RSS cadence and completion-triggered searches unchanged.
