### PR TITLE
Add persistent soju IRC bouncer

### DIFF
--- a/kubernetes/soju/certificate.yaml
+++ b/kubernetes/soju/certificate.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+
+metadata:
+  name: soju-tls
+
+spec:
+  secretName: soju-tls
+  issuerRef:
+    name: letsencrypt
+    kind: ClusterIssuer
+  dnsNames:
+  - soju.k.oneill.net

--- a/kubernetes/soju/config
+++ b/kubernetes/soju/config
@@ -1,0 +1,12 @@
+hostname soju.k.oneill.net
+title "oneill.net IRC bouncer"
+
+listen ircs://:6697
+listen unix+admin:///run/soju/admin.sock
+tls /tls/tls.crt /tls/tls.key
+
+auth internal
+db sqlite3 /db/main.db
+message-store db
+# TODO: Uncomment after upgrading past v0.10.1; this directive is not yet released.
+# message-expiry 90d

--- a/kubernetes/soju/deploy.yaml
+++ b/kubernetes/soju/deploy.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: soju
+  annotations:
+    reloader.stakater.com/auto: 'true'
+
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: soju
+      app.kubernetes.io/instance: soju
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: soju
+        app.kubernetes.io/instance: soju
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: soju
+        image: codeberg.org/emersion/soju:v0.10.1@sha256:c0473d8f19554a03790f2a475d59646600f2f384b07b296afa782aec4c40253d
+        imagePullPolicy: IfNotPresent
+        args:
+        - -config
+        - /config/config
+        ports:
+        - name: ircs
+          containerPort: 6697
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+        startupProbe:
+          tcpSocket:
+            port: ircs
+          failureThreshold: 30
+          periodSeconds: 2
+        readinessProbe:
+          tcpSocket:
+            port: ircs
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: ircs
+          periodSeconds: 30
+        volumeMounts:
+        - name: config
+          mountPath: /config
+          readOnly: true
+        - name: data
+          mountPath: /db
+        - name: runtime
+          mountPath: /run/soju
+        - name: tls
+          mountPath: /tls
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: soju-config
+      - name: data
+        persistentVolumeClaim:
+          claimName: soju-data
+      - name: runtime
+        emptyDir: {}
+      - name: tls
+        secret:
+          secretName: soju-tls

--- a/kubernetes/soju/kustomization.yaml
+++ b/kubernetes/soju/kustomization.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: soju
+
+commonAnnotations:
+  argoManaged: 'true'
+
+resources:
+- namespace.yaml
+- certificate.yaml
+- deploy.yaml
+- pvc.yaml
+- service.yaml
+
+labels:
+
+- pairs:
+    app.kubernetes.io/name: soju
+    app.kubernetes.io/instance: soju
+  includeSelectors: true
+
+configMapGenerator:
+- name: soju-config
+  files:
+  - config

--- a/kubernetes/soju/namespace.yaml
+++ b/kubernetes/soju/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: soju
+  labels:
+    goldilocks.fairwinds.com/enabled: 'true'
+  annotations:
+    goldilocks.fairwinds.com/vpa-update-mode: InPlaceOrRecreate
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","controlledValues":"RequestsOnly"}]}'

--- a/kubernetes/soju/pvc.yaml
+++ b/kubernetes/soju/pvc.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+
+metadata:
+  name: soju-data
+  labels:
+    velero.io/backup: 'true'
+
+spec:
+  storageClassName: synology-iscsi
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/kubernetes/soju/service.yaml
+++ b/kubernetes/soju/service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: soju
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: soju.k.oneill.net
+    metallb.io/allow-shared-ip: plexmediaserver
+
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 172.19.74.21
+  selector:
+    app.kubernetes.io/name: soju
+    app.kubernetes.io/instance: soju
+  ports:
+  - name: ircs
+    port: 6697
+    targetPort: ircs
+    protocol: TCP


### PR DESCRIPTION
IRC clients and automation need a shared, always-on connection layer without storing tracker credentials in Git. This adds a dedicated soju deployment with TLS, a stable load-balancer address, and iSCSI-backed SQLite persistence while leaving network credentials in soju's runtime database.
