### PR TITLE
Update Bambuddy to 1.2.5

### DIFF
--- a/kubernetes/bambuddy/deployment.yaml
+++ b/kubernetes/bambuddy/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: bambuddy
-        image: ghcr.io/maziggy/bambuddy:0.2.4.9@sha256:d68ab4746f18c51a6e22f5cd536533a4ae3c1eb48f4eecccbb68c2be23d0ef52
+        image: ghcr.io/maziggy/bambuddy:1.2.5@sha256:9fd7ae3e59e8ce5713306d33ca034422f1b2150b788b6c6848a41726065084fd
         args:
         - uvicorn
         - backend.app.main:app


### PR DESCRIPTION
Move Bambuddy across its upstream versioning-scheme transition from 0.2.4.9 to 1.2.5 and pin the new multi-architecture image digest.
