### PR TITLE
Update Speakr to 0.10.2-alpha

### DIFF
--- a/kubernetes/speakr/deploy-speakr.yaml
+++ b/kubernetes/speakr/deploy-speakr.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: speakr
-        image: learnedmachine/speakr:0.8.21-alpha@sha256:1f2f873eb174abfcf4ca99cf8473f963026195b212cd0dcae89023c192704b44
+        image: learnedmachine/speakr:0.10.2-alpha@sha256:2e6789ccf8b16ac6c278186ec52ff03658cd7b015727da9055295e4e258f38ad
         ports:
         - name: http
           containerPort: 8899
@@ -89,7 +89,7 @@ spec:
           value: 'true'
         volumeMounts:
         - name: uploads
-          mountPath: /app/uploads
+          mountPath: /data
       volumes:
       - name: uploads
         persistentVolumeClaim:


### PR DESCRIPTION
Update Speakr to the tested 0.10.2-alpha image digest.

Mount the persistent volume at /data so uploads and the generated instance secret use the paths expected by current Speakr releases.
