### PR TITLE
Extend Authentik proxy sessions

### DIFF
--- a/kubernetes/scripts/templates/provider-app-proxy.tf.j2
+++ b/kubernetes/scripts/templates/provider-app-proxy.tf.j2
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "{{ app }}" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
   {% if basic %}
   basic_auth_enabled            = true

--- a/opentofu/modules/authentik/generated-alertmanager.tf
+++ b/opentofu/modules/authentik/generated-alertmanager.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "alertmanager" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
 
   skip_path_regex = <<-EOT

--- a/opentofu/modules/authentik/generated-ara.tf
+++ b/opentofu/modules/authentik/generated-ara.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "ara" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
 
 }

--- a/opentofu/modules/authentik/generated-bazarr.tf
+++ b/opentofu/modules/authentik/generated-bazarr.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "bazarr" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
   basic_auth_enabled            = true
   basic_auth_username_attribute = "username"

--- a/opentofu/modules/authentik/generated-bookbridge.tf
+++ b/opentofu/modules/authentik/generated-bookbridge.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "bookbridge" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
 
 }

--- a/opentofu/modules/authentik/generated-camofox.tf
+++ b/opentofu/modules/authentik/generated-camofox.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "camofox" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
 
 }

--- a/opentofu/modules/authentik/generated-changedetection.tf
+++ b/opentofu/modules/authentik/generated-changedetection.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "changedetection" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
 
 }

--- a/opentofu/modules/authentik/generated-felix-www.tf
+++ b/opentofu/modules/authentik/generated-felix-www.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "felix-www" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
 
 }

--- a/opentofu/modules/authentik/generated-goldilocks.tf
+++ b/opentofu/modules/authentik/generated-goldilocks.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "goldilocks" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
 
 }

--- a/opentofu/modules/authentik/generated-healthchecks.tf
+++ b/opentofu/modules/authentik/generated-healthchecks.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "healthchecks" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
 
   skip_path_regex = <<-EOT

--- a/opentofu/modules/authentik/generated-homepage.tf
+++ b/opentofu/modules/authentik/generated-homepage.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "homepage" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
 
 }

--- a/opentofu/modules/authentik/generated-minuspod.tf
+++ b/opentofu/modules/authentik/generated-minuspod.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "minuspod" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
 
 }

--- a/opentofu/modules/authentik/generated-netdata.tf
+++ b/opentofu/modules/authentik/generated-netdata.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "netdata" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
 
 }

--- a/opentofu/modules/authentik/generated-prometheus.tf
+++ b/opentofu/modules/authentik/generated-prometheus.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "prometheus" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
 
   skip_path_regex = <<-EOT

--- a/opentofu/modules/authentik/generated-prowlarr.tf
+++ b/opentofu/modules/authentik/generated-prowlarr.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "prowlarr" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
   basic_auth_enabled            = true
   basic_auth_username_attribute = "username"

--- a/opentofu/modules/authentik/generated-qbit-manage.tf
+++ b/opentofu/modules/authentik/generated-qbit-manage.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "qbit-manage" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
 
 }

--- a/opentofu/modules/authentik/generated-radarr.tf
+++ b/opentofu/modules/authentik/generated-radarr.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "radarr" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
   basic_auth_enabled            = true
   basic_auth_username_attribute = "username"

--- a/opentofu/modules/authentik/generated-readest-hardcover-sync.tf
+++ b/opentofu/modules/authentik/generated-readest-hardcover-sync.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "readest-hardcover-sync" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
 
 }

--- a/opentofu/modules/authentik/generated-smokeping.tf
+++ b/opentofu/modules/authentik/generated-smokeping.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "smokeping" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
 
 }

--- a/opentofu/modules/authentik/generated-sonarr.tf
+++ b/opentofu/modules/authentik/generated-sonarr.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "sonarr" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
   basic_auth_enabled            = true
   basic_auth_username_attribute = "username"

--- a/opentofu/modules/authentik/generated-tautulli.tf
+++ b/opentofu/modules/authentik/generated-tautulli.tf
@@ -10,7 +10,7 @@ resource "authentik_provider_proxy" "tautulli" {
   cookie_domain         = "oneill.net"
   authorization_flow    = data.authentik_flow.default_authorization.id
   invalidation_flow     = data.authentik_flow.default_invalidation.id
-  access_token_validity = "hours=1"
+  access_token_validity = "days=365"
 
   basic_auth_enabled            = true
   basic_auth_username_attribute = "username"


### PR DESCRIPTION
Set generated proxy-provider access tokens to one year and update the shared template. Native OIDC provider lifetimes remain unchanged.
