### PR TITLE
Defer active ezShare file failures

### DIFF
--- a/kubernetes/cpap-ezshare-sync/cronjob.yaml
+++ b/kubernetes/cpap-ezshare-sync/cronjob.yaml
@@ -28,6 +28,11 @@ spec:
               value: http://192.168.4.1
             - name: SYNC_TARGET
               value: /mirror/card
+            - name: HEALTHCHECK_PING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: healthchecks
+                  key: HEALTHCHECK_PING_KEY
             volumeMounts:
             - name: script
               mountPath: /scripts

--- a/kubernetes/cpap-ezshare-sync/externalsecret-healthcheck.yaml
+++ b/kubernetes/cpap-ezshare-sync/externalsecret-healthcheck.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+
+metadata:
+  name: healthchecks
+
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: production
+    kind: ClusterSecretStore
+  target:
+    name: healthchecks
+    creationPolicy: Owner
+  data:
+  - secretKey: HEALTHCHECK_PING_KEY
+    remoteRef:
+      key: healthchecks
+      property: PING_KEY

--- a/kubernetes/cpap-ezshare-sync/kustomization.yaml
+++ b/kubernetes/cpap-ezshare-sync/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: cpap-ezshare-sync
 
 resources:
 - namespace.yaml
+- externalsecret-healthcheck.yaml
 - pvc.yaml
 - cronjob.yaml
 

--- a/kubernetes/cpap-ezshare-sync/run
+++ b/kubernetes/cpap-ezshare-sync/run
@@ -39,16 +39,36 @@ error_count=$(grep -c 'ERROR:' "$sync_log" || true)
 ignored_count=$(grep -Ec \
   'ERROR: Failed to sync directory /(\.Spotlight-V100|\.fseventsd):' \
   "$sync_log" || true)
+deferred_count=$(grep -Ec \
+  'ERROR: Failed to sync file /DATALOG/[0-9]{8}/[0-9]{8}_[0-9]{6}_(BRP|PLD|SAD)\.edf: failed to download: failed to write file: unexpected EOF$' \
+  "$sync_log" || true)
+expected_error_count=$((ignored_count + deferred_count))
 
-if ((sync_status != 0 &&
-     error_count > 0 &&
-     error_count == ignored_count)) &&
+if ((sync_status == 0 && error_count == 0)); then
+  :
+elif ((sync_status != 0 &&
+       error_count > 0 &&
+       error_count == expected_error_count)) &&
    grep -Eq \
      "Sync complete: [0-9]+ files synced, [0-9]+ skipped, ${error_count} errors$" \
-     "$sync_log"; then
-  printf 'Ignoring %d macOS metadata directory error(s)\n' \
-    "$ignored_count" >&2
+   "$sync_log"; then
+  if ((ignored_count > 0)); then
+    printf 'Ignoring %d macOS metadata directory error(s)\n' \
+      "$ignored_count" >&2
+  fi
+else
+  exit "$sync_status"
+fi
+
+if ((deferred_count > 0)); then
+  printf 'Deferring %d active CPAP waveform file(s) until a later sync\n' \
+    "$deferred_count" >&2
   exit 0
 fi
 
-exit "$sync_status"
+curl -fsS \
+  --connect-timeout 10 \
+  --max-time 30 \
+  --retry 5 \
+  -o /dev/null \
+  "https://hc.k.oneill.net/ping/${HEALTHCHECK_PING_KEY}/ezshare-sync"

--- a/opentofu/healthchecks.tf
+++ b/opentofu/healthchecks.tf
@@ -63,6 +63,18 @@ resource "healthchecksio_check" "codex_auth_refresh" {
   channels = [data.healthchecksio_channel.selfhosted_email.id]
 }
 
+# ezShare CPAP sync - hourly job, alerts after 48h without a complete sync
+resource "healthchecksio_check" "ezshare_sync" {
+  provider = healthchecksio.selfhosted
+
+  name     = "ezshare-sync"
+  desc     = "Hourly ezShare CPAP data sync"
+  tags     = ["cpap", "kubernetes", "ezshare"]
+  timeout  = 172800 # 48 hours
+  grace    = 3600   # 1 hour
+  channels = [data.healthchecksio_channel.selfhosted_email.id]
+}
+
 # Got Your Back - full weekly Gmail backup
 resource "healthchecksio_check" "gyb_full" {
   provider = healthchecksio.selfhosted


### PR DESCRIPTION
- Treat truncated active waveform downloads as deferred work
- Ping Healthchecks after completed runs with no deferred or unrecognized errors
- Manage the 48-hour Healthchecks alert and email notification channel in OpenTofu
- Add the shared Healthchecks secret to the CronJob