### PR TITLE
Update Hermes Agent to v2026.8.13

### DIFF
--- a/kubernetes/felix/deployment.yaml
+++ b/kubernetes/felix/deployment.yaml
@@ -103,7 +103,7 @@ spec:
           readOnly: true
       containers:
       - name: hermes
-        image: docker.io/nousresearch/hermes-agent:v2026.6.19@sha256:9f367c7756ef087661a361536a89f438d57a122b958dc23d82d456b1433e6e9e
+        image: docker.io/nousresearch/hermes-agent:v2026.8.13@sha256:68e15ae2a6d894d0ccbd9f8aacbbe13d4d28fa5dc9b6a303970b67bb2499b1a6
         args:
         - gateway
         - run


### PR DESCRIPTION
Hermes Agent v2026.8.3 contains a gateway memory regression, while v2026.8.13 includes the upstream memory-pressure eviction fix. Update Felix directly to the first fixed release so the gateway receives the safety fix without taking the broader v2026.8.18 change set.
