### PR TITLE
Add PiFire host configuration

### DIFF
--- a/ansible/host_vars/pifire.yaml
+++ b/ansible/host_vars/pifire.yaml
@@ -1,0 +1,34 @@
+---
+manage_network: true
+host_ipv4: "172.19.74.89"
+
+# WiFi configuration (layereight.wifi role)
+wifi_country: "US"
+wifi_ssid: "bleh"
+wifi_psk: "{{ vault_wifi_psk_bleh }}"
+
+traefik_config_files:
+  - pifire
+traefik_conflicting_services:
+  - nginx
+traefik_network_mode: host
+pifire_backend_url: http://127.0.0.1:8000
+
+interfaces_ether_interfaces:
+  - device: wlan0
+    bootproto: static
+    address: "172.19.74.89"
+    netmask: "255.255.255.0"
+    gateway: 172.19.74.1
+    dnsnameservers: 172.19.74.1
+    dnssearch: oneill.net
+    wpaconf: /etc/wpa_supplicant/wpa_supplicant.conf
+    ip6:
+      address: "{{ infrastructure_ipv6_prefix }}::74:{{ host_ipv4.split('.')[3] }}"
+      prefix: "{{ infrastructure_ipv6_netmask }}"
+      gateway: "{{ infrastructure_ipv6_gateway }}"
+
+restic_host_config:
+  default:
+    backup:
+      schedule: "*-*-* 03:00:00"

--- a/ansible/inventory/default
+++ b/ansible/inventory/default
@@ -11,7 +11,8 @@ k5 ansible_host=k5.oneill.net domain=oneill.net
 #gasherbrum-display ansible_host=gasherbrum-display.oneill.net domain=oneill.net
 pantrypi ansible_host=pantrypi.oneill.net domain=oneill.net
 garagepi ansible_host=garagepi.oneill.net domain=oneill.net
-spoolbuddy ansible_host=spoolbuddy.oneill.net domain=oneill.net
+#spoolbuddy ansible_host=spoolbuddy.oneill.net domain=oneill.net
+pifire ansible_host=pifire.oneill.net domain=oneill.net
 infra1 ansible_host=infra1.oneill.net domain=oneill.net
 p1 ansible_host=p1.oneill.net domain=oneill.net
 
@@ -46,7 +47,8 @@ k5
 #gasherbrum-display
 pantrypi
 garagepi
-spoolbuddy
+#spoolbuddy
+pifire
 
 [pizero]
 #voron2-pizero
@@ -67,6 +69,7 @@ infra1
 luser
 pantrypi
 garagepi
+pifire
 
 [rtl433]
 pantrypi
@@ -75,6 +78,7 @@ garagepi
 [traefik]
 infra1
 pantrypi
+pifire
 
 [zwavejs]
 pantrypi

--- a/ansible/roles/traefik/tasks/main.yml
+++ b/ansible/roles/traefik/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: Stop services that conflict with Traefik
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    enabled: false
+    state: stopped
+  loop: "{{ traefik_conflicting_services | default([]) }}"
+
 - name: Create traefik directory
   ansible.builtin.file:
     path: /etc/traefik
@@ -43,8 +50,8 @@
   notify: Restart traefik
 
 - name: Deploy traefik docker-compose file
-  ansible.builtin.copy:
-    src: docker-compose.yml
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
     dest: /etc/traefik/docker-compose.yml
     owner: root
     group: root

--- a/ansible/roles/traefik/templates/conf.d/pifire.yml.j2
+++ b/ansible/roles/traefik/templates/conf.d/pifire.yml.j2
@@ -1,0 +1,16 @@
+---
+http:
+  routers:
+    pifire:
+      rule: "Host(`{{ ansible_host }}`)"
+      entryPoints:
+        - websecure
+      service: pifire
+      tls:
+        certResolver: letsencrypt
+
+  services:
+    pifire:
+      loadBalancer:
+        servers:
+          - url: "{{ pifire_backend_url }}"

--- a/ansible/roles/traefik/templates/docker-compose.yml.j2
+++ b/ansible/roles/traefik/templates/docker-compose.yml.j2
@@ -4,10 +4,14 @@ services:
     # renovate: datasource=docker
     image: traefik:v3.7.4@sha256:fcdef599e6259359833dd2e1d49f9e964f66825d69bd3dd468f51102ce013d03
     restart: unless-stopped
+{% if traefik_network_mode | default('bridge') == 'host' %}
+    network_mode: host
+{% else %}
     ports:
       - "80:80"
       - "443:443"
       - "3443:3443"
+{% endif %}
     env_file:
       - traefik.env
     volumes:
@@ -39,6 +43,7 @@ services:
       - "--certificatesresolvers.letsencrypt.acme.dnschallenge.provider=cloudflare"
       - "--certificatesresolvers.letsencrypt.acme.email=admin@oneill.net"
       - "--certificatesresolvers.letsencrypt.acme.storage=/acme/acme.json"
+{% if traefik_network_mode | default('bridge') != 'host' %}
     networks:
       - traefik
 
@@ -46,3 +51,4 @@ networks:
   traefik:
     name: traefik
     driver: bridge
+{% endif %}

--- a/opentofu/locals.tf
+++ b/opentofu/locals.tf
@@ -125,6 +125,12 @@ locals {
       hostname = "spoolbuddy.oneill.net"
       note     = "Raspberry Pi 4 for BambuBuddy SpoolBuddy"
     }
+    pifire = {
+      mac      = "e4:5f:01:97:25:83"
+      ip       = "172.19.74.89"
+      hostname = "pifire.oneill.net"
+      note     = "Raspberry Pi 4"
+    }
     landroid = {
       mac         = "7c:fa:80:61:08:2e"
       ip          = "172.20.6.67"


### PR DESCRIPTION
Register PiFire with managed Wi-Fi, static IPv4 and IPv6 addressing, and DNS records.

- Run Traefik locally for dual-stack HTTPS access to the PiFire UI.
- Schedule the host backup for 3:00 AM.
- Temporarily disable SpoolBuddy while preserving its configuration.
