### PR TITLE
Use repository Python for Semaphore ARA

### DIFF
--- a/kubernetes/semaphore/scripts/ansible-wrapper.sh
+++ b/kubernetes/semaphore/scripts/ansible-wrapper.sh
@@ -24,10 +24,10 @@ fi
 # Set CA bundle for Python requests library
 export REQUESTS_CA_BUNDLE=/etc/ssl/cert.pem
 
-# Enable ARA callback and action plugins using nix Python environment
-NIX_PYTHON=$(find /nix/store -maxdepth 1 -name "*python3-*-env" -type d 2>/dev/null | head -1)/bin/python3
+# Enable ARA callback and action plugins using the repository's Nix environment
+NIX_PYTHON=/infra/ansible-bins/python3
 if [ ! -x "$NIX_PYTHON" ]; then
-  echo "WARNING: Could not find executable nix Python environment at $NIX_PYTHON" >&2
+  echo "WARNING: Could not find repository Nix Python at $NIX_PYTHON" >&2
   echo "ARA integration will be disabled" >&2
   NIX_PYTHON=""
 fi

--- a/kubernetes/semaphore/scripts/setup-nix.sh
+++ b/kubernetes/semaphore/scripts/setup-nix.sh
@@ -25,17 +25,29 @@ curl -fL https://install.determinate.systems/nix \
 cd /infra
 eval "$(nix print-dev-env .#semaphore)"
 
-# Create ansible-bins directory and populate with symlinks
-PYTHON_ENV_DIR=$(find /nix/store -maxdepth 1 -name "*python3-*-env" -type d 2>/dev/null | head -1)
-if [ -z "$PYTHON_ENV_DIR" ]; then
-  echo "ERROR: Could not find Python environment in /nix/store" >&2
+# Preserve the tools from the repository's Nix environment before init-tools.sh
+# replaces Semaphore's bundled Ansible executables with wrappers.
+NIX_ANSIBLE=$(command -v ansible) || {
+  echo "ERROR: ansible not found in the repository Nix environment" >&2
   exit 1
-fi
+}
+NIX_ENV_BIN=$(dirname "$NIX_ANSIBLE")
+case "$NIX_ENV_BIN" in
+  /nix/store/*-python3-*-env/bin) ;;
+  *)
+    echo "ERROR: ansible resolved outside the repository Nix environment: $NIX_ANSIBLE" >&2
+    exit 1
+    ;;
+esac
+
 mkdir -p /infra/ansible-bins
-for tool in ansible ansible-playbook ansible-galaxy ansible-vault; do
-  if [ -x "$PYTHON_ENV_DIR/bin/$tool" ]; then
-    ln -sf "$PYTHON_ENV_DIR/bin/$tool" "/infra/ansible-bins/$tool"
+for tool in python3 ansible ansible-playbook ansible-galaxy ansible-vault; do
+  tool_path="$NIX_ENV_BIN/$tool"
+  if [ ! -x "$tool_path" ]; then
+    echo "ERROR: $tool not found in the repository Nix environment" >&2
+    exit 1
   fi
+  ln -sf "$tool_path" "/infra/ansible-bins/$tool"
 done
 
 echo "Nix setup complete"


### PR DESCRIPTION
Persist the Python and Ansible executables selected by the repository Nix environment under /infra/ansible-bins.

Point the Semaphore wrapper at that stable Python path instead of selecting an arbitrary matching environment from /nix/store. Fail setup when the expected repository tools are missing or resolve outside the evaluated environment.
