### PR TITLE
Pin MinusPod to deployed 2.76.1

### DIFF
--- a/kubernetes/minuspod/deploy.yaml
+++ b/kubernetes/minuspod/deploy.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: minuspod
-        image: ttlequals0/minuspod:2.65.0@sha256:da001eeeead9aa843e13429ebbc92d51fca7237026ef4dd5087d7086ef9ccd58
+        image: ttlequals0/minuspod:2.76.1@sha256:7720ead9bab495130b2f96d8221eeac02dca0cb05a732d37637f265639237c79
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Pin the manifest to the MinusPod version and digest already validated in the cluster.

- Preserve the deployed 2.76.1 image through GitOps reconciliation
- Avoid advancing to Renovate's current 2.77.0 candidate
