### PR TITLE
Use shared Renovate evaluation config

### DIFF
--- a/.renovate-eval.md
+++ b/.renovate-eval.md
@@ -115,7 +115,8 @@ after evaluation. These are in addition to the default actions provided by the
 skill (Merge, Review later, Close).
 
 - **Deploy for testing** — Show for kubernetes, ansible, and terraform/opentofu
-  updates. Read `.claude/rules/` for deployment instructions specific to each
-  update type. For Kubernetes: `kubectl apply -k kubernetes/<app>/`. For
-  Ansible: run `ansible-playbook` from the `ansible/` directory. For OpenTofu:
-  run `tofu plan` then `tofu apply` from the `opentofu/` directory.
+  updates. Follow the repository instructions loaded by the current agent and
+  read any detailed deployment guidance they reference. For Kubernetes:
+  `kubectl apply -k kubernetes/<app>/`. For Ansible: run `ansible-playbook` from
+  the `ansible/` directory. For OpenTofu: run `tofu plan` then `tofu apply` from
+  the `opentofu/` directory.


### PR DESCRIPTION
Move Renovate-specific repository policy from `.claude/renovate-eval.md` to the provider-neutral root `.renovate-eval.md`. Deployment actions now follow the current agent’s loaded repository instructions and any detailed guidance they reference, without a separate provider-rules discovery contract.