### PR TITLE
Fix shared deployment Python lint debt

### DIFF
--- a/scripts/argocd-deploy
+++ b/scripts/argocd-deploy
@@ -27,13 +27,10 @@ import os
 import subprocess
 import sys
 import time
-from typing import List, Optional
 
 
 class DeploymentError(Exception):
     """Custom exception for deployment failures"""
-
-    pass
 
 
 class ArgoCDDeployer:
@@ -41,10 +38,10 @@ class ArgoCDDeployer:
 
     def __init__(
         self,
-        apps: List[str],
+        apps: list[str],
         target_revision: str,
-        pr_number: Optional[str] = None,
-        action_run_url: Optional[str] = None,
+        pr_number: str | None = None,
+        action_run_url: str | None = None,
         sync_timeout: int = 300,
         max_retries: int = 3,
     ):
@@ -56,7 +53,7 @@ class ArgoCDDeployer:
         self.max_retries = max_retries
 
     def run_command(
-        self, cmd: List[str], capture_output: bool = True
+        self, cmd: list[str], capture_output: bool = True
     ) -> subprocess.CompletedProcess:
         """Run a command and return the result"""
         print(f"Running command: {' '.join(cmd)}")
@@ -79,8 +76,8 @@ class ArgoCDDeployer:
                     if result.stderr:
                         print(f"stderr: {result.stderr}")
             return result
-        except Exception as e:
-            raise DeploymentError(f"Failed to run command {' '.join(cmd)}: {e}")
+        except OSError as e:
+            raise DeploymentError(f"Failed to run command {' '.join(cmd)}: {e}") from e
 
     def sync_app_to_revision(self, app: str) -> None:
         """Sync a single application to the target revision"""

--- a/scripts/format-kustomization
+++ b/scripts/format-kustomization
@@ -95,9 +95,11 @@ def normalize_blank_lines(doc: str) -> str:
             curr_key = m.group("key").strip("'\"")
 
             # Insert a single blank line between sections, except apiVersion -> kind
-            if last_key and not (last_key == "apiVersion" and curr_key == "kind"):
-                if out and out[-1] != "\n":
-                    out.append("\n")
+            needs_spacing = last_key is not None and (
+                last_key != "apiVersion" or curr_key != "kind"
+            )
+            if needs_spacing and out and out[-1] != "\n":
+                out.append("\n")
 
             # Emit pending top-level comments then the key line
             out.extend(lines[start:i])
@@ -189,7 +191,8 @@ def main():
             elif changed:
                 any_changed = True
                 print(f"Formatted: {p}")
-        except Exception as e:
+        # Isolate formatter failures so every requested file is checked.
+        except Exception as e:  # noqa: BLE001
             ok = False
             print(f"Error formatting {p}: {e}", file=sys.stderr)
             traceback.print_exc()

--- a/scripts/gen-esphome-hosts
+++ b/scripts/gen-esphome-hosts
@@ -308,7 +308,7 @@ def main():
 
         print(f"\nRunning: {' '.join(cmd)}")
         os.chdir(OPENTOFU_DIR)
-        result = subprocess.run(cmd)
+        result = subprocess.run(cmd, check=False)
         sys.exit(result.returncode)
 
 

--- a/tools/weather-bg/generate
+++ b/tools/weather-bg/generate
@@ -12,14 +12,14 @@ Usage:
   generate --list              # List all image names
 """
 
-import json
 import base64
-import urllib.error
-import urllib.request
+import json
+import os
 import subprocess
 import sys
-import os
 import time
+import urllib.error
+import urllib.request
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 IMAGE_DIR = os.path.join(SCRIPT_DIR, "images")
@@ -254,7 +254,8 @@ def main():
         except urllib.error.URLError as e:
             print(f"ERROR: Network - {e.reason}")
             errors += 1
-        except Exception as e:
+        # A failure for one image must not prevent attempts for the remaining batch.
+        except Exception as e:  # noqa: BLE001
             print(f"ERROR: {e}")
             errors += 1
         time.sleep(2)


### PR DESCRIPTION
- Narrow subprocess error handling and make non-raising execution explicit.
- Preserve intentional per-file and per-image failure isolation with documented lint suppressions.
- Modernize Python annotations and simplify kustomization spacing without changing behavior.
