### PR TITLE
Preserve failed ESPHome build logs

### DIFF
--- a/esphome/scripts/esphome-all
+++ b/esphome/scripts/esphome-all
@@ -188,11 +188,11 @@ for f in "${files[@]}"; do
   printf "Queued %s\n" "$cfg"
   throttle
   (
-    "$ESPHOME_CMD" "$COMMAND" "$cfg" "${ESPHOME_ARGS[@]}" >"$log_file" 2>&1
-    rc=$?
-    if [ $rc -eq 0 ]; then
+    if "$ESPHOME_CMD" "$COMMAND" "$cfg" "${ESPHOME_ARGS[@]}" >"$log_file" 2>&1; then
+      rc=0
       echo OK >"$status_file"
     else
+      rc=$?
       echo FAIL >"$status_file"
     fi
     exit $rc


### PR DESCRIPTION
Failed parallel ESPHome builds exit under errexit before recording their status, so CI cannot identify, print, or upload their logs. Run each compile as an if condition so both successful and failed commands write a status file while preserving the original exit code.
