### PR TITLE
Upgrade Karakeep Meilisearch to 1.51

### DIFF
--- a/kubernetes/karakeep/helm/meilisearch/configmap.yaml
+++ b/kubernetes/karakeep/helm/meilisearch/configmap.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   MEILI_ENV: "production"
-  MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE: "true"
   MEILI_NO_ANALYTICS: "true"
+  MEILI_UPGRADE_DB: "true"
 

--- a/kubernetes/karakeep/helm/meilisearch/statefulset.yaml
+++ b/kubernetes/karakeep/helm/meilisearch/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
         app.kubernetes.io/part-of: meilisearch
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: c1ea38479afd481f11fa588d3466d631f87bbd3ca920651685e33aaa4075eb1a
+        checksum/config: 4cb7c9de031634b65307b783c37ea7c3e2595a65f3f88d75bc6e509d673328fd
     spec:
       serviceAccountName: karakeep-meilisearch
       securityContext:

--- a/kubernetes/karakeep/kustomization.yaml
+++ b/kubernetes/karakeep/kustomization.yaml
@@ -26,4 +26,4 @@ images:
   newName: ghcr.io/karakeep-app/karakeep-chrome
   newTag: 151.0.7922.47-r1@sha256:5b19bbb160e9ff60681a3abd97e1c4ec9f64212301410de658c3900ab7ef31e7
 - name: getmeili/meilisearch
-  newTag: v1.49.0@sha256:bdc7d7e7939911c40d88d6bcd01f9c72c81f7293135916d48bce241569f721bd
+  newTag: v1.51.0@sha256:a9eb29ee09ab4943db3b4c68620bd6f3382e6b2b0ac4431c0e607b48dbcd4c14

--- a/kubernetes/karakeep/values.yaml
+++ b/kubernetes/karakeep/values.yaml
@@ -100,7 +100,7 @@ controllers:
 meilisearch:
   enabled: true
   environment:
-    MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE: 'true'
+    MEILI_UPGRADE_DB: 'true'
   auth:
     existingMasterKeySecret: karakeep-meilisearch
   persistence:


### PR DESCRIPTION
Meilisearch 1.51 renamed its in-place database upgrade switch, so updating only the image would leave the existing 1.49 database unreadable at startup. Upgrade the pinned image and rename the setting together, then refresh the rendered manifests so the database migration is enabled during rollout.
