### PR TITLE
Audit Healthchecks notification channels

### DIFF
--- a/ansible/group_vars/all/restic.yaml
+++ b/ansible/group_vars/all/restic.yaml
@@ -81,6 +81,9 @@ restic_default_config:
         headers:
           - name: Content-Type
             value: text/plain; charset=UTF-8
+      # Intentionally use /log instead of /fail: individual failed backup runs
+      # are tolerated. Alert only when no later success arrives before the
+      # Healthchecks dead-man timeout.
       send-after-fail:
         method: POST
         url: "https://{{ restic_healthcheck_host }}/ping/{% raw %}{{ $healthcheck_ping_key }}/restic-{{ .Hostname }}-{{ .Profile.Name }}{% endraw %}/log"

--- a/kubernetes/healthchecks/audit-channels
+++ b/kubernetes/healthchecks/audit-channels
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+import urllib.request
+
+
+def main() -> int:
+    base_url = os.environ.get(
+        "HEALTHCHECK_BASE_URL", "https://hc.k.oneill.net"
+    ).rstrip("/")
+    api_key = os.environ["HEALTHCHECK_API_KEY"]
+    ping_key = os.environ["HEALTHCHECK_PING_KEY"]
+
+    request = urllib.request.Request(
+        f"{base_url}/api/v1/checks/",
+        headers={"X-Api-Key": api_key},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        checks = json.load(response)["checks"]
+
+    missing = sorted(
+        check["name"] for check in checks if not check.get("channels")
+    )
+    ping_url = f"{base_url}/ping/{ping_key}/healthchecks-channel-audit"
+
+    if missing:
+        body = (
+            f"Found {len(missing)} Healthchecks checks without notification "
+            f"channels:\n{'\n'.join(missing)}\n"
+        ).encode()
+        request = urllib.request.Request(f"{ping_url}/fail", data=body, method="POST")
+        with urllib.request.urlopen(request, timeout=30):
+            pass
+        return 1
+
+    with urllib.request.urlopen(ping_url, timeout=30):
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kubernetes/healthchecks/cronjob-channel-audit.yaml
+++ b/kubernetes/healthchecks/cronjob-channel-audit.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+
+metadata:
+  name: channel-audit
+
+spec:
+  # The Healthchecks dead-man check alerts after 28 hours without a success.
+  schedule: "15 6 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 120
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: audit
+            image: ghcr.io/astral-sh/uv:python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca
+            command:
+            - /usr/local/bin/python3
+            - /scripts/audit-channels
+            env:
+            - name: HEALTHCHECK_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: healthchecks
+                  key: HEALTHCHECK_API_KEY
+            - name: HEALTHCHECK_PING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: healthchecks
+                  key: HEALTHCHECK_PING_KEY
+            volumeMounts:
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+          volumes:
+          - name: script
+            configMap:
+              name: channel-audit-script
+              defaultMode: 0555

--- a/kubernetes/healthchecks/externalsecret.yaml
+++ b/kubernetes/healthchecks/externalsecret.yaml
@@ -22,5 +22,13 @@ spec:
     remoteRef:
       key: healthchecks
       property: canary-ping-key
+  - secretKey: HEALTHCHECK_API_KEY
+    remoteRef:
+      key: healthchecks
+      property: api-key
+  - secretKey: HEALTHCHECK_PING_KEY
+    remoteRef:
+      key: healthchecks
+      property: PING_KEY
   target:
     name: healthchecks

--- a/kubernetes/healthchecks/kustomization.yaml
+++ b/kubernetes/healthchecks/kustomization.yaml
@@ -13,7 +13,13 @@ resources:
 - postgres-cluster.yaml
 - helm/healthchecks/common.yaml
 - cronjob-canary-ping.yaml
+- cronjob-channel-audit.yaml
 - tailscale-ingress.yaml
+
+configMapGenerator:
+- name: channel-audit-script
+  files:
+  - audit-channels
 
 commonAnnotations:
   argoManaged: 'true'

--- a/kubernetes/restic/profiles.yaml
+++ b/kubernetes/restic/profiles.yaml
@@ -64,6 +64,9 @@ hetzner:
       headers:
       - name: Content-Type
         value: text/plain; charset=UTF-8
+    # Intentionally use /log instead of /fail: individual failed backup runs
+    # are tolerated. Alert only when no later success arrives before the
+    # Healthchecks dead-man timeout.
     send-after-fail: &send_after_fail
       method: POST
       url: https://hc.k.oneill.net/ping/${HEALTHCHECK_PING_KEY}/kube-restic-${PROFILE_NAME}-${PROFILE_COMMAND}/log

--- a/kubernetes/restic/render-and-sync
+++ b/kubernetes/restic/render-and-sync
@@ -322,6 +322,8 @@ def sync_healthchecks() -> None:
         print("  HEALTHCHECK_API_KEY not set, skipping", file=sys.stderr)
         return
 
+    failures = 0
+
     for repo in REPOS:
         for i, command in enumerate(COMMANDS):
             slug = f"kube-restic-{repo}-{command}"
@@ -334,6 +336,7 @@ def sync_healthchecks() -> None:
                 "tz": "America/New_York",
                 "tags": "backup kubernetes restic",
                 "grace": 86400,
+                "channels": "*",
                 "unique": ["slug"],
             }
 
@@ -348,14 +351,28 @@ def sync_healthchecks() -> None:
             )
 
             try:
-                with urllib.request.urlopen(req) as resp:
-                    resp.read()  # Ensure request completes
+                with urllib.request.urlopen(req, timeout=20) as resp:
+                    check = json.load(resp)
+                    if not check.get("channels"):
+                        print(
+                            f"  Healthcheck sync returned no channels for {slug}",
+                            file=sys.stderr,
+                        )
+                        failures += 1
+                        continue
                     print(f"  Created/updated: {slug} (schedule: {schedule})")
             except urllib.error.HTTPError as e:
                 body = e.read().decode()
                 print(
                     f"  Error for {slug}: {e.code} {e.reason}: {body}", file=sys.stderr
                 )
+                failures += 1
+            except urllib.error.URLError as e:
+                print(f"  Error for {slug}: {e}", file=sys.stderr)
+                failures += 1
+
+    if failures:
+        raise RuntimeError(f"Healthcheck sync failed for {failures} check(s)")
 
 
 def sync_secrets(*, create_missing: bool = False) -> None:

--- a/opentofu/healthchecks.tf
+++ b/opentofu/healthchecks.tf
@@ -75,6 +75,18 @@ resource "healthchecksio_check" "ezshare_sync" {
   channels = [data.healthchecksio_channel.selfhosted_email.id]
 }
 
+# Daily safeguard: alerts if any main-project check has no notification channel
+resource "healthchecksio_check" "channel_audit" {
+  provider = healthchecksio.selfhosted
+
+  name     = "healthchecks-channel-audit"
+  desc     = "Daily audit for checks without a notification channel"
+  tags     = ["healthchecks", "kubernetes"]
+  timeout  = 93600 # 26 hours
+  grace    = 7200  # 2 hours
+  channels = [data.healthchecksio_channel.selfhosted_email.id]
+}
+
 # Got Your Back - full weekly Gmail backup
 resource "healthchecksio_check" "gyb_full" {
   provider = healthchecksio.selfhosted


### PR DESCRIPTION
- Attach API-managed restic checks to project channels.
- Add a daily zero-channel audit with email notification.
- Document intentional restic failure logging behavior.
