### PR TITLE
Reconcile Slack manifests for provider update

### DIFF
--- a/opentofu/slack/.terraform.lock.hcl
+++ b/opentofu/slack/.terraform.lock.hcl
@@ -2,25 +2,35 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/change-engine/slack-app" {
-  version     = "0.1.2"
-  constraints = "~> 0.1"
+  version     = "0.2.0"
+  constraints = "~> 0.2"
   hashes = [
-    "h1:YC9RVh30LjUcYG5L6Gp94DLq5SCLVjO2OuDcdfjKlj8=",
-    "h1:wynoTv5zRDWVdnfqDHl7YUFdMSakR2bPeWlOKdrUKyg=",
-    "zh:0ad37ffe159a731d02b62b2c1218f4fd62b638c62dd85280a96f818689164caf",
-    "zh:0e926c6cdfe9c4bf41281bb1eb089b2ca927d9b9b18282b0580abda3bdeb7f1a",
-    "zh:194b9a34ef73fd77860f7e03253257dfd467e0bc0bded5bec9811820e25a1f66",
-    "zh:197df48588a0437fd5b8432482963e65001610b0c9fda2b53f769aaae39ea142",
-    "zh:2046f92451f20cdf11ad4ad8f051d7ce3769a227d9a32768b580f2ccebc75baf",
-    "zh:39a9710f0d758f0e158e689ce1d0a3dc56057922fac173f9c5a6be1926b34f83",
-    "zh:72b4f43a84023ccb33ab5b2a002c2b06b181d18023ef3cb04730c4645c60594b",
-    "zh:7b163e8eea395697d132e22eb58965f6c55b2b8eaf12d3d48704ff8c3a3f018b",
+    "h1:0DC4Z6PMRx5ssCtFjkYWLz8xWtMdOUeoBF9/ezdHzkA=",
+    "h1:7RaqJhidtJDvxrMY1VmvxStyQCTIVu8O1li6YTF/o98=",
+    "h1:8HO+f9Ba7pPkkW/s2UJyfHCsDaacN5IqU3gx/QIMJRc=",
+    "h1:9HbHAGrePY3HrSadb00U77wnZ+UpTlpk95zUfrOJYg0=",
+    "h1:CLfIKq+lcFkiqSTTKnpRAPb33kfMPiEjPBFsNGPzYeA=",
+    "h1:FfK64NcLc2vSnQYsA1FXfJbWXa3Ce8+5bkmZHAZYwYo=",
+    "h1:LIzOUX5suO85kNner7NK0YglzePH+lsjc2DDE8RLThU=",
+    "h1:RJJZ+b8QQTiJ9xEXb0C2RzLFg9cJ3U8GQ3WgADY8zg8=",
+    "h1:XXtvBU2Q9WfUzoIrV0h3K+ijogPMrysRzkdXaIC7dr4=",
+    "h1:by3BMbfvB4rC+WS2M7g2Tga8r7jzD3m5MXkT0td+Y44=",
+    "h1:kbavrtahsp4/DXkpIaLHp9d/637p+/NB0SxHF67ExFc=",
+    "h1:tBS1/EYvMsgvmgEjm+/PKTVTO1PIDy9RhBAxPXdkP58=",
+    "h1:wz9UWkqqOl4+zay3PVF2d2aBpaFb+SiSw93+AhDgnzQ=",
+    "zh:18bfd732af26b3e7905022cc96fcd338980a67d4ef4639212195e33fff8f0487",
+    "zh:3658e6cf0f6896f33cacbab9b04290c89448b335f3bbbca4797bb3ac1695c553",
+    "zh:37024a733aa5be6203ca70beec91e5a418ad77ff6bae999ecbdf22bb414d0eee",
+    "zh:52325c505495cc631e1a891068e81aba91901cd9d75dda158700aca032892cab",
+    "zh:67f7d1dbaca1b4d310ea23079343e7a07e1e4d25406f0ac262bac2a02f22fec1",
     "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
-    "zh:98eb44b25fee20f74c2bac627ad9e316e506336794f8b2e5deba1f96748c744f",
-    "zh:a09e5b2e7ae8a7d8e97e0e6db0592f234472250e11b0c502dbfe4ccb25c2ad36",
-    "zh:b6d2b37a1b8946195e30a14a4226adea14106543aa761010b9a34e477fe91613",
-    "zh:c13dd76a801ad5170f9b29a20d019ae0cb13ba5758f7159f0d2057a6dc845a88",
-    "zh:c28176a0541dc8e3500e1a9211e910e39666e028e9efbddc4b1706a7fd8b46f3",
-    "zh:faeae25ce67386bf4f4ac2113b3d23501b3fdc8d31db1208ea444e77a01760a4",
+    "zh:907e769dc85bbcb4ea9cb4c383a529a0842f771f393ebf98de0af8813183969f",
+    "zh:a1009df3daf27893daf5afc40e30b18fec4eead10ca25de63c70aae38d163e1d",
+    "zh:b05c93711a603a6acef013970128b8c34a1b2e015d2605636285fc25a07964a7",
+    "zh:c57549d2da8ac69fdbe4e2dff64d63e22396349b05a95cac452b267738212951",
+    "zh:c9bcd9a5daf6d6a456ea8d4cc6f4b604bdc5b106bf7613791187ec21ecd7563a",
+    "zh:cf0a56c99609a4156de3d0cbffb66a10f2c7651e526a740d963fa4d376b882db",
+    "zh:d74078203cad80b474480e3920c42490a7fa8c0554b89661a6634fb307f58cca",
+    "zh:eb992df7376866312b090921d575f50ba8a559bb20fa669d7e0ff5f3be924c3a",
   ]
 }

