### PR TITLE
Disable Wi-Fi power saving on Pi hosts

### DIFF
--- a/ansible/group_vars/pi.yaml
+++ b/ansible/group_vars/pi.yaml
@@ -1,6 +1,7 @@
 ---
 node_exporter_enabled: true
 persistent_journal_enabled: true
+disable_wifi_power_save: true
 
 # Map Ansible architecture to restic release names (arm covers armv6/armv7)
 restic_arch: >-

--- a/ansible/roles/common/files/disable-wifi-power-save
+++ b/ansible/roles/common/files/disable-wifi-power-save
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+set -eu
+
+report_change=false
+case "${1:-}" in
+	"") ;;
+	--report-change) report_change=true ;;
+	*)
+		echo "Usage: $0 [--report-change]" >&2
+		exit 2
+		;;
+esac
+
+set --
+for wireless_path in /sys/class/net/*/wireless; do
+	[ -d "${wireless_path}" ] || continue
+	interface=${wireless_path%/wireless}
+	set -- "$@" "${interface##*/}"
+done
+
+if [ "$#" -eq 0 ]; then
+	echo "no wireless interfaces found"
+fi
+
+changed=false
+for interface in "$@"; do
+	[ -d "/sys/class/net/${interface}/wireless" ] || continue
+	state=$(/usr/sbin/iw dev "${interface}" get power_save)
+
+	case "${state}" in
+		"Power save: on")
+			/usr/sbin/iw dev "${interface}" set power_save off
+			printf 'wireless iface %s: disabled\n' "${interface}"
+			changed=true
+			;;
+		"Power save: off")
+			printf 'wireless iface %s: already disabled\n' "${interface}"
+			;;
+		*)
+			printf 'wireless iface %s: unexpected state: %s\n' "${interface}" "${state}" >&2
+			exit 1
+			;;
+	esac
+done
+
+if [ "${report_change}" = true ] && [ "${changed}" = true ]; then
+	exit 10
+fi

--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -35,6 +35,18 @@
   ansible.builtin.include_tasks: journald.yaml
   when: "'pi' in group_names"
 
+- name: Remove Wi-Fi power-saving hook when disabled
+  ansible.builtin.file:
+    path: /etc/network/if-up.d/disable-wifi-power-save
+    state: absent
+  when: not (disable_wifi_power_save | default(false) | bool)
+  tags: wifi_power_save
+
+- name: Disable Wi-Fi power saving
+  ansible.builtin.import_tasks: wifi_power_save.yaml
+  when: disable_wifi_power_save | default(false) | bool
+  tags: wifi_power_save
+
 - name: "Check if Proxmox is installed"
   ansible.builtin.stat:
     path: /usr/bin/pvesh

--- a/ansible/roles/common/tasks/wifi_power_save.yaml
+++ b/ansible/roles/common/tasks/wifi_power_save.yaml
@@ -1,0 +1,30 @@
+---
+- name: Install Wi-Fi configuration tools
+  ansible.builtin.apt:
+    name: iw
+    state: present
+
+- name: Create network interface hook directory
+  ansible.builtin.file:
+    path: /etc/network/if-up.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Install Wi-Fi power-saving hook
+  ansible.builtin.copy:
+    src: disable-wifi-power-save
+    dest: /etc/network/if-up.d/disable-wifi-power-save
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Disable Wi-Fi power saving immediately
+  ansible.builtin.command:
+    argv:
+      - /etc/network/if-up.d/disable-wifi-power-save
+      - --report-change
+  register: common_wifi_power_save_result
+  changed_when: common_wifi_power_save_result.rc == 10
+  failed_when: common_wifi_power_save_result.rc not in [0, 10]


### PR DESCRIPTION
- Install a common ifupdown hook for every wireless interface.
- Report live Ansible changes without failing interface startup.
- Enable the behavior for the Pi inventory group.
