### PR TITLE
Exercise MinusPod digest evaluation

### DIFF
--- a/kubernetes/minuspod/deploy.yaml
+++ b/kubernetes/minuspod/deploy.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: minuspod
-        image: ttlequals0/minuspod:latest@sha256:5696fbe1fdf264bcb7782c3ae812c237196abbd0558063b6ffd1cdec0af8b2bf
+        image: ttlequals0/minuspod:latest@sha256:7720ead9bab495130b2f96d8221eeac02dca0cb05a732d37637f265639237c79
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
The published-edge change accidentally pre-applied the current latest digest, leaving Renovate with no update to propose. Keep the latest channel tag while restoring the previously tested 2.76.1 digest so Renovate can create the intended 2.88.3 digest update and exercise the evaluation workflow.
