### PR TITLE
Remove Ansible vault secrets from CI

### DIFF
--- a/.github/workflows/ansible-integration-test.yaml
+++ b/.github/workflows/ansible-integration-test.yaml
@@ -35,12 +35,6 @@ jobs:
             - 'Dockerfile.ansible'
             - '.github/workflows/ansible-integration-test.yaml'
 
-    - name: Write vault password file
-      if: steps.changes.outputs.ansible == 'true'
-      run: echo "$ANSIBLE_VAULT_PASSWORD" > ansible/ansible-vault-password
-      env:
-        ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
-
     - name: Run Ansible integration test
       if: steps.changes.outputs.ansible == 'true'
       run: ansible/scripts/docker-integration-test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,11 +37,6 @@ jobs:
         restore-keys: |
           precommit-
 
-    - name: Write vault password file
-      run: echo "$ANSIBLE_VAULT_PASSWORD" > ansible/ansible-vault-password
-      env:
-        ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
-
     - name: Run lint on all files
       run: nix develop --command ./scripts/lint --all-files --show-diff-on-failure
       env:

--- a/Dockerfile.ansible
+++ b/Dockerfile.ansible
@@ -53,6 +53,13 @@ RUN su ansible -c 'cd /workspace && nix develop --command true'
 # Now copy ansible directory (changes frequently, but layers above are cached)
 COPY --chown=ansible:ansible ansible /workspace/ansible
 
+# Integration tests exercise playbook behavior without production credentials.
+# Replace inline vault values only inside this disposable image, then remove the
+# password-file setting so Ansible cannot attempt to load a real vault secret.
+RUN su ansible -c \
+    'cd /workspace && nix develop --command ansible/scripts/sanitize-vault-values ansible' && \
+    sed -i '/^vault_password_file=/d' /workspace/ansible/ansible.cfg
+
 WORKDIR /workspace/ansible
 
 # Ensure the Nix wrapper is executable before using it

--- a/ansible/host_vars/ansible-integration-test.yaml
+++ b/ansible/host_vars/ansible-integration-test.yaml
@@ -9,3 +9,23 @@ setup_upgrade_update_grub: false
 hostname_manage_etc_hosts: false
 sshd_config_validation: false
 qemu_guest_agent_enabled: false
+
+# Exercise user management without decrypting or changing production hashes.
+genericusers_users:
+  - name: root
+    comment: Root user
+    shell: /bin/bash
+    groups: []
+    ssh_keys: []
+  - name: coneill
+    comment: Integration test user
+    shell: /bin/bash
+    uid: 10001
+    groups: [sudo, audio, video, dialout]
+    append: true
+    ssh_keys: []
+  - name: ansible
+    comment: Ansible role user
+    uid: 9000
+    groups: [sudo]
+    ssh_keys: []

