### PR TITLE
Halve Codex runner capacity

### DIFF
--- a/kubernetes/codex-runners/helm/dotfiles-autoscalingrunnerset.yaml
+++ b/kubernetes/codex-runners/helm/dotfiles-autoscalingrunnerset.yaml
@@ -15,7 +15,7 @@ metadata:
     actions.github.com/scale-set-name: codex-dotfiles
     actions.github.com/scale-set-namespace: codex-runners
   annotations:
-    actions.github.com/values-hash: 5e499db42df11894157c9d8bc01011f6a800ae83691db4f5bec9ccc7bd10654
+    actions.github.com/values-hash: e80871f37c03c4425bc74f684d6e0a3c9dd0eb0a009c51f0d8f118fde63393d
     actions.github.com/cleanup-manager-role-binding: codex-runners-gha-rs-manager
     actions.github.com/cleanup-manager-role-name: codex-runners-gha-rs-manager
 spec:
@@ -24,7 +24,7 @@ spec:
   runnerScaleSetName: codex-dotfiles
   runnerScaleSetLabels:
     - codex
-  maxRunners: 8
+  maxRunners: 4
   minRunners: 0
   template:
     metadata:

--- a/kubernetes/codex-runners/helm/github-actions-autoscalingrunnerset.yaml
+++ b/kubernetes/codex-runners/helm/github-actions-autoscalingrunnerset.yaml
@@ -15,7 +15,7 @@ metadata:
     actions.github.com/scale-set-name: codex-github-actions
     actions.github.com/scale-set-namespace: codex-runners
   annotations:
-    actions.github.com/values-hash: a2f62f82dba409f0eb8e567f27ca1de98fbc7daccb895739ed4c2941bd09a22
+    actions.github.com/values-hash: cd648a2eeb6a6cd9f30386a41a9bdfcaf8dbfd2c0ff9f4ee71c84a28a0fc8f3
     actions.github.com/cleanup-manager-role-binding: codex-runners-gha-rs-manager
     actions.github.com/cleanup-manager-role-name: codex-runners-gha-rs-manager
 spec:
@@ -24,7 +24,7 @@ spec:
   runnerScaleSetName: codex-github-actions
   runnerScaleSetLabels:
     - codex
-  maxRunners: 8
+  maxRunners: 4
   minRunners: 0
   template:
     metadata:

--- a/kubernetes/codex-runners/helm/go-unifi-mcp-autoscalingrunnerset.yaml
+++ b/kubernetes/codex-runners/helm/go-unifi-mcp-autoscalingrunnerset.yaml
@@ -15,7 +15,7 @@ metadata:
     actions.github.com/scale-set-name: codex-go-unifi-mcp
     actions.github.com/scale-set-namespace: codex-runners
   annotations:
-    actions.github.com/values-hash: ad0944e1abfdb7a018843289e510d905885110b1b4681192aec2cf366acc47b
+    actions.github.com/values-hash: 192ba8695fb3c370dd9ef10bd3ebdc9b3e3349883a1acaa26c1118af473a670
     actions.github.com/cleanup-manager-role-binding: codex-runners-gha-rs-manager
     actions.github.com/cleanup-manager-role-name: codex-runners-gha-rs-manager
 spec:
@@ -24,7 +24,7 @@ spec:
   runnerScaleSetName: codex-go-unifi-mcp
   runnerScaleSetLabels:
     - codex
-  maxRunners: 8
+  maxRunners: 4
   minRunners: 0
   template:
     metadata:

--- a/kubernetes/codex-runners/helm/infra-autoscalingrunnerset.yaml
+++ b/kubernetes/codex-runners/helm/infra-autoscalingrunnerset.yaml
@@ -15,7 +15,7 @@ metadata:
     actions.github.com/scale-set-name: codex-infra
     actions.github.com/scale-set-namespace: codex-runners
   annotations:
-    actions.github.com/values-hash: 471cb33186debc09cdd2ca5164ea2c33fcb91d8e191353dee264911c4e28f45
+    actions.github.com/values-hash: ed2f1c04f76c5fe7c8fa45296356231b651a3411365af738b5b8e6c96bde87c
     actions.github.com/cleanup-manager-role-binding: codex-runners-gha-rs-manager
     actions.github.com/cleanup-manager-role-name: codex-runners-gha-rs-manager
 spec:
@@ -24,7 +24,7 @@ spec:
   runnerScaleSetName: codex-infra
   runnerScaleSetLabels:
     - codex
-  maxRunners: 8
+  maxRunners: 4
   minRunners: 0
   template:
     metadata:

--- a/kubernetes/codex-runners/values.yaml
+++ b/kubernetes/codex-runners/values.yaml
@@ -11,7 +11,7 @@ scaleSetLabels:
 - codex
 
 minRunners: 0
-maxRunners: 8
+maxRunners: 4
 
 template:
   metadata:


### PR DESCRIPTION
The four repository-specific runner scale sets currently allow 32 concurrent Codex jobs in aggregate, which is more capacity than this homelab workflow needs. Lowering each maximum from eight to four keeps burst capacity while reducing the aggregate ceiling to 16 runners and the associated resource pressure.
