### PR TITLE
Normalize docs and miscellaneous YAML

### DIFF
--- a/.beads/README.md
+++ b/.beads/README.md
@@ -1,12 +1,16 @@
 # Beads - AI-Native Issue Tracking
 
-Welcome to Beads! This repository uses **Beads** for issue tracking - a modern, AI-native tool designed to live directly in your codebase alongside your code.
+Welcome to Beads! This repository uses **Beads** for issue tracking - a modern,
+AI-native tool designed to live directly in your codebase alongside your code.
 
 ## What is Beads?
 
-Beads is issue tracking that lives in your repo, making it perfect for AI coding agents and developers who want their issues close to their code. No web UI required - everything works through the CLI and integrates seamlessly with git.
+Beads is issue tracking that lives in your repo, making it perfect for AI coding
+agents and developers who want their issues close to their code. No web UI
+required - everything works through the CLI and integrates seamlessly with git.
 
-**Learn more:** [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
+**Learn more:**
+[github.com/steveyegge/beads](https://github.com/steveyegge/beads)
 
 ## Quick Start
 
@@ -33,6 +37,7 @@ bd sync
 ### Working with Issues
 
 Issues in Beads are:
+
 - **Git-native**: Stored in `.beads/issues.jsonl` and synced like code
 - **AI-friendly**: CLI-first design works perfectly with AI coding agents
 - **Branch-aware**: Issues can follow your branch workflow
@@ -41,16 +46,19 @@ Issues in Beads are:
 ## Why Beads?
 
 ✨ **AI-Native Design**
+
 - Built specifically for AI-assisted development workflows
 - CLI-first interface works seamlessly with AI coding agents
 - No context switching to web UIs
 
 🚀 **Developer Focused**
+
 - Issues live in your repo, right next to your code
 - Works offline, syncs when you push
 - Fast, lightweight, and stays out of your way
 
 🔧 **Git Integration**
+
 - Automatic sync with git commits
 - Branch-aware issue tracking
 - Intelligent JSONL merge resolution
@@ -72,10 +80,12 @@ bd create "Try out Beads"
 
 ## Learn More
 
-- **Documentation**: [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
+- **Documentation**:
+  [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
 - **Quick Start Guide**: Run `bd quickstart`
-- **Examples**: [github.com/steveyegge/beads/examples](https://github.com/steveyegge/beads/tree/main/examples)
+- **Examples**:
+  [github.com/steveyegge/beads/examples](https://github.com/steveyegge/beads/tree/main/examples)
 
 ---
 
-*Beads: Issue tracking that moves at the speed of thought* ⚡
+_Beads: Issue tracking that moves at the speed of thought_ ⚡

--- a/.claude/rules/kubernetes/deployment-pattern.md
+++ b/.claude/rules/kubernetes/deployment-pattern.md
@@ -4,7 +4,8 @@ paths: ["kubernetes/**/*"]
 
 # Kubernetes Application Deployment Pattern
 
-**Critical**: This repository uses a GitOps approach with pre-rendered Helm templates, NOT direct Helm installations.
+**Critical**: This repository uses a GitOps approach with pre-rendered Helm
+templates, NOT direct Helm installations.
 
 ## Application Structure
 
@@ -23,11 +24,15 @@ app-name/
 
 ## Helm Chart Workflow
 
-1. **Define Dependencies**: Update `Chart.yaml` with chart name, version, and repository
+1. **Define Dependencies**: Update `Chart.yaml` with chart name, version, and
+   repository
 2. **Configure Values**: Set application configuration in `values.yaml`
-3. **Render Templates**: Run `./render` script to generate static YAML in `helm/` directory
-4. **Reference in Kustomize**: List rendered templates in `kustomization.yaml` resources
-5. **Deploy**: ArgoCD deploys the kustomized manifests (note `argoManaged: 'true'` annotation is set via kustomize)
+3. **Render Templates**: Run `./render` script to generate static YAML in
+   `helm/` directory
+4. **Reference in Kustomize**: List rendered templates in `kustomization.yaml`
+   resources
+5. **Deploy**: ArgoCD deploys the kustomized manifests (note
+   `argoManaged: 'true'` annotation is set via kustomize)
 
 ## Deployment and Testing
 
@@ -40,9 +45,13 @@ kubectl apply -k <directory>      # Deploy using kustomize (standard approach)
 Do NOT use `kubectl apply -f <file>` directly.
 
 **Testing workflow:**
-- Apply changes locally with `kubectl apply -k <directory>` to test during development
-- ArgoCD manages deployments from main branch, but apply locally first to verify changes work before committing
-- For cronjobs, trigger a manual run with: `kubectl create job --from=cronjob/<name> <test-name>`
+
+- Apply changes locally with `kubectl apply -k <directory>` to test during
+  development
+- ArgoCD manages deployments from main branch, but apply locally first to verify
+  changes work before committing
+- For cronjobs, trigger a manual run with:
+  `kubectl create job --from=cronjob/<name> <test-name>`
 
 ## ConfigMap and Secret Reload
 
@@ -60,4 +69,7 @@ triggers a rolling restart when referenced ConfigMaps or Secrets change.
 
 ## Rendering Helm Charts
 
-Render scripts for Kubernetes applications are standardized across this repository. Refer to [helm-rendering.md](./helm-rendering.md) for the canonical render script pattern, helper usage, and best practices that apply to all applications.
+Render scripts for Kubernetes applications are standardized across this
+repository. Refer to [helm-rendering.md](./helm-rendering.md) for the canonical
+render script pattern, helper usage, and best practices that apply to all
+applications.

--- a/.claude/rules/kubernetes/helm-rendering.md
+++ b/.claude/rules/kubernetes/helm-rendering.md
@@ -6,7 +6,8 @@ paths: ["kubernetes/**/render", "kubernetes/**/Chart.yaml"]
 
 ## Render Script Pattern
 
-Each application directory contains a `render` script that generates static YAML manifests from Helm charts.
+Each application directory contains a `render` script that generates static YAML
+manifests from Helm charts.
 
 ### Standard Pattern
 
@@ -21,11 +22,17 @@ mv tmp/*/* helm && rmdir tmp/*
 
 ### Key Points
 
-- **Source chart-version helper**: Located at `kubernetes/scripts/chart-version` (relative to repository root), provides `helm_template` function with correct repository/version handling
-- **Clean output**: Remove existing `helm/` and `tmp/` directories before rendering
-- **Use helm_template function**: Ensures charts are rendered with correct repository and version from `Chart.yaml`
-- **Post-processing**: Some render scripts may remove deprecated resources or perform other transformations
+- **Source chart-version helper**: Located at `kubernetes/scripts/chart-version`
+  (relative to repository root), provides `helm_template` function with correct
+  repository/version handling
+- **Clean output**: Remove existing `helm/` and `tmp/` directories before
+  rendering
+- **Use helm_template function**: Ensures charts are rendered with correct
+  repository and version from `Chart.yaml`
+- **Post-processing**: Some render scripts may remove deprecated resources or
+  perform other transformations
 
 ### Critical Rule
 
-**Never run `helm install` or `helm upgrade` directly** - all deployments use pre-rendered manifests that are deployed via kustomize and managed by ArgoCD.
+**Never run `helm install` or `helm upgrade` directly** - all deployments use
+pre-rendered manifests that are deployed via kustomize and managed by ArgoCD.

--- a/.claude/rules/tooling/authentik.md
+++ b/.claude/rules/tooling/authentik.md
@@ -1,5 +1,6 @@
 # Authentik Integration
 
-When setting up Authentik for new services, you must run `ak-tool` to provision them via terraform.
+When setting up Authentik for new services, you must run `ak-tool` to provision
+them via terraform.
 
 Run `ak-tool --help` for details.

--- a/.claude/rules/tooling/pre-commit.md
+++ b/.claude/rules/tooling/pre-commit.md
@@ -17,4 +17,5 @@ The following directories are excluded from most hooks:
 
 ## Usage
 
-Do not run pre-commit or linting tools manually - they run automatically on commit.
+Do not run pre-commit or linting tools manually - they run automatically on
+commit.

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,7 +1,9 @@
 # Development Workflow
 
-Development happens locally with direct application to the homelab infrastructure.
+Development happens locally with direct application to the homelab
+infrastructure.
 
-**Always apply changes and verify they work - do not stop after writing code to ask for permission to deploy.**
+**Always apply changes and verify they work - do not stop after writing code to
+ask for permission to deploy.**
 
 See technology-specific rules for deployment commands and testing procedures.

--- a/.github/actions/setup-semaphore/action.yml
+++ b/.github/actions/setup-semaphore/action.yml
@@ -23,7 +23,7 @@ runs:
 
   - name: Verify Semaphore connectivity
     shell: bash
-    run: |
+    run: |-
       set -euo pipefail
       curl -sf --max-time 10 "https://semaphore.cow-banjo.ts.net/api/ping" || {
         echo "Failed to reach Semaphore API"; exit 1

--- a/.kyverno/policies/require-goldilocks-vpa-config.yaml
+++ b/.kyverno/policies/require-goldilocks-vpa-config.yaml
@@ -1,8 +1,10 @@
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
+
 metadata:
   name: require-goldilocks-vpa-config
+
 spec:
   validationFailureAction: Enforce
   rules:
@@ -18,7 +20,8 @@ spec:
     validate:
       message: >-
         Namespaces with goldilocks.fairwinds.com/enabled=true MUST have both annotations:
-        1. goldilocks.fairwinds.com/vpa-update-mode (values: Off, Initial, Recreate, Auto, InPlaceOrRecreate)
+        1. goldilocks.fairwinds.com/vpa-update-mode (values: Off, Initial, Recreate,
+        Auto, InPlaceOrRecreate)
         2. goldilocks.fairwinds.com/vpa-resource-policy (JSON format)
 
         Standard configurations:

--- a/esphome/common/device-classes/opengarage.yaml
+++ b/esphome/common/device-classes/opengarage.yaml
@@ -41,49 +41,49 @@ logger:
 #   - Timeout: Cap at 450cm
 #   - Filter: Median of 15 readings
 sensor:
-  - platform: ultrasonic
-    trigger_pin: 12
-    echo_pin: 14
-    name: "${human_devicename} Distance"
-    id: ${device_id}_distance
-    update_interval: 500ms
-    timeout: 4.5m
-    unit_of_measurement: cm
-    accuracy_decimals: 1
-    icon: mdi:ruler
-    filters:
-      - multiply: 100
-      - median:
-          window_size: 15
-          send_every: 1
-      - sliding_window_moving_average:
-          window_size: 5
-          send_every: 1
-      - round: 1  # Round to nearest 0.1cm
-      - delta: 1  # Only report changes >= 1cm
+- platform: ultrasonic
+  trigger_pin: 12
+  echo_pin: 14
+  name: "${human_devicename} Distance"
+  id: ${device_id}_distance
+  update_interval: 500ms
+  timeout: 4.5m
+  unit_of_measurement: cm
+  accuracy_decimals: 1
+  icon: mdi:ruler
+  filters:
+  - multiply: 100
+  - median:
+      window_size: 15
+      send_every: 1
+  - sliding_window_moving_average:
+      window_size: 5
+      send_every: 1
+  - round: 1  # Round to nearest 0.1cm
+  - delta: 1  # Only report changes >= 1cm
 
 # Door trigger button - exposed to Home Assistant for template cover control
 button:
-  - platform: template
-    name: "${human_devicename} Trigger"
-    id: ${device_id}_trigger_button
-    icon: mdi:garage
-    on_press:
-      - script.execute: ${device_id}_trigger_door
+- platform: template
+  name: "${human_devicename} Trigger"
+  id: ${device_id}_trigger_button
+  icon: mdi:garage
+  on_press:
+  - script.execute: ${device_id}_trigger_door
 
 # Relay for door trigger (internal - controlled via script)
 switch:
-  - platform: gpio
-    pin: 15
-    id: ${device_id}_relay
-    internal: true
-    restore_mode: ALWAYS_OFF
+- platform: gpio
+  pin: 15
+  id: ${device_id}_relay
+  internal: true
+  restore_mode: ALWAYS_OFF
 
 # Buzzer output for RTTTL alarm tones
 output:
-  - platform: esp8266_pwm
-    pin: 13
-    id: ${device_id}_buzzer_output
+- platform: esp8266_pwm
+  pin: 13
+  id: ${device_id}_buzzer_output
 
 # RTTTL component for playing alarm tones before door action
 rtttl:
@@ -93,57 +93,57 @@ rtttl:
 # Configurable alarm duration before door action (stock OpenGarage behavior)
 # Minimum 5 seconds enforced by stock firmware for auto-close
 number:
-  - platform: template
-    name: "${human_devicename} Alarm Duration"
-    id: ${device_id}_alarm_duration
-    icon: mdi:timer
-    min_value: 0
-    max_value: 30
-    step: 1
-    initial_value: 5
-    unit_of_measurement: s
-    optimistic: true
-    restore_value: true
+- platform: template
+  name: "${human_devicename} Alarm Duration"
+  id: ${device_id}_alarm_duration
+  icon: mdi:timer
+  min_value: 0
+  max_value: 30
+  step: 1
+  initial_value: 5
+  unit_of_measurement: s
+  optimistic: true
+  restore_value: true
 
 # Door trigger script - plays alarm then pulses relay
 script:
-  - id: ${device_id}_trigger_door
-    then:
-      - if:
-          condition:
-            lambda: 'return id(${device_id}_alarm_duration).state > 0;'
-          then:
-            - rtttl.play:
-                rtttl: 'alarm:d=4,o=5,b=120:d,p,d,p,d,p,d,p,d,p,d,p,d,p,d,p,d,p,d,p'
-            - delay: !lambda 'return id(${device_id}_alarm_duration).state * 1000;'
-            - rtttl.stop:
-      - switch.turn_on: ${device_id}_relay
-      - delay: 500ms
-      - switch.turn_off: ${device_id}_relay
+- id: ${device_id}_trigger_door
+  then:
+  - if:
+      condition:
+        lambda: 'return id(${device_id}_alarm_duration).state > 0;'
+      then:
+      - rtttl.play:
+          rtttl: 'alarm:d=4,o=5,b=120:d,p,d,p,d,p,d,p,d,p,d,p,d,p,d,p,d,p,d,p'
+      - delay: !lambda 'return id(${device_id}_alarm_duration).state * 1000;'
+      - rtttl.stop:
+  - switch.turn_on: ${device_id}_relay
+  - delay: 500ms
+  - switch.turn_off: ${device_id}_relay
 
 # Physical button on device
 binary_sensor:
-  - platform: gpio
-    pin:
-      number: 0
-      mode: INPUT_PULLUP
-      inverted: true
-    name: "${human_devicename} Button"
-    id: ${device_id}_button
-    internal: true
-    filters:
-      - delayed_on: 50ms
-      - delayed_off: 50ms
-    on_press:
-      - script.execute: ${device_id}_trigger_door
+- platform: gpio
+  pin:
+    number: 0
+    mode: INPUT_PULLUP
+    inverted: true
+  name: "${human_devicename} Button"
+  id: ${device_id}_button
+  internal: true
+  filters:
+  - delayed_on: 50ms
+  - delayed_off: 50ms
+  on_press:
+  - script.execute: ${device_id}_trigger_door
 
   # Door state from ultrasonic sensor (informational only, not authoritative)
-  - platform: template
-    name: "${human_devicename} Door State"
-    id: ${device_id}_door_state
-    device_class: garage_door
-    lambda: |-
-      return id(${device_id}_distance).state <= 75;
+- platform: template
+  name: "${human_devicename} Door State"
+  id: ${device_id}_door_state
+  device_class: garage_door
+  lambda: |-
+    return id(${device_id}_distance).state <= 75;
 
 # Status LED
 status_led:

--- a/esphome/decommissioned/README.md
+++ b/esphome/decommissioned/README.md
@@ -1,11 +1,14 @@
 # Decommissioned ESPHome Devices
 
-This directory contains ESPHome configuration files for devices that are no longer in active use but are kept for reference.
+This directory contains ESPHome configuration files for devices that are no
+longer in active use but are kept for reference.
 
-These configurations are excluded from CI builds (the `esphome-all` script only processes top-level YAML files).
+These configurations are excluded from CI builds (the `esphome-all` script only
+processes top-level YAML files).
 
 ## Devices
 
 - **water-pump.yaml** - ESP32-S3 Lolin S3 Mini water pump controller
   - Decommissioned: 2025-11-10
-  - Reason: Build issues with neopixelbus requiring Arduino framework while other ESP32 devices migrated to ESP-IDF
+  - Reason: Build issues with neopixelbus requiring Arduino framework while
+    other ESP32 devices migrated to ESP-IDF

--- a/tests/rpi/docker-compose.yaml
+++ b/tests/rpi/docker-compose.yaml
@@ -1,10 +1,11 @@
+---
 services:
   rpi-vm:
     build: .
     privileged: true  # Required for losetup
     environment:
-      - IMAGE=/images/rpi.img
+    - IMAGE=/images/rpi.img
     volumes:
-      - ${RPI_IMAGE}:/images/rpi.img:ro
+    - ${RPI_IMAGE}:/images/rpi.img:ro
     ports:
-      - "2222:22"
+    - "2222:22"

--- a/tools/managarr/config.yml
+++ b/tools/managarr/config.yml
@@ -2,11 +2,11 @@
 theme: default
 
 radarr:
-  - name: radarr
-    uri: https://radarr.k.oneill.net
-    api_token: !env ${RADARR_API_KEY}
+- name: radarr
+  uri: https://radarr.k.oneill.net
+  api_token: !env ${RADARR_API_KEY}
 
 sonarr:
-  - name: sonarr
-    uri: https://sonarr.k.oneill.net
-    api_token: !env ${SONARR_API_KEY}
+- name: sonarr
+  uri: https://sonarr.k.oneill.net
+  api_token: !env ${SONARR_API_KEY}


### PR DESCRIPTION
Apply the repository formatters' current output to documentation and non-Kubernetes configuration files that predate the active lint rules.

- Reflow Markdown without changing its content.
- Normalize YAML document markers, list indentation, scalar chomping, and structural whitespace.
- Preserve parsed configuration values and composite-action behavior.
