### PR TITLE
Adopt acme.sh ARI renewal cadence

### DIFF
--- a/kubernetes/acme-sh/cronjob-renew.yaml
+++ b/kubernetes/acme-sh/cronjob-renew.yaml
@@ -6,7 +6,7 @@ metadata:
   name: acme-renew
 
 spec:
-  schedule: 0 4 * * *
+  schedule: 17 4,10,16,22 * * *
   jobTemplate:
     spec:
       template:
@@ -20,7 +20,7 @@ spec:
             runAsUser: 1000
           containers:
           - name: acme-sh
-            image: neilpang/acme.sh:3.1.3@sha256:3e7593e957e16edf357655bcd89164b81cd1634849df90e6dcb54891be9cc86b
+            image: neilpang/acme.sh:3.1.4@sha256:08bad323dd6537ea2caba64260ef6e70e96057c4d9214afb9c07861db26653d9
             command: [/bin/sh, /scripts/acme-renew.sh]
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/acme-sh/cronjob-synology.yaml
+++ b/kubernetes/acme-sh/cronjob-synology.yaml
@@ -20,7 +20,7 @@ spec:
             runAsUser: 1000
           containers:
           - name: acme-sh
-            image: neilpang/acme.sh:3.1.3@sha256:3e7593e957e16edf357655bcd89164b81cd1634849df90e6dcb54891be9cc86b
+            image: neilpang/acme.sh:3.1.4@sha256:08bad323dd6537ea2caba64260ef6e70e96057c4d9214afb9c07861db26653d9
             command: [/bin/sh, /scripts/acme-synology.sh]
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/acme-sh/cronjob-udmp.yaml
+++ b/kubernetes/acme-sh/cronjob-udmp.yaml
@@ -20,7 +20,7 @@ spec:
             runAsUser: 1000
           containers:
           - name: acme-sh
-            image: neilpang/acme.sh:3.1.3@sha256:3e7593e957e16edf357655bcd89164b81cd1634849df90e6dcb54891be9cc86b
+            image: neilpang/acme.sh:3.1.4@sha256:08bad323dd6537ea2caba64260ef6e70e96057c4d9214afb9c07861db26653d9
             command: [/bin/sh, /scripts/acme-udmp.sh]
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
acme.sh 3.1.4 enables CA-directed renewal timing, but the Kubernetes CronJob bypasses upstream’s six-hour scheduler and would continue polling only once daily. Update all three jobs to 3.1.4 and move the renewal check to an offset six-hour cadence so changed renewal windows are discovered promptly without running on common hour boundaries.
