### PR TITLE
Enforce pinned image pull policy

### DIFF
--- a/.kyverno/policies/require-pinned-image-pull-policy.yaml
+++ b/.kyverno/policies/require-pinned-image-pull-policy.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+
+metadata:
+  name: require-pinned-image-pull-policy
+
+spec:
+  validationFailureAction: Enforce
+  rules:
+  - name: require-if-not-present-for-pinned-images
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        Images pinned by digest must omit imagePullPolicy or set it to
+        IfNotPresent. Images using a latest tag must set it explicitly.
+      foreach:
+      - list: request.object.spec.containers || `[]`
+        preconditions:
+          all:
+          - key: "{{ contains(element.image, '@sha256:') }}"
+            operator: Equals
+            value: true
+        deny:
+          conditions:
+            any:
+            - key: "{{ element.imagePullPolicy || 'IfNotPresent' }}"
+              operator: NotEquals
+              value: IfNotPresent
+            - key: >-
+                {{ element.imagePullPolicy ||
+                contains(element.image, ':latest@sha256:') }}
+              operator: Equals
+              value: true
+      - list: request.object.spec.initContainers || `[]`
+        preconditions:
+          all:
+          - key: "{{ contains(element.image, '@sha256:') }}"
+            operator: Equals
+            value: true
+        deny:
+          conditions:
+            any:
+            - key: "{{ element.imagePullPolicy || 'IfNotPresent' }}"
+              operator: NotEquals
+              value: IfNotPresent
+            - key: >-
+                {{ element.imagePullPolicy ||
+                contains(element.image, ':latest@sha256:') }}
+              operator: Equals
+              value: true
+      - list: request.object.spec.ephemeralContainers || `[]`
+        preconditions:
+          all:
+          - key: "{{ contains(element.image, '@sha256:') }}"
+            operator: Equals
+            value: true
+        deny:
+          conditions:
+            any:
+            - key: "{{ element.imagePullPolicy || 'IfNotPresent' }}"
+              operator: NotEquals
+              value: IfNotPresent
+            - key: >-
+                {{ element.imagePullPolicy ||
+                contains(element.image, ':latest@sha256:') }}
+              operator: Equals
+              value: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,10 +72,11 @@ repos:
     pass_filenames: false
   - id: kyverno-validate
     name: kyverno policy validation
-    entry: kubernetes/scripts/kyverno-wrapper
+    entry: kubernetes/scripts/kyverno-wrapper --all-pinned-images
     language: system
     pass_filenames: true
-    files: ^kubernetes/.*\.(ya?ml)$
+    always_run: true
+    files: ^(kubernetes/.*|\.kyverno/policies/.*)\.(ya?ml)$
   - id: esphome-hosts-check
     name: check ESPHome hosts terraform is up to date
     entry: scripts/gen-esphome-hosts --check

--- a/kubernetes/awair-exporter/deploy.yaml
+++ b/kubernetes/awair-exporter/deploy.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
       - name: awair-exporter
         image: dvorak/awair_exporter:latest@sha256:5c0cae7ff6b699eec82c28ad1b54b22142ab09aeb99688cd397948167f8cca91
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         envFrom:
         - secretRef:
             name: awair-exporter

--- a/kubernetes/blackbox-exporter/deploy.yaml
+++ b/kubernetes/blackbox-exporter/deploy.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - name: blackbox-exporter
         image: prom/blackbox-exporter:v0.28.0@sha256:e753ff9f3fc458d02cca5eddab5a77e1c175eee484a8925ac7d524f04366c2fc
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args:
         - --config.file=/config/config.yaml
         - --web.config.file=/web-config/web-config.yaml

--- a/kubernetes/cluster-backup/cronjob.yaml
+++ b/kubernetes/cluster-backup/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
           containers:
           - name: cluster-backup
             image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
-            imagePullPolicy: Always
+            imagePullPolicy: IfNotPresent
             command:
             - /script/backup
             volumeMounts:

--- a/kubernetes/got-your-back/cronjob-full.yaml
+++ b/kubernetes/got-your-back/cronjob-full.yaml
@@ -16,7 +16,7 @@ spec:
           - name: got-your-back
             image: debian:stable-slim@sha256:328d16499860ae6cb9b345e2e4cebca08c2a36e4f7278482c7bd1f39d71e5bfd
             command: [/usr/local/bin/run]
-            imagePullPolicy: Always
+            imagePullPolicy: IfNotPresent
             env:
             - name: HEALTHCHECK_PING_KEY
               valueFrom:

