### PR TITLE
Upgrade Byparr with bounded ephemeral storage

### DIFF
--- a/kubernetes/byparr/deployment.yaml
+++ b/kubernetes/byparr/deployment.yaml
@@ -28,10 +28,13 @@ spec:
         fsGroup: 1000
       containers:
       - name: byparr
-        image: ghcr.io/thephaseless/byparr:2.1.0@sha256:01a46a2865d9a6db5eb8ead04ec0dd33b8fbe233e8565ae70b50d4cc0af4cfb0
+        image: ghcr.io/thephaseless/byparr:3.0.4@sha256:874f719518f617d03a60e03411fc5d090647e1a877041e81f8dc965927c7deb6
         ports:
         - name: http
           containerPort: 8191
+        resources:
+          limits:
+            ephemeral-storage: 2Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -42,12 +45,7 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
-        - name: home
-          mountPath: /home/ubuntu
       volumes:
       - name: tmp
-        emptyDir:
-          sizeLimit: 2Gi
-      - name: home
         emptyDir:
           sizeLimit: 2Gi


### PR DESCRIPTION
Byparr v3 stores required Python and browser assets in its home and cache directories, so mounting emptyDir volumes over those paths prevents startup. Upgrade the image and use a 2 GiB container ephemeral-storage limit to cap disposable writes without masking packaged runtime files.