### PR TITLE
Use namespaced Docker interface facts

### DIFF
--- a/ansible/roles/matter/templates/docker-compose.yaml.j2
+++ b/ansible/roles/matter/templates/docker-compose.yaml.j2
@@ -15,9 +15,9 @@ services:
     environment:
       OT_RCP_DEVICE: "spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=460800&uart-flow-control"
       OT_INFRA_IF: {{ matter_backbone_interface }}
-      OT_REST_LISTEN_ADDR: "{{ ansible_docker0.ipv4.address }}"
+      OT_REST_LISTEN_ADDR: "{{ ansible_facts['docker0']['ipv4']['address'] }}"
       OT_REST_LISTEN_PORT: "8081"
-      OT_WEB_LISTEN_ADDR: "{{ ansible_docker0.ipv4.address }}"
+      OT_WEB_LISTEN_ADDR: "{{ ansible_facts['docker0']['ipv4']['address'] }}"
       OT_WEB_LISTEN_PORT: "8080"
       TZ: America/New_York
     healthcheck:

--- a/ansible/roles/traefik/templates/conf.d/matter.yaml.j2
+++ b/ansible/roles/traefik/templates/conf.d/matter.yaml.j2
@@ -35,9 +35,9 @@ http:
     otbr-web:
       loadBalancer:
         servers:
-          - url: "http://{{ ansible_docker0.ipv4.address }}:8080"
+          - url: "http://{{ ansible_facts['docker0']['ipv4']['address'] }}:8080"
 
     otbr-api:
       loadBalancer:
         servers:
-          - url: "http://{{ ansible_docker0.ipv4.address }}:8081"
+          - url: "http://{{ ansible_facts['docker0']['ipv4']['address'] }}:8081"


### PR DESCRIPTION
Replace deprecated injected ansible_docker0 aliases with namespaced fact access in the Matter and Traefik templates.

Preserve the rendered bridge addresses while remaining compatible with Ansible Core 2.24.