--- a/kubernetes/got-your-back/cronjob-incremental.yaml
+++ b/kubernetes/got-your-back/cronjob-incremental.yaml
@@ -16,7 +16,7 @@ spec:
           - name: got-your-back
             image: debian:stable-slim@sha256:328d16499860ae6cb9b345e2e4cebca08c2a36e4f7278482c7bd1f39d71e5bfd
             command: [/usr/local/bin/run, --fast-incremental]
-            imagePullPolicy: Always
+            imagePullPolicy: IfNotPresent
             env:
             - name: HEALTHCHECK_PING_KEY
               valueFrom:

--- a/kubernetes/meshcentral/deploy.yaml
+++ b/kubernetes/meshcentral/deploy.yaml
@@ -32,7 +32,7 @@ spec:
       containers:
       - name: meshcentral
         image: typhonragewind/meshcentral:1.1.53@sha256:9ea262ff902fa18fcca8688af4c7fe62988254f5cf08f273193bec6b4cf626be
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         env:
         - name: TZ
           value: America/New_York

--- a/kubernetes/mosquitto/deploy.yaml
+++ b/kubernetes/mosquitto/deploy.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
       - name: mosquitto
         image: eclipse-mosquitto:2.0@sha256:212f89e1eaeb2c322d6441b64396e3346026674db8fa9c27beac293405c32b3c
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         resources:
           limits:
             cpu: '0.5'

--- a/kubernetes/mqtt-log/deploy.yaml
+++ b/kubernetes/mqtt-log/deploy.yaml
@@ -38,4 +38,4 @@ spec:
         command: [/usr/bin/mosquitto_sub]
         args: [-h, mosquitto, -t, '#', -v, -u, $(MQTT_USERNAME), -P, $(MQTT_PASSWORD),
           -F, '{"timestamp":"%I","topic":"%t","message":"%p"}']
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent

--- a/kubernetes/netatmo-wunderground-agent/deploy.yaml
+++ b/kubernetes/netatmo-wunderground-agent/deploy.yaml
@@ -23,6 +23,7 @@ spec:
       containers:
       - name: netatmo-wunderground-agent
         image: brbeaird/netatmo-wunderground-agent:latest@sha256:9762b8722cb99722fa7f0669d389b4298f8b8599c8f06d745683ae1d89f319fe
+        imagePullPolicy: IfNotPresent
         env:
         - name: netatmo_tokenFileDirectory
           value: /data

--- a/kubernetes/plexmediaserver/deploy.yaml
+++ b/kubernetes/plexmediaserver/deploy.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: plexmediaserver
         image: lscr.io/linuxserver/plex:1.42.2.10156-f737b826c-ls288@sha256:1720efa8e919a724ff3003cce7c1c0ae91a54e097ca3c8f6713a780c6fd73432
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
             command: [dd, if=/dev/zero, of=/config/health-check, bs=1M, count=1]

--- a/kubernetes/qbittorrent/deploy.yaml
+++ b/kubernetes/qbittorrent/deploy.yaml
@@ -28,7 +28,7 @@ spec:
         # Before upgrading qBittorrent, verify the target version is supported by
         # the qbit_manage image pinned in ../qbit-manage/deploy.yaml.
         image: ghcr.io/qbittorrent/docker-qbittorrent-nox:5.2.3-lt2-1@sha256:f269c2aae56f1bf8caddd77a59e7ba2a278919d8401213266b8fe154c6ac1043
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           runAsGroup: 10001
           runAsNonRoot: true
@@ -68,7 +68,7 @@ spec:
               key: cross-seed-api-key
       - name: qbittorrent-log
         image: ghcr.io/qbittorrent/docker-qbittorrent-nox:5.2.3-lt2-1@sha256:f269c2aae56f1bf8caddd77a59e7ba2a278919d8401213266b8fe154c6ac1043
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           runAsGroup: 10001
           runAsNonRoot: true

--- a/kubernetes/rclone-exporter/deployment.yaml
+++ b/kubernetes/rclone-exporter/deployment.yaml
@@ -22,6 +22,7 @@ spec:
       containers:
       - name: rclone-exporter
         image: ghcr.io/crazyuploader/rclone_exporter:latest@sha256:bfed0633be29c7d14f895b578452e5356dca28644878dfa5a6eebe5021a84c5b
+        imagePullPolicy: IfNotPresent
         env:
         - name: RC_EXPORTER_RCLONE_TIMEOUT
           value: 1m50s