--- a/opentofu/slack/apps.tf
+++ b/opentofu/slack/apps.tf
@@ -1,13 +1,255 @@
+locals {
+  hermes_slack_command_url = "https://hermes-agent.local/slack/commands"
+  hermes_slack_commands = [
+    {
+      command     = "/hermes"
+      description = "Talk to Hermes or run a subcommand"
+      usage_hint  = "[subcommand] [args]"
+    },
+    {
+      command     = "/btw"
+      description = "Alias for /background — Run a prompt in the background"
+      usage_hint  = "<prompt>"
+    },
+    {
+      command     = "/bg"
+      description = "Alias for /background — Run a prompt in the background"
+      usage_hint  = "<prompt>"
+    },
+    {
+      command     = "/start"
+      description = "Acknowledge platform start pings without a reply"
+    },
+    {
+      command     = "/new"
+      description = "Start a new session (fresh session ID + history)"
+      usage_hint  = "[name]"
+    },
+    {
+      command     = "/retry"
+      description = "Retry the last message (resend to agent)"
+    },
+    {
+      command     = "/undo"
+      description = "Back up N user turns and re-prompt (default 1)"
+      usage_hint  = "[N]"
+    },
+    {
+      command     = "/title"
+      description = "Set a title for the current session"
+      usage_hint  = "[name]"
+    },
+    {
+      command     = "/branch"
+      description = "Branch the current session (explore a different path)"
+      usage_hint  = "[name]"
+    },
+    {
+      command     = "/compress"
+      description = "Compress conversation context (add 'here [N]' to keep recent N turns; --preview shows what would happen)"
+      usage_hint  = "[here [N] | focus topic | --preview|--dry-run]"
+    },
+    {
+      command     = "/rollback"
+      description = "List or restore filesystem checkpoints"
+      usage_hint  = "[number]"
+    },
+    {
+      command     = "/stop"
+      description = "Kill all running background processes"
+    },
+    {
+      command     = "/approve"
+      description = "Approve a pending dangerous command"
+      usage_hint  = "[session|always]"
+    },
+    {
+      command     = "/deny"
+      description = "Deny a pending dangerous command (optionally with a reason)"
+      usage_hint  = "[all] [reason]"
+    },
+    {
+      command     = "/background"
+      description = "Run a prompt in the background"
+      usage_hint  = "<prompt>"
+    },
+    {
+      command     = "/agents"
+      description = "Show active agents and running tasks"
+    },
+    {
+      command     = "/queue"
+      description = "Queue a prompt for the next turn (doesn't interrupt)"
+      usage_hint  = "<prompt>"
+    },
+    {
+      command     = "/steer"
+      description = "Inject a message after the next tool call without interrupting"
+      usage_hint  = "<prompt>"
+    },
+    {
+      command     = "/goal"
+      description = "Set a standing goal Hermes works on across turns until achieved"
+      usage_hint  = "[text | draft <text> | show | gate add <cmd> | pause | resume | clear | status | wait <pid> | unwait"
+    },
+    {
+      command     = "/subgoal"
+      description = "Add or manage extra criteria on the active goal"
+      usage_hint  = "[text | remove N | clear]"
+    },
+    {
+      command     = "/context"
+      description = "Show detailed context window view with usage gauge, category breakdown, compression stats, and throughput"
+      usage_hint  = "[all]"
+    },
+    {
+      command     = "/whoami"
+      description = "Show your slash command access (admin / user)"
+    },
+    {
+      command     = "/profile"
+      description = "Show active profile name and home directory"
+    },
+    {
+      command     = "/sethome"
+      description = "Set this chat as the home channel"
+    },
+    {
+      command     = "/resume"
+      description = "Resume a previously-named session"
+      usage_hint  = "[name]"
+    },
+    {
+      command     = "/sessions"
+      description = "Browse and resume previous sessions"
+    },
+    {
+      command     = "/model"
+      description = "Switch model (session-scoped; --global to persist)"
+      usage_hint  = "[model] [--provider name] [--global|--session] [--refresh]"
+    },
+    {
+      command     = "/codex-runtime"
+      description = "Toggle codex app-server runtime for OpenAI/Codex models"
+      usage_hint  = "[auto|codex_app_server]"
+    },
+    {
+      command     = "/personality"
+      description = "Set a predefined personality"
+      usage_hint  = "[name]"
+    },
+    {
+      command     = "/footer"
+      description = "Toggle gateway runtime-metadata footer on final replies"
+      usage_hint  = "[on|off|status]"
+    },
+    {
+      command     = "/yolo"
+      description = "Toggle YOLO mode (skip all dangerous command approvals)"
+    },
+    {
+      command     = "/approvals"
+      description = "Show or set the persistent dangerous-command approval mode"
+      usage_hint  = "[manual|smart|off]"
+    },
+    {
+      command     = "/reasoning"
+      description = "Manage reasoning effort and display"
+      usage_hint  = "[level|show|hide|full|clamp] [--global]"
+    },
+    {
+      command     = "/fast"
+      description = "Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode (Normal/Fast)"
+      usage_hint  = "[normal|fast|status] [--global]"
+    },
+    {
+      command     = "/voice"
+      description = "Toggle voice mode"
+      usage_hint  = "[on|off|tts|status]"
+    },
+    {
+      command     = "/memory"
+      description = "Review pending memory writes / toggle the approval gate"
+      usage_hint  = "[pending|approve|reject|approval] [id|on|off]"
+    },
+    {
+      command     = "/bundles"
+      description = "List skill bundles (aliases /<name> for multiple skills)"
+    },
+    {
+      command     = "/learn"
+      description = "Learn a reusable skill from anything you describe (dirs, URLs, this chat, notes)"
+      usage_hint  = "<what to learn from>"
+    },
+    {
+      command     = "/suggestions"
+      description = "Review suggested automations (accept/dismiss)"
+      usage_hint  = "[accept|dismiss N | catalog]"
+    },
+    {
+      command     = "/blueprint"
+      description = "Set up an automation from a blueprint template"
+      usage_hint  = "[name] [slot=value ...]"
+    },
+    {
+      command     = "/curator"
+      description = "Background skill maintenance (status, run, pin, archive, list-archived)"
+      usage_hint  = "[subcommand]"
+    },
+    {
+      command     = "/kanban"
+      description = "Multi-profile collaboration board (tasks, links, comments)"
+      usage_hint  = "[subcommand]"
+    },
+    {
+      command     = "/reload-mcp"
+      description = "Reload MCP servers from config"
+    },
+    {
+      command     = "/reload-skills"
+      description = "Re-scan ~/.hermes/skills/ for newly installed or removed skills"
+    },
+    {
+      command     = "/commands"
+      description = "Browse all commands and skills (paginated)"
+      usage_hint  = "[page]"
+    },
+    {
+      command     = "/help"
+      description = "Show available commands"
+    },
+    {
+      command     = "/restart"
+      description = "Gracefully restart the gateway after draining active runs"
+    },
+    {
+      command     = "/usage"
+      description = "Show token usage and rate limits; `reset` redeems a banked Codex limit reset"
+      usage_hint  = "[reset [--force]]"
+    },
+    {
+      command     = "/insights"
+      description = "Show usage insights and analytics"
+      usage_hint  = "[days]"
+    },
+    {
+      command     = "/platform"
+      description = "Pause, resume, or list a failing gateway platform"
+      usage_hint  = "<pause|resume|list> [name]"
+    },
+  ]
+}
+
 resource "slack-app_manifest" "felix" {
   manifest = jsonencode({
     display_information = {
       name             = "Felix"
-      description      = "Felix"
-      background_color = "#2c5c4a"
+      description      = "Your Felix agent on Slack"
+      background_color = "#1a1a2e"
     }
     features = {
       assistant_view = {
-        assistant_description = "Felix"
+        assistant_description = "Chat with Hermes in threads and DMs."
       }
       app_home = {
         home_tab_enabled               = false
@@ -16,10 +258,17 @@ resource "slack-app_manifest" "felix" {
       }
       bot_user = {
         display_name  = "Felix"
-        always_online = false
+        always_online = true
       }
+      slash_commands = [
+        for command in local.hermes_slack_commands : merge(command, {
+          url           = local.hermes_slack_command_url
+          should_escape = false
+        })
+      ]
     }
     oauth_config = {
+      pkce_enabled = false
       scopes = {
         bot = [
           "app_mentions:read",
@@ -27,6 +276,7 @@ resource "slack-app_manifest" "felix" {
           "channels:history",
           "channels:read",
           "chat:write",
+          "commands",
           "files:read",
           "files:write",
           "groups:history",
@@ -36,10 +286,7 @@ resource "slack-app_manifest" "felix" {
           "im:write",
           "mpim:history",
           "mpim:read",
-          "pins:read",
-          "pins:write",
           "reactions:read",
-          "reactions:write",
           "users:read",
         ]
       }
@@ -48,14 +295,12 @@ resource "slack-app_manifest" "felix" {
       event_subscriptions = {
         bot_events = [
           "app_mention",
-          "member_joined_channel",
-          "member_left_channel",
+          "assistant_thread_context_changed",
+          "assistant_thread_started",
           "message.channels",
           "message.groups",
           "message.im",
           "message.mpim",
-          "pin_added",
-          "pin_removed",
           "reaction_added",
           "reaction_removed",
         ]
@@ -63,6 +308,7 @@ resource "slack-app_manifest" "felix" {
       interactivity = {
         is_enabled = true
       }
+      is_mcp_enabled         = false
       org_deploy_enabled     = false
       socket_mode_enabled    = true
       token_rotation_enabled = false
@@ -83,6 +329,7 @@ resource "slack-app_manifest" "home" {
       }
     }
     oauth_config = {
+      pkce_enabled = false
       scopes = {
         bot = [
           "chat:write",
@@ -92,6 +339,7 @@ resource "slack-app_manifest" "home" {
       }
     }
     settings = {
+      is_mcp_enabled         = false
       org_deploy_enabled     = false
       socket_mode_enabled    = false
       token_rotation_enabled = false

--- a/opentofu/slack/main.tf
+++ b/opentofu/slack/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     slack-app = {
       source  = "change-engine/slack-app"
-      version = "~> 0.1"
+      version = "~> 0.2"
     }
   }
 


### PR DESCRIPTION
The provider upgrade exposed drift between the live Felix Hermes manifest and the tracked configuration, which would have removed working commands, scopes, and event subscriptions. Update the tracked manifest to match live Slack while adopting slack-app 0.2 so plans preserve current behavior and only normalize the new provider state field.
