### PR TITLE
Add ESPHome Device Builder launcher

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -121,7 +121,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "esphome/scripts/esphome"
+        "esphome/scripts/versions"
       ],
       "matchStrings": [
         "ESPHOME_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""

--- a/esphome/scripts/esphome
+++ b/esphome/scripts/esphome
@@ -5,11 +5,10 @@
 
 set -Eeuo pipefail
 
-# ESPHome version
-ESPHOME_VERSION="2026.6.5"
-
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "${SCRIPT_DIR}/versions"
 
 # Set the ESPHome config directory (parent of scripts directory)
 ESPHOME_DIR="${ESPHOME_DIR:-$(dirname "$SCRIPT_DIR")}"

--- a/esphome/scripts/esphome-device-builder
+++ b/esphome/scripts/esphome-device-builder
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# ESPHome Device Builder wrapper script
+# Serves this repository's ESPHome configs on the local machine only.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ESPHOME_DIR="${ESPHOME_DIR:-$(dirname "$SCRIPT_DIR")}"
+
+source "${SCRIPT_DIR}/versions"
+
+cd "$ESPHOME_DIR" || exit 1
+ESPHOME_DIR="$(pwd -P)"
+
+export PLATFORMIO_CORE_DIR="${ESPHOME_DIR}/.platformio"
+
+unset PYTHONPATH
+exec uv run --no-managed-python \
+  --with pip \
+  --with "esphome==${ESPHOME_VERSION}" \
+  --with "esphome-device-builder[esphome]" \
+  esphome-device-builder "$@" --host 127.0.0.1 "$ESPHOME_DIR"

--- a/esphome/scripts/versions
+++ b/esphome/scripts/versions
@@ -1,0 +1,2 @@
+# Managed by Renovate. Sourced by the ESPHome command wrappers.
+ESPHOME_VERSION="2026.6.5"


### PR DESCRIPTION
Running Device Builder from arbitrary working directories previously required reconstructing the uv command and version manually. Add a loopback-only wrapper that opens the repository configuration directory, and move the ESPHome version into a shared Renovate-managed file so both launchers stay aligned.
