### PR TITLE
Upgrade OpenArchiver and add Apache Tika

### DIFF
--- a/kubernetes/openarchiver/configmap.yaml
+++ b/kubernetes/openarchiver/configmap.yaml
@@ -19,5 +19,6 @@ data:
   REDIS_PORT: '6379'
   REDIS_TLS_ENABLED: 'false'
   MEILI_HOST: http://openarchiver-meilisearch:7700
+  TIKA_URL: http://openarchiver-tika:9998
   RATE_LIMIT_WINDOW_MS: '60000'
   RATE_LIMIT_MAX_REQUESTS: '100'

--- a/kubernetes/openarchiver/deploy.yaml
+++ b/kubernetes/openarchiver/deploy.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: openarchiver
-        image: docker.io/logiclabshq/open-archiver:v0.5.0@sha256:e57f6ad9953aa70b1d9e900d78c0b74517e102aeacb3af8f4836479926422189
+        image: docker.io/logiclabshq/open-archiver:v0.5.2@sha256:3d756fa193421f832a59be18d16147b41442ecede45b95e844e82e774a77c549
         imagePullPolicy: IfNotPresent
         envFrom:
         - configMapRef:

--- a/kubernetes/openarchiver/kustomization.yaml
+++ b/kubernetes/openarchiver/kustomization.yaml
@@ -18,6 +18,8 @@ resources:
 - helm/valkey/statefulset.yaml
 - meilisearch-service.yaml
 - meilisearch-statefulset.yaml
+- tika-service.yaml
+- tika-deployment.yaml
 - service.yaml
 - deploy.yaml
 - ingress.yaml

--- a/kubernetes/openarchiver/tika-deployment.yaml
+++ b/kubernetes/openarchiver/tika-deployment.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: openarchiver-tika
+  namespace: openarchiver
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: openarchiver-tika
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: openarchiver-tika
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 35002
+        runAsGroup: 35002
+        fsGroup: 35002
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: tika
+        image: docker.io/apache/tika:3.2.2.0@sha256:031530a4b81f37454631ce9352b07cedfd03d83c875b05677d80bff6958d11ff
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        ports:
+        - name: http
+          containerPort: 9998
+        startupProbe:
+          httpGet:
+            path: /version
+            port: http
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 30
+        readinessProbe:
+          httpGet:
+            path: /version
+            port: http
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /version
+            port: http
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}

--- a/kubernetes/openarchiver/tika-service.yaml
+++ b/kubernetes/openarchiver/tika-service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: openarchiver-tika
+  namespace: openarchiver
+
+spec:
+  selector:
+    app.kubernetes.io/name: openarchiver-tika
+  ports:
+  - name: http
+    port: 9998
+    targetPort: http


### PR DESCRIPTION
OpenArchiver's in-process PDF parser can block the Node worker indefinitely on malformed documents, preventing the indexing queue from advancing. Upgrade to v0.5.2 and route attachment extraction through a separate Apache Tika service so parser failures remain bounded and indexing can continue.\n\nThe Tika workload deliberately defines no resource requests or limits because the namespace VPA manages requests.
