### PR TITLE
Track MinusPod published edge digest

### DIFF
--- a/.claude/renovate-eval.md
+++ b/.claude/renovate-eval.md
@@ -44,6 +44,31 @@ Record the inspected revisions and security-relevant findings in the evaluation.
 If the exact upstream diff cannot be inspected, record that limitation as an
 unresolved hazard and do not recommend merging the update.
 
+## MinusPod Published Edge Digest Updates
+
+`kubernetes/minuspod/deploy.yaml` tracks
+`ttlequals0/minuspod:latest@sha256:<digest>`. MinusPod defines `latest` as its
+published edge channel, while the committed digest keeps the deployed image
+immutable.
+
+For every MinusPod digest update:
+
+- Resolve both the current and proposed digests to their numeric MinusPod image
+  tags. Report and evaluate the numeric version change, not merely a Docker
+  digest change.
+- Confirm that the proposed digest equals the current Docker Hub `latest` digest
+  and that its numeric tag is the newest published GitHub Release, including
+  GitHub pre-releases. If either check fails, treat the proposal as stale and do
+  not recommend merging it.
+- Treat numeric Docker tags without a corresponding GitHub Release as
+  unpublished build artifacts, not as newer release candidates.
+- Evaluate the complete release and configuration delta between the resolved
+  current and proposed versions. Do not recommend switching to a different
+  release that is not represented by the proposed digest.
+- Do not describe the deployment as using an unpinned or mutable image. The
+  floating tag selects the release channel for Renovate, while Kubernetes uses
+  the committed immutable digest.
+
 ## Available Tools
 
 - `skopeo` -- container image inspection (list tags, inspect manifests)

--- a/.renovaterc
+++ b/.renovaterc
@@ -267,6 +267,9 @@
         "kustomize",
         "kubernetes"
       ],
+      "matchPackageNames": [
+        "!ttlequals0/minuspod"
+      ],
       "minimumReleaseAge": "0 days",
       "schedule": [
         "after 2am and before 8am on thursday"
@@ -277,6 +280,27 @@
         "automerge"
       ],
       "description": "Auto-merge Docker image digest updates in Kubernetes if CI passes"
+    },
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "matchManagers": [
+        "kustomize",
+        "kubernetes"
+      ],
+      "matchPackageNames": [
+        "ttlequals0/minuspod"
+      ],
+      "minimumReleaseAge": "0 days",
+      "schedule": [
+        "at any time"
+      ],
+      "automerge": false,
+      "description": "Evaluate MinusPod published edge digest updates"
     },
     {
       "matchDatasources": [

--- a/kubernetes/minuspod/deploy.yaml
+++ b/kubernetes/minuspod/deploy.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: minuspod
-        image: ttlequals0/minuspod:2.76.1@sha256:7720ead9bab495130b2f96d8221eeac02dca0cb05a732d37637f265639237c79
+        image: ttlequals0/minuspod:latest@sha256:5696fbe1fdf264bcb7782c3ae812c237196abbd0558063b6ffd1cdec0af8b2bf
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Numeric Docker tags appear before MinusPod publishes releases, while the repository-wide 14-day age gate leaves Renovate evaluating older candidates. Track the publisher's latest edge alias at an immutable digest so proposals follow published releases instead of build artifacts.

Exclude MinusPod from generic Kubernetes digest automerge and give its digest updates an explicit no-age, manual-evaluation rule. Add evaluator context to resolve digests to release versions and reject stale or unpublished targets.
