### PR TITLE
Persist journals on SSD-backed Pi hosts

### DIFF
--- a/ansible/group_vars/pi.yaml
+++ b/ansible/group_vars/pi.yaml
@@ -1,5 +1,6 @@
 ---
 node_exporter_enabled: true
+persistent_journal_enabled: true
 
 # Map Ansible architecture to restic release names (arm covers armv6/armv7)
 restic_arch: >-

--- a/ansible/roles/common/handlers/main.yaml
+++ b/ansible/roles/common/handlers/main.yaml
@@ -7,6 +7,11 @@
     - common_smartd_enabled is defined
     - common_smartd_enabled | bool
 
+- name: Restart journald
+  ansible.builtin.service:
+    name: systemd-journald
+    state: restarted
+
 - name: Reload sysctl
   ansible.builtin.command: sysctl --system
   changed_when: true

--- a/ansible/roles/common/tasks/journald.yaml
+++ b/ansible/roles/common/tasks/journald.yaml
@@ -1,0 +1,84 @@
+---
+- name: Find root filesystem source
+  ansible.builtin.command:
+    argv:
+      - findmnt
+      - --noheadings
+      - --output
+      - SOURCE
+      - --target
+      - /
+  register: common_pi_root_source
+  changed_when: false
+  failed_when: false
+
+- name: Resolve root filesystem source
+  ansible.builtin.command:
+    argv:
+      - readlink
+      - --canonicalize-existing
+      - "{{ common_pi_root_source.stdout | trim }}"
+  register: common_pi_root_device
+  changed_when: false
+  failed_when: false
+  when:
+    - common_pi_root_source.rc == 0
+    - common_pi_root_source.stdout | trim | length > 0
+
+- name: Find root filesystem backing devices
+  ansible.builtin.command:
+    argv:
+      - lsblk
+      - --noheadings
+      - --raw
+      - --paths
+      - --output
+      - NAME
+      - --inverse
+      - "{{ common_pi_root_device.stdout | trim }}"
+  register: common_pi_root_backing_devices
+  changed_when: false
+  failed_when: false
+  when:
+    - common_pi_root_device.rc | default(1) == 0
+    - common_pi_root_device.stdout | default('') | trim | length > 0
+
+- name: Determine whether journal storage should be persistent
+  ansible.builtin.set_fact:
+    common_pi_journal_should_persist: >-
+      {{
+        persistent_journal_enabled | default(false) | bool
+        and common_pi_root_backing_devices.rc | default(1) == 0
+        and common_pi_root_backing_devices.stdout_lines | default([]) | length > 0
+        and common_pi_root_backing_devices.stdout_lines
+          | default([])
+          | select('match', '^/dev/mmcblk')
+          | list
+          | length == 0
+      }}
+
+- name: Create journald configuration directory
+  ansible.builtin.file:
+    path: /etc/systemd/journald.conf.d
+    state: directory
+    mode: "0755"
+    owner: root
+    group: root
+  when: common_pi_journal_should_persist
+
+- name: Configure journal storage
+  ansible.builtin.template:
+    src: journald-storage.conf.j2
+    dest: /etc/systemd/journald.conf.d/90-ansible-storage.conf
+    mode: "0644"
+    owner: root
+    group: root
+  when: common_pi_journal_should_persist
+  notify: Restart journald
+
+- name: Remove persistent journal configuration
+  ansible.builtin.file:
+    path: /etc/systemd/journald.conf.d/90-ansible-storage.conf
+    state: absent
+  when: not common_pi_journal_should_persist
+  notify: Restart journald

--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -31,6 +31,10 @@
     dest: /etc/timezone
     mode: "0644"
 
+- name: Configure persistent journal
+  ansible.builtin.include_tasks: journald.yaml
+  when: "'pi' in group_names"
+
 - name: "Check if Proxmox is installed"
   ansible.builtin.stat:
     path: /usr/bin/pvesh

--- a/ansible/roles/common/templates/journald-storage.conf.j2
+++ b/ansible/roles/common/templates/journald-storage.conf.j2
@@ -1,0 +1,3 @@
+# Ansible managed - persist the systemd journal
+[Journal]
+Storage=persistent


### PR DESCRIPTION
Enable persistent journald storage for Pi-group hosts whose root filesystem is not on an mmcblk device.

- Isolate journald configuration in common role tasks.
- Override the Raspberry Pi OS volatile default with a later drop-in.