--- a/ansible/scripts/docker-integration-test
+++ b/ansible/scripts/docker-integration-test
@@ -9,13 +9,6 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
-# Check if vault password file exists
-if [[ $# -eq 0 ]] && [[ ! -f "ansible/ansible-vault-password" ]]; then
-    echo "Error: ansible/ansible-vault-password file not found"
-    echo "Please ensure the vault password file exists before running the integration test"
-    exit 1
-fi
-
 echo "Building Ansible integration test image..."
 docker build --load -t ansible-integration-test -f Dockerfile.ansible .
 
@@ -27,7 +20,6 @@ if [[ $# -eq 0 ]]; then
       --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw \
       --cgroupns=host \
       --hostname ansible-integration-test \
-      -v "$(pwd)/ansible/ansible-vault-password:/var/lib/ansible-vault-password:ro" \
       --entrypoint /lib/systemd/systemd \
       ansible-integration-test)
 
@@ -63,10 +55,6 @@ if [[ $# -eq 0 ]]; then
         docker rm "$CONTAINER_ID" > /dev/null
         exit 1
     fi
-
-    # Copy vault password to workspace and execute the playbook inside the running container
-    # Note: Mount to /var/lib/ because systemd mounts tmpfs over /tmp and /run
-    docker exec "$CONTAINER_ID" cp /var/lib/ansible-vault-password /workspace/ansible/ansible-vault-password
 
     # Run playbook and capture output for deprecation analysis
     ANSIBLE_LOG="/var/lib/ansible-output.log"

--- a/ansible/scripts/sanitize-vault-values
+++ b/ansible/scripts/sanitize-vault-values
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <ansible-directory>" >&2
+    exit 2
+fi
+
+target_dir=$1
+if [[ ! -d "$target_dir" ]]; then
+    echo "Error: directory not found: $target_dir" >&2
+    exit 1
+fi
+
+sanitized_count=0
+while IFS= read -r -d '' yaml_file; do
+    if ! grep -q '!vault' "$yaml_file"; then
+        continue
+    fi
+
+    vault_count=$(yq '[.. | select(tag == "!vault")] | length' "$yaml_file")
+    if ((vault_count == 0)); then
+        continue
+    fi
+
+    yq -i '
+      (.. | select(tag == "!vault")) = "bogus-vault-value" |
+      (.. | select(tag == "!vault")) tag = "!!str"
+    ' "$yaml_file"
+
+    remaining_count=$(yq '[.. | select(tag == "!vault")] | length' "$yaml_file")
+    if ((remaining_count != 0)); then
+        echo "Error: failed to sanitize all vault values in $yaml_file" >&2
+        exit 1
+    fi
+
+    sanitized_count=$((sanitized_count + vault_count))
+done < <(find "$target_dir" -type f \( -name '*.yaml' -o -name '*.yml' \) -print0)
+
+echo "Replaced $sanitized_count Ansible vault values with test placeholders"

--- a/scripts/ansible-lint-wrapper
+++ b/scripts/ansible-lint-wrapper
@@ -1,28 +1,74 @@
 #!/bin/bash
 
-set -eu -o pipefail
+set -euo pipefail
 
-# Set Ansible temp directory to avoid sandbox permission issues with ~/.ansible/tmp
-export ANSIBLE_LOCAL_TEMP="${PWD}/.tmp/ansible"
-
-# Change to the ansible directory
-cd ansible
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
 
 # Filter files to only include YAML files under ansible/ directory
 # and convert paths to be relative to the ansible directory
-filtered_files=()
+fix_files=()
+lint_only_files=()
 for file in "$@"; do
     if [[ "$file" =~ ^ansible/.*\.(yaml|yml)$ ]]; then
         # Remove the ansible/ prefix to make paths relative to ansible directory
         relative_file="${file#ansible/}"
-        filtered_files+=("$relative_file")
+        # Never copy a sanitized vault value back into the real checkout. Lint
+        # those files without --fix so violations remain visible for a human.
+        if grep -q '!vault' "$file"; then
+            lint_only_files+=("$relative_file")
+        else
+            fix_files+=("$relative_file")
+        fi
     fi
 done
 
 # Only run ansible-lint if we have files to process
-if [ ${#filtered_files[@]} -gt 0 ]; then
-    exec ansible-lint --fix "${filtered_files[@]}"
-else
+if ((${#fix_files[@]} == 0 && ${#lint_only_files[@]} == 0)); then
     echo "No YAML files under ansible/ directory to lint"
     exit 0
 fi
+
+# ansible-lint evaluates the whole project even when passed specific files. Use
+# a disposable copy so it can parse vaulted variables without receiving the
+# production vault password or rewriting encrypted values during --fix.
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+cp -a ansible "$work_dir/ansible"
+ansible/scripts/sanitize-vault-values "$work_dir/ansible"
+sed -i.bak '/^vault_password_file=/d' "$work_dir/ansible/ansible.cfg"
+rm "$work_dir/ansible/ansible.cfg.bak"
+
+# Keep Ansible's temporary files inside the disposable tree.
+export ANSIBLE_LOCAL_TEMP="$work_dir/ansible/.tmp"
+
+lint_status=0
+if ((${#fix_files[@]} > 0)); then
+    set +e
+    (
+        cd "$work_dir/ansible"
+        ansible-lint --fix "${fix_files[@]}"
+    )
+    lint_status=$?
+    set -e
+
+    for relative_file in "${fix_files[@]}"; do
+        cp "$work_dir/ansible/$relative_file" "$repo_root/ansible/$relative_file"
+    done
+fi
+
+if ((${#lint_only_files[@]} > 0)); then
+    set +e
+    (
+        cd "$work_dir/ansible"
+        ansible-lint "${lint_only_files[@]}"
+    )
+    lint_only_status=$?
+    set -e
+
+    if ((lint_status == 0)); then
+        lint_status=$lint_only_status
+    fi
+fi
+
+exit "$lint_status"


### PR DESCRIPTION
Sanitize inline vault values in disposable lint and integration-test copies so GitHub Actions never receives the production vault password.

Use integration-specific user variables without passwords. Preserve ansible-lint autofixes for ordinary files while reporting violations in vaulted files without rewriting their ciphertext.
