### PR TITLE
Scope Alloy log discovery to each node

### DIFF
--- a/kubernetes/alloy/helm/templates/configmap.yaml
+++ b/kubernetes/alloy/helm/templates/configmap.yaml
@@ -21,6 +21,11 @@ data:
     
     discovery.kubernetes "pods" {
       role = "pod"
+      // Each DaemonSet pod should collect logs only from its own node.
+      selectors {
+        role  = "pod"
+        field = "spec.nodeName=" + sys.env("K8S_NODE_NAME")
+      }
     }
     
     discovery.relabel "pods" {
@@ -47,7 +52,7 @@ data:
         action = "replace"
       }
       rule {
-        source_labels = ["__meta_kubernetes_node_name"]
+        source_labels = ["__meta_kubernetes_pod_node_name"]
         target_label = "node"
         action = "replace"
       }

--- a/kubernetes/alloy/helm/templates/controllers/daemonset.yaml
+++ b/kubernetes/alloy/helm/templates/controllers/daemonset.yaml
@@ -66,9 +66,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/alloy
-            - name: varlog
-              mountPath: /var/log
-              readOnly: true
             - mountPath: /var/lib/alloy
               name: alloy-storage
         - name: config-reloader
@@ -93,9 +90,6 @@ spec:
         - name: config
           configMap:
             name: alloy
-        - name: varlog
-          hostPath:
-            path: /var/log
         - hostPath:
             path: /var/lib/alloy
             type: DirectoryOrCreate

--- a/kubernetes/alloy/values.yaml
+++ b/kubernetes/alloy/values.yaml
@@ -7,12 +7,10 @@ alloy:
   - name: TZ
     value: America/New_York
 
-  # Persist Alloy state so DaemonSet rollouts do not replay old logs.
+  # Persist Alloy cursor state across DaemonSet pod replacements on each node.
   storagePath: /var/lib/alloy
 
-  # Enable log file mounts
   mounts:
-    varlog: true
     extra:
     - name: alloy-storage
       mountPath: /var/lib/alloy
@@ -28,6 +26,11 @@ alloy:
 
       discovery.kubernetes "pods" {
         role = "pod"
+        // Each DaemonSet pod should collect logs only from its own node.
+        selectors {
+          role  = "pod"
+          field = "spec.nodeName=" + sys.env("K8S_NODE_NAME")
+        }
       }
 
       discovery.relabel "pods" {
@@ -54,7 +57,7 @@ alloy:
           action = "replace"
         }
         rule {
-          source_labels = ["__meta_kubernetes_node_name"]
+          source_labels = ["__meta_kubernetes_pod_node_name"]
           target_label = "node"
           action = "replace"
         }


### PR DESCRIPTION
Restricts each Alloy DaemonSet pod's Kubernetes discovery to workloads on its own node and corrects the node metadata relabel.

This also removes the read-only `/var/log` host mount. That mount had no effect on log ingestion: no configured Alloy component reads `/var/log`, and `loki.source.kubernetes` collects logs through Kubernetes rather than the host filesystem. `/var/lib/alloy` remains mounted for cursor state.

The exact candidate is deployed and passed Alloy validation, API-server dry-run, five node-pinned log canaries, a syslog canary, and ten minutes of health monitoring.