### PR TITLE
Upgrade OpenArchiver Meilisearch to 1.51

### DIFF
--- a/kubernetes/openarchiver/meilisearch-statefulset.yaml
+++ b/kubernetes/openarchiver/meilisearch-statefulset.yaml
@@ -24,14 +24,14 @@ spec:
         runAsUser: 1000
       containers:
       - name: meilisearch
-        image: docker.io/getmeili/meilisearch:v1.49.0@sha256:bdc7d7e7939911c40d88d6bcd01f9c72c81f7293135916d48bce241569f721bd
+        image: docker.io/getmeili/meilisearch:v1.51.0@sha256:a9eb29ee09ab4943db3b4c68620bd6f3382e6b2b0ac4431c0e607b48dbcd4c14
         imagePullPolicy: IfNotPresent
         env:
         - name: MEILI_ENV
           value: production
         - name: MEILI_NO_ANALYTICS
           value: 'true'
-        - name: MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE
+        - name: MEILI_UPGRADE_DB
           value: 'true'
         - name: MEILI_MASTER_KEY
           valueFrom:


### PR DESCRIPTION
Meilisearch 1.51 renamed its in-place database upgrade setting, so updating only the image would leave OpenArchiver’s existing 1.49 database unreadable at startup. Upgrade the pinned image and rename the setting together so the database migration is enabled during rollout.

Closes #2740
