### PR TITLE
Use noop registry for ExternalDNS

### DIFF
--- a/kubernetes/external-dns/helm/templates/clusterrole.yaml
+++ b/kubernetes/external-dns/helm/templates/clusterrole.yaml
@@ -25,3 +25,4 @@ rules:
   - apiGroups: ["extensions","networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get","watch","list"]
+

--- a/kubernetes/external-dns/helm/templates/clusterrolebinding.yaml
+++ b/kubernetes/external-dns/helm/templates/clusterrolebinding.yaml
@@ -17,3 +17,4 @@ subjects:
   - kind: ServiceAccount
     name: external-dns
     namespace: default
+

--- a/kubernetes/external-dns/helm/templates/deployment.yaml
+++ b/kubernetes/external-dns/helm/templates/deployment.yaml
@@ -59,11 +59,10 @@ spec:
             - --source=service
             - --source=ingress
             - --policy=sync
-            - --registry=txt
-            - --txt-owner-id=external-dns
-            - --txt-prefix=extdns-
-            - --domain-filter=oneill.net
+            - --registry=noop
+            - --domain-filter=k.oneill.net
             - --provider=cloudflare
+            - "--zone-id-filter=5a8d9de1c40f089d2f98f49a4569e1cd"
           ports:
             - name: http
               protocol: TCP

--- a/kubernetes/external-dns/helm/templates/deployment.yaml
+++ b/kubernetes/external-dns/helm/templates/deployment.yaml
@@ -85,3 +85,4 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5
+

--- a/kubernetes/external-dns/helm/templates/service.yaml
+++ b/kubernetes/external-dns/helm/templates/service.yaml
@@ -20,3 +20,4 @@ spec:
       port: 7979
       targetPort: http
       protocol: TCP
+

--- a/kubernetes/external-dns/helm/templates/serviceaccount.yaml
+++ b/kubernetes/external-dns/helm/templates/serviceaccount.yaml
@@ -11,3 +11,4 @@ metadata:
     app.kubernetes.io/version: "0.21.0"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
+

--- a/kubernetes/external-dns/values.yaml
+++ b/kubernetes/external-dns/values.yaml
@@ -3,11 +3,12 @@ provider:
   name: cloudflare
 
 policy: sync
-txtPrefix: extdns-
-txtOwnerId: external-dns
+registry: noop
 triggerLoopOnEvent: true
 domainFilters:
-- oneill.net
+- k.oneill.net
+extraArgs:
+- --zone-id-filter=5a8d9de1c40f089d2f98f49a4569e1cd
 env:
 - name: CF_API_TOKEN
   valueFrom:


### PR DESCRIPTION
Stop creating per-record ownership TXT records in Cloudflare.

- Limit reconciliation to k.oneill.net.
- Select the parent zone by ID for Cloudflare discovery.

This is needed to stay under the 200 record limit on the cloud flare free plan 😭