--- a/kubernetes/scripts/kyverno-wrapper
+++ b/kubernetes/scripts/kyverno-wrapper
@@ -1,25 +1,76 @@
 #!/usr/bin/env bash
-# Filter YAML files to only those with valid Kubernetes kind field
-# Pass filtered files to kyverno apply
+# Normalize Kubernetes YAML documents and pass them to kyverno apply.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BASEDIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 POLICY_DIR="$BASEDIR/.kyverno/policies"
+PINNED_IMAGE_POLICY="$POLICY_DIR/require-pinned-image-pull-policy.yaml"
 
-# Use yq to filter all files at once - much faster than per-file checks
-# select(.kind) filters to documents with a kind field, filename outputs the path
-mapfile -t valid_files < <(yq 'select(.kind) | filename' "$@" 2>/dev/null | sort -u)
+validate_files() {
+  local policy_path=$1
+  local resource_file=$2
+  shift 2
 
-if [[ ${#valid_files[@]} -eq 0 ]]; then
+  if [[ $# -eq 0 ]]; then
+    return
+  fi
+
+  # First identify parseable files containing Kubernetes resources. Some
+  # values files are intentionally not standalone YAML and are ignored here.
+  local -a valid_files
+  mapfile -t valid_files < <(
+    printf '%s\0' "$@" \
+      | xargs -0 -n 1 -P 8 yq 'select(.kind) | filename' 2>/dev/null \
+      | sort -u
+  )
+
+  if [[ ${#valid_files[@]} -eq 0 ]]; then
+    return
+  fi
+
+  # Normalize multi-document input before validation. This removes empty
+  # documents and comments which the Kyverno CLI can otherwise reject.
+  yq 'select(.kind and .kind != "CustomResourceDefinition")' \
+    "${valid_files[@]}" > "$resource_file"
+
+  if [[ -s $resource_file ]]; then
+    kyverno apply "$policy_path" --resource "$resource_file"
+  fi
+}
+
+validate_all_pinned_images=false
+if [[ ${1:-} == "--all-pinned-images" ]]; then
+  validate_all_pinned_images=true
+  shift
+fi
+
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
+
+# Preserve the existing behavior for changed, non-generated manifests.
+validate_files "$POLICY_DIR" "$temp_dir/changed-resources.yaml" "$@"
+
+if [[ $validate_all_pinned_images != true ]]; then
   exit 0
 fi
 
-# Build --resource args
-args=()
-for f in "${valid_files[@]}"; do
-  args+=(--resource "$f")
-done
+# Build each deployable, top-level Kustomization so the pinned-image policy
+# evaluates final resources after Helm output, patches, and components are
+# composed.
+raw_resource_file="$temp_dir/raw-rendered-resources.yaml"
+while IFS= read -r kustomization; do
+  printf '%s\n' '---' >> "$raw_resource_file"
+  kubectl kustomize "${kustomization%/*}" >> "$raw_resource_file"
+done < <(
+  find "$BASEDIR/kubernetes" -mindepth 2 -maxdepth 2 -type f \
+    \( -name 'kustomization.yaml' -o -name 'kustomization.yml' \) \
+    | sort
+)
 
-exec kyverno apply "$POLICY_DIR" "${args[@]}"
+yq 'select(.kind and .kind != "CustomResourceDefinition")' \
+  "$raw_resource_file" > "$temp_dir/rendered-resources.yaml"
+
+kyverno apply "$PINNED_IMAGE_POLICY" \
+  --resource "$temp_dir/rendered-resources.yaml"

--- a/kubernetes/smokeping/deploy.yaml
+++ b/kubernetes/smokeping/deploy.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: smokeping
         image: dvorak/docker-smokeping:latest@sha256:f458e95b8d4ae8499e6efff9bb891b937eff13bd65550cb59f5b7a246a0de352
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         volumeMounts:

--- a/kubernetes/tautulli/deploy.yaml
+++ b/kubernetes/tautulli/deploy.yaml
@@ -24,7 +24,7 @@ spec:
         securityContext:
           privileged: true
         image: tautulli/tautulli:v2.17.2@sha256:864245fb24830ef6516b5f383bf4d8ba37939ae2f0574dc0217ca02fba4301ff
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8181
         env:


### PR DESCRIPTION
Require digest-pinned containers to omit imagePullPolicy or use IfNotPresent.

Update existing pinned workloads and make pre-commit validate final Kustomize output, including rendered Helm resources.
