### PR TITLE
Increase k2 root disk to 500 GiB

### DIFF
--- a/opentofu/proxmox.tf
+++ b/opentofu/proxmox.tf
@@ -99,7 +99,7 @@ resource "proxmox_virtual_environment_vm" "k2" {
   disk {
     interface    = "scsi0"
     datastore_id = "local-zfs"
-    size         = 150
+    size         = 500
     file_format  = "raw"
     iothread     = true
     discard      = "on"


### PR DESCRIPTION
Runner workloads can consume enough node-local space to approach kubelet eviction thresholds on k2. Increase the Proxmox disk declaration from 150 GiB to 500 GiB so the live expansion remains represented in infrastructure code and provides sufficient operating headroom.