### PR TITLE
Isolate ESPHome Python environment

### DIFF
--- a/esphome/scripts/esphome
+++ b/esphome/scripts/esphome
@@ -22,4 +22,5 @@ cd "$ESPHOME_DIR" || exit 1
 export PLATFORMIO_CORE_DIR="${ESPHOME_DIR}/.platformio"
 
 # Run ESPHome via uv with pip included (required by PlatformIO)
+unset PYTHONPATH
 exec uv run --no-managed-python --with pip --with "esphome==${ESPHOME_VERSION}" esphome "$@"


### PR DESCRIPTION
The Nix development shell exports its Python package set through PYTHONPATH, which leaks incompatible Click and cryptography versions into ESP-IDF's private environment. Unset PYTHONPATH before launching ESPHome so uv can keep using the Nix interpreter without inheriting unrelated Nix packages.
