### PR TITLE
Require explicit Argo management intent

### DIFF
--- a/.kyverno/policies/require-explicit-argo-management.yaml
+++ b/.kyverno/policies/require-explicit-argo-management.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+
+metadata:
+  name: require-explicit-argo-management
+
+spec:
+  validationFailureAction: Enforce
+  rules:
+  - name: require-argo-managed-annotation
+    match:
+      any:
+      - resources:
+          kinds:
+          - Kustomization
+    validate:
+      message: >-
+        Top-level application Kustomizations must set
+        commonAnnotations.argoManaged to either 'true' or 'false'.
+      pattern:
+        commonAnnotations:
+          argoManaged: true | false

--- a/kubernetes/hass/kustomization.yaml
+++ b/kubernetes/hass/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 
 namespace: hass
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - namespace.yaml
 - hass-postgres-cluster.yaml

--- a/kubernetes/network-storage-benchmark/kustomization.yaml
+++ b/kubernetes/network-storage-benchmark/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 
 namespace: network-storage-benchmark
 
+commonAnnotations:
+  argoManaged: 'false'
+
 resources:
 - namespace.yaml
 - pvc-iscsi.yaml

--- a/kubernetes/scripts/kyverno-wrapper
+++ b/kubernetes/scripts/kyverno-wrapper
@@ -7,6 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BASEDIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 POLICY_DIR="$BASEDIR/.kyverno/policies"
 PINNED_IMAGE_POLICY="$POLICY_DIR/require-pinned-image-pull-policy.yaml"
+ARGO_MANAGEMENT_POLICY="$POLICY_DIR/require-explicit-argo-management.yaml"
 
 validate_files() {
   local policy_path=$1
@@ -50,7 +51,26 @@ temp_dir=$(mktemp -d)
 trap 'rm -rf "$temp_dir"' EXIT
 
 # Preserve the existing behavior for changed, non-generated manifests.
-validate_files "$POLICY_DIR" "$temp_dir/changed-resources.yaml" "$@"
+for policy in "$POLICY_DIR"/*.yaml; do
+  if [[ $policy == "$ARGO_MANAGEMENT_POLICY" ]]; then
+    continue
+  fi
+
+  validate_files "$policy" "$temp_dir/changed-resources.yaml" "$@"
+done
+
+# The normal policy path validates only changed manifests, which can include
+# nested Kustomizations. This policy must instead mirror the ApplicationSet's
+# repository-wide kubernetes/*/kustomization.yaml scope: unchanged apps must be
+# checked, while nested Kustomizations must not require app-level intent.
+mapfile -t top_level_kustomizations < <(
+  find "$BASEDIR/kubernetes" -mindepth 2 -maxdepth 2 -type f \
+    \( -name 'kustomization.yaml' -o -name 'kustomization.yml' \) \
+    | sort
+)
+validate_files "$ARGO_MANAGEMENT_POLICY" \
+  "$temp_dir/top-level-kustomizations.yaml" \
+  "${top_level_kustomizations[@]}"
 
 if [[ $validate_all_pinned_images != true ]]; then
   exit 0

--- a/kubernetes/smtp-relay/kustomization.yaml
+++ b/kubernetes/smtp-relay/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 
 namespace: smtp-relay
 
+commonAnnotations:
+  argoManaged: 'true'
+
 resources:
 - namespace.yaml
 - certificate.yaml
@@ -24,9 +27,3 @@ patches:
   target:
     kind: StatefulSet
     name: smtp
-
-labels:
-
-- pairs:
-    argoManaged: 'true'
-  includeSelectors: false


### PR DESCRIPTION
Top-level application Kustomizations could silently fall outside the ApplicationSet when argoManaged was missing or placed in the wrong field. Validate every app with a path-scoped Kyverno policy and record explicit management intent for the existing exceptions.
