### PR TITLE
Upgrade Karakeep and enable embeddings

### DIFF
--- a/kubernetes/karakeep/helm/karakeep/common.yaml
+++ b/kubernetes/karakeep/helm/karakeep/common.yaml
@@ -122,12 +122,11 @@ spec:
       dnsPolicy: ClusterFirst
       containers: 
         - args:
-          - --remote-debugging-address=0.0.0.0
-          - --remote-debugging-port=9222
-          - --headless
-          - --hide-scrollbars
           - --disable-gpu
           - --disable-dev-shm-usage
+          - --hide-scrollbars
+          - --disable-blink-features=AutomationControlled
+          - --window-size=1440,900
           image: gcr.io/zenika-hub/alpine-chrome:124
           livenessProbe:
             failureThreshold: 3
@@ -232,8 +231,20 @@ spec:
             value: /data
           - name: DISABLE_PASSWORD_AUTH
             value: "true"
+          - name: EMBEDDING_CONTEXT_LENGTH
+            value: "6000"
+          - name: EMBEDDING_DIMENSIONS
+            value: "1024"
+          - name: EMBEDDING_ENABLE_AUTO_INDEXING
+            value: "true"
+          - name: EMBEDDING_OPENAI_API_KEY
+            value: ollama
+          - name: EMBEDDING_OPENAI_BASE_URL
+            value: http://ollama.ollama.svc.cluster.local:11434/v1
           - name: EMBEDDING_TEXT_MODEL
             value: snowflake-arctic-embed2
+          - name: EMBEDDING_TEXT_MODEL_DIMENSION_OVERRIDE
+            value: "1024"
           - name: INFERENCE_CONTEXT_LENGTH
             value: "16384"
           - name: INFERENCE_ENABLE_AUTO_SUMMARIZATION

--- a/kubernetes/karakeep/kustomization.yaml
+++ b/kubernetes/karakeep/kustomization.yaml
@@ -21,6 +21,9 @@ commonAnnotations:
 
 images:
 - name: ghcr.io/karakeep-app/karakeep
-  newTag: 0.32.0@sha256:64d6a9bbf2d37b5c808cf06b5d87f1f1c7846fdd3844724145a9741aeb06fd31
+  newTag: 0.33.2@sha256:b069e4307dec06ea06d16989c6861c30a1ff208568be44ed5fb5d422cd3e950c
+- name: gcr.io/zenika-hub/alpine-chrome
+  newName: ghcr.io/karakeep-app/karakeep-chrome
+  newTag: 151.0.7922.47-r1@sha256:5b19bbb160e9ff60681a3abd97e1c4ec9f64212301410de658c3900ab7ef31e7
 - name: getmeili/meilisearch
   newTag: v1.49.0@sha256:bdc7d7e7939911c40d88d6bcd01f9c72c81f7293135916d48bce241569f721bd

--- a/kubernetes/karakeep/values.yaml
+++ b/kubernetes/karakeep/values.yaml
@@ -68,7 +68,13 @@ controllers:
           INFERENCE_TEXT_MODEL: gpt-5-mini
           INFERENCE_USE_MAX_COMPLETION_TOKENS: 'true'
           OLLAMA_BASE_URL: http://ollama.ollama.svc.cluster.local:11434
+          EMBEDDING_OPENAI_BASE_URL: http://ollama.ollama.svc.cluster.local:11434/v1
+          EMBEDDING_OPENAI_API_KEY: ollama
           EMBEDDING_TEXT_MODEL: snowflake-arctic-embed2
+          EMBEDDING_DIMENSIONS: '1024'
+          EMBEDDING_TEXT_MODEL_DIMENSION_OVERRIDE: '1024'
+          EMBEDDING_CONTEXT_LENGTH: '6000'
+          EMBEDDING_ENABLE_AUTO_INDEXING: 'true'
           SEARCH_NUM_WORKERS: '3'
         envFrom:
         - secretRef:
@@ -77,6 +83,19 @@ controllers:
             name: karakeep-meilisearch
         - secretRef:
             name: karakeep-oidc
+
+  chrome:
+    containers:
+      chrome:
+        # Match Karakeep v0.33.2's documented Chrome crawler settings. The
+        # image entrypoint owns the remote-debugging address and port.
+        # https://github.com/karakeep-app/karakeep/blob/v0.33.2/docs/docs/06-administration/09-chrome-image-migration.md
+        args:
+        - --disable-gpu
+        - --disable-dev-shm-usage
+        - --hide-scrollbars
+        - --disable-blink-features=AutomationControlled
+        - --window-size=1440,900
 
 meilisearch:
   enabled: true


### PR DESCRIPTION
Upgrades Karakeep to 0.33.2, migrates the crawler to Karakeep's supported Chrome image and flags, and enables Ollama-backed semantic search with 1024-dimensional embeddings and a validated 6000-character input limit.

This supersedes Renovate PR #2692.