### PR TITLE
Reduce Renovate maintenance toil

### DIFF
--- a/.renovate-eval.md
+++ b/.renovate-eval.md
@@ -27,6 +27,22 @@ workflows. Needing one of these normal workflows is not, by itself, evidence for
 - For pre-merge testing: `kubectl apply -k kubernetes/<app>/` for Kubernetes,
   `ansible-playbook` for Ansible (run from `ansible/` directory)
 
+## Migration Risk Calibration
+
+For this repository, expected pod replacement, use of an unchanged
+application-managed migration mechanism, forward-only schema changes, lack of
+downgrade support, and migration duration that varies with data size do not
+constitute migration concerns by themselves. Do not infer exceptional downtime
+merely because an update contains migrations or because the live data size is
+unknown. Treat unknown duration as a validation boundary, not a verdict
+escalator.
+
+Raise a migration concern only for concrete version-specific evidence such as
+required manual prerequisites outside the normal GitOps path, explicit data loss
+or destructive conversion, failure or bypass of the configured migration
+mechanism, incompatibility with the deployed configuration, or
+upstream-documented outage or recovery steps materially beyond a normal rollout.
+
 ## Pre-commit Hook Security Review
 
 For every Renovate update to `.pre-commit-config.yaml`, check out or fetch the

--- a/.renovaterc
+++ b/.renovaterc
@@ -2,9 +2,10 @@
   "extends": [
     "config:best-practices"
   ],
+  "description": "Run manually reviewed Renovate updates from midnight through 3:59 AM Eastern on the first and third Mondays of each month.",
   "timezone": "America/New_York",
   "schedule": [
-    "after 12am and before 2am on monday"
+    "* 0-3 1-7,15-21 * 1"
   ],
   "ignorePaths": [
     "ansible/galaxy/**"
@@ -171,7 +172,8 @@
         "docker"
       ],
       "matchPackageNames": [
-        "getmeili/meilisearch"
+        "getmeili/meilisearch",
+        "docker.io/getmeili/meilisearch"
       ]
     },
     {
@@ -253,9 +255,6 @@
       "matchManagers": [
         "pre-commit"
       ],
-      "schedule": [
-        "after 2am and before 8am on thursday"
-      ],
       "automerge": false,
       "description": "Require manual review of pre-commit hook updates"
     },
@@ -296,9 +295,6 @@
         "ttlequals0/minuspod"
       ],
       "minimumReleaseAge": "0 days",
-      "schedule": [
-        "at any time"
-      ],
       "automerge": false,
       "description": "Evaluate MinusPod stable digest updates"
     },
@@ -456,16 +452,6 @@
         "automerge"
       ],
       "description": "Auto-merge digest updates for CI/test Dockerfiles"
-    },
-    {
-      "description": "OpenClaw: no stabilization delay, updates via weekly schedule",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "ghcr.io/openclaw/openclaw"
-      ],
-      "minimumReleaseAge": "0 days"
     },
     {
       "description": "MariaDB: LTS versions at least 6 months old (auto-managed)",


### PR DESCRIPTION
The weekly dependency queue creates more routine review work than this homelab warrants, while evaluator reports can overstate ordinary migration behavior. This limits routine branch creation to overnight windows on the first and third Mondays, aligns the Meilisearch aliases, removes the obsolete OpenClaw exception, and calibrates migration findings around concrete version-specific hazards.
