### PR TITLE
Quote shell expansions in workflows

### DIFF
--- a/.github/workflows/argocd-diff.yml
+++ b/.github/workflows/argocd-diff.yml
@@ -62,7 +62,7 @@ jobs:
       run: |
         # Query PR base dynamically instead of assuming 'main'
         BASE=$(gh pr view "$ISSUE_NUMBER" --json baseRefName -q .baseRefName)
-        echo "base=$BASE" >> $GITHUB_OUTPUT
+        echo "base=$BASE" >> "$GITHUB_OUTPUT"
         git fetch origin "$BASE:$BASE"
 
     - name: Get PR head SHA
@@ -73,7 +73,7 @@ jobs:
         ISSUE_NUMBER: ${{ github.event.issue.number }}
       run: |
         PR_HEAD=$(gh pr view "$ISSUE_NUMBER" --json headRefOid -q .headRefOid)
-        echo "sha=$PR_HEAD" >> $GITHUB_OUTPUT
+        echo "sha=$PR_HEAD" >> "$GITHUB_OUTPUT"
 
     - name: Detect Changed Apps
       if: steps.diff.outputs.command-name
@@ -102,7 +102,7 @@ jobs:
         ISSUE_NUMBER: ${{ github.event.issue.number }}
       run: |
         PR_BRANCH=$(gh pr view "$ISSUE_NUMBER" --json headRefName -q .headRefName)
-        echo "branch=$PR_BRANCH" >> $GITHUB_OUTPUT
+        echo "branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
 
     - name: ArgoCD Diff
       if: steps.diff.outputs.command-name && steps.detect.outputs.apps != ''

--- a/.github/workflows/deploy-reset-commands.yml
+++ b/.github/workflows/deploy-reset-commands.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
         # Query PR base dynamically instead of assuming 'main'
         BASE=$(gh pr view "$ISSUE_NUMBER" --json baseRefName -q .baseRefName)
-        echo "base=$BASE" >> $GITHUB_OUTPUT
+        echo "base=$BASE" >> "$GITHUB_OUTPUT"
         git fetch origin "$BASE:$BASE"
 
     - name: Get PR Info
@@ -85,7 +85,7 @@ jobs:
         RESET_COMMAND: ${{ steps.reset.outputs.command-name }}
       run: |
         PR_BRANCH=$(gh pr view "$ISSUE_NUMBER" --json headRefName -q .headRefName)
-        echo "branch=$PR_BRANCH" >> $GITHUB_OUTPUT
+        echo "branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
 
         if [[ "$DEPLOY_COMMAND" == "deploy" ]]; then
           echo "Deploying branch: $PR_BRANCH"
@@ -94,7 +94,7 @@ jobs:
           echo "Resetting branch: $PR_BRANCH to main"
           TARGET_REVISION="main"
         fi
-        echo "target-revision=$TARGET_REVISION" >> $GITHUB_OUTPUT
+        echo "target-revision=$TARGET_REVISION" >> "$GITHUB_OUTPUT"
 
     - name: Get PR head SHA
       if: steps.deploy.outputs.command-name || steps.reset.outputs.command-name
@@ -104,7 +104,7 @@ jobs:
         ISSUE_NUMBER: ${{ github.event.issue.number }}
       run: |
         PR_HEAD=$(gh pr view "$ISSUE_NUMBER" --json headRefOid -q .headRefOid)
-        echo "sha=$PR_HEAD" >> $GITHUB_OUTPUT
+        echo "sha=$PR_HEAD" >> "$GITHUB_OUTPUT"
 
     - name: Detect Changed Apps
       if: steps.deploy.outputs.command-name || steps.reset.outputs.command-name

--- a/.github/workflows/render-helm.yaml
+++ b/.github/workflows/render-helm.yaml
@@ -81,7 +81,7 @@ jobs:
           HEAD_SHA=$PUSH_HEAD_SHA
         fi
         echo "Comparing $BASE_SHA..$HEAD_SHA"
-        git diff --name-only -z $BASE_SHA $HEAD_SHA \
+        git diff --name-only -z "$BASE_SHA" "$HEAD_SHA" \
           | xargs -0 -r -n1 dirname \
           | sort -u \
           | while read -r dir; do


### PR DESCRIPTION
Quote GitHub output paths and Git revision arguments so embedded workflow scripts do not perform unintended word splitting or glob expansion.
