### PR TITLE
Add SpoolBuddy network configuration

### DIFF
--- a/ansible/host_vars/spoolbuddy.yaml
+++ b/ansible/host_vars/spoolbuddy.yaml
@@ -1,0 +1,22 @@
+---
+manage_network: true
+host_ipv4: "172.19.74.87"
+
+# WiFi configuration (layereight.wifi role)
+wifi_country: "US"
+wifi_ssid: "bleh"
+wifi_psk: "{{ vault_wifi_psk_bleh }}"
+
+interfaces_ether_interfaces:
+  - device: wlan0
+    bootproto: static
+    address: "172.19.74.87"
+    netmask: "255.255.255.0"
+    gateway: 172.19.74.1
+    dnsnameservers: 172.19.74.1
+    dnssearch: oneill.net
+    wpaconf: /etc/wpa_supplicant/wpa_supplicant.conf
+    ip6:
+      address: "{{ infrastructure_ipv6_prefix }}::74:{{ host_ipv4.split('.')[3] }}"
+      prefix: "{{ infrastructure_ipv6_netmask }}"
+      gateway: "{{ infrastructure_ipv6_gateway }}"

--- a/ansible/inventory/default
+++ b/ansible/inventory/default
@@ -11,6 +11,7 @@ k5 ansible_host=k5.oneill.net domain=oneill.net
 #gasherbrum-display ansible_host=gasherbrum-display.oneill.net domain=oneill.net
 pantrypi ansible_host=pantrypi.oneill.net domain=oneill.net
 garagepi ansible_host=garagepi.oneill.net domain=oneill.net
+spoolbuddy ansible_host=spoolbuddy.oneill.net domain=oneill.net
 infra1 ansible_host=infra1.oneill.net domain=oneill.net
 p1 ansible_host=p1.oneill.net domain=oneill.net
 
@@ -45,6 +46,7 @@ k5
 #gasherbrum-display
 pantrypi
 garagepi
+spoolbuddy
 
 [pizero]
 #voron2-pizero

--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -119,6 +119,12 @@ locals {
       hostname = "pantrypi.oneill.net"
       note     = "Raspberry Pi in pantry - zwavejs, zigbee2mqtt, rtl433"
     }
+    spoolbuddy = {
+      mac      = "dc:a6:32:9d:b7:10"
+      ip       = "172.19.74.87"
+      hostname = "spoolbuddy.oneill.net"
+      note     = "Raspberry Pi 4 for BambuBuddy SpoolBuddy"
+    }
     landroid = {
       mac         = "7c:fa:80:61:08:2e"
       ip          = "172.20.6.67"


### PR DESCRIPTION
Register SpoolBuddy in the Raspberry Pi inventory and configure its static Wi-Fi network settings.

Reserve its address and hostname through the OpenTofu-managed network host map.
