### PR TITLE
Fix Renovate version discovery

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -223,6 +223,26 @@
       "description": "Track LT2 qBittorrent image build revisions"
     },
     {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/maziggy/bambuddy"
+      ],
+      "versioning": "loose",
+      "description": "Support Bambuddy's four-part release versions"
+    },
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "plexinc/pms-docker"
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)\\.(?<build>\\d+)-[0-9a-f]+$",
+      "description": "Track official Plex version tags"
+    },
+    {
       "matchPackageNames": [
         "linuxserver/radarr"
       ],
@@ -429,7 +449,7 @@
     },
     {
       "description": "MariaDB: LTS versions at least 6 months old (auto-managed)",
-      "allowedVersions": "/^(11\\.8|11\\.4|10\\.11)\\./",
+      "allowedVersions": "/^(11\\.8|11\\.4|10\\.11)(?:\\.|$)/",
       "matchDatasources": [
         "docker"
       ],

--- a/kubernetes/plexmediaserver/deploy.yaml
+++ b/kubernetes/plexmediaserver/deploy.yaml
@@ -28,7 +28,7 @@ spec:
       priorityClassName: gpu-priority
       containers:
       - name: plexmediaserver
-        image: lscr.io/linuxserver/plex:1.42.2.10156-f737b826c-ls288@sha256:1720efa8e919a724ff3003cce7c1c0ae91a54e097ca3c8f6713a780c6fd73432
+        image: plexinc/pms-docker:1.42.2.10156-f737b826c@sha256:9c03c26b9479ba9a09935f3367459bfdc8d21545f42ed2a13258983c5be1b252
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -51,12 +51,10 @@ spec:
         - containerPort: 32414
           protocol: UDP
         env:
-        - name: PUID
+        - name: PLEX_UID
           value: '1001'
-        - name: PGID
+        - name: PLEX_GID
           value: '1001'
-        - name: VERSION
-          value: docker
         - name: NVIDIA_VISIBLE_DEVICES
           value: all
         - name: NVIDIA_DRIVER_CAPABILITIES

--- a/scripts/update-renovate-versions.py
+++ b/scripts/update-renovate-versions.py
@@ -60,7 +60,7 @@ def get_mariadb_allowed_versions() -> str | None:
         print("Warning: No MariaDB LTS versions found >= 6 months old", file=sys.stderr)
         return None
 
-    return f"/^({'|'.join(lts_cycles)})\\./"
+    return f"/^({'|'.join(lts_cycles)})(?:\\.|$)/"
 
 
 def get_postgresql_allowed_versions() -> str | None:


### PR DESCRIPTION
- support Bambuddy and official Plex version formats
- accept floating MariaDB LTS aliases
- move Plex to the official same-version image
