### PR TITLE
Fix shell lint and Immich VPA policy

### DIFF
--- a/kubernetes/immich/namespace.yaml
+++ b/kubernetes/immich/namespace.yaml
@@ -6,3 +6,6 @@ metadata:
   name: immich
   labels:
     goldilocks.fairwinds.com/enabled: 'true'
+  annotations:
+    goldilocks.fairwinds.com/vpa-update-mode: InPlaceOrRecreate
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","controlledValues":"RequestsOnly"}]}'

--- a/kubernetes/vpa/toggle-updater
+++ b/kubernetes/vpa/toggle-updater
@@ -10,12 +10,12 @@ ACTION="${1:-}"
 NAMESPACE="${VPA_NAMESPACE:-vpa}"
 DEPLOYMENT="vpa-updater"
 
-if [[ "$ACTION" != "on" && "$ACTION" != "off" ]]; then
+if [ "$ACTION" != "on" ] && [ "$ACTION" != "off" ]; then
   echo "Usage: $0 [on|off]" >&2
   exit 1
 fi
 
-if [[ "$ACTION" == "on" ]]; then
+if [ "$ACTION" = "on" ]; then
   REPLICAS=1
   echo "Enabling VPA updater (scaling to 1 replica)..."
 else

--- a/scripts/ansible-detect-changes
+++ b/scripts/ansible-detect-changes
@@ -45,7 +45,9 @@ while IFS= read -r file; do
       hostname=$(basename "$file" .yaml)
       if [[ "$hostname" != "ansible-integration-test" ]] && \
          grep -qE "^${hostname}[[:space:]]|^${hostname}$" ansible/inventory/default 2>/dev/null; then
-        [[ ! " ${hosts[*]:-} " =~ " ${hostname} " ]] && hosts+=("$hostname")
+        if [[ " ${hosts[*]:-} " != *" $hostname "* ]]; then
+          hosts+=("$hostname")
+        fi
       fi
       ;;
     *)

--- a/scripts/rpi-image-test
+++ b/scripts/rpi-image-test
@@ -57,9 +57,9 @@ LOGS_PID=$!
 echo "Waiting for VM to boot and cloud-init to complete (this takes ~8 minutes)..."
 MAX_WAIT=900  # 15 minutes
 WAITED=0
-SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -p 2222"
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -p 2222)
 
-while ! ssh $SSH_OPTS root@localhost 'test -f /run/cloud-init-complete' 2>&1; do
+while ! ssh "${SSH_OPTS[@]}" root@localhost 'test -f /run/cloud-init-complete' 2>&1; do
     if ! docker compose ps --format json | jq -e 'select(.State == "running")' >/dev/null 2>&1; then
         kill $LOGS_PID 2>/dev/null || true
         echo "ERROR: Container stopped unexpectedly"


### PR DESCRIPTION
Add the missing Immich Goldilocks VPA policy annotations. Replace non-POSIX tests and unsafe word splitting while preserving the existing script behavior.
