### PR TITLE
Prefer ingress for Kubernetes access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ including:
 
 - **GitOps for Kubernetes**: We test locally first with `kubectl apply -k`
   before creating PRs for ArgoCD deployment
+- **Kubernetes service access**: Use configured ingress by default. Use
+  `kubectl port-forward` only when direct service access is explicitly required
 - **Infrastructure as code**: All changes tracked in version control
 - **Automation first**: Prefer scripts and tooling over manual steps
 


### PR DESCRIPTION
Use configured ingress for service access by default, reserving kubectl port-forward for cases that explicitly require direct access.

