### PR TITLE
Catalog ESPHome compile warnings

### DIFF
--- a/.agents/rules/esphome/upgrades.md
+++ b/.agents/rules/esphome/upgrades.md
@@ -1,0 +1,28 @@
+# ESPHome Upgrade Warnings
+
+ESPHome compile logs are the source for `esphome/warning-catalog.yaml`. The
+catalog is a generated inventory of the ESPHome `WARNING` records currently
+emitted by every active top-level device configuration. It is not an allowlist
+and does not suppress warnings.
+
+CI checks each compile shard against the catalog. A new, changed, or removed
+warning makes the check fail so the catalog cannot silently become stale.
+Compiler and toolchain diagnostics such as lowercase `warning:` messages are
+outside this catalog and remain visible in the normal compile logs.
+
+When CI reports a warning change:
+
+1. Read the warning and determine whether the configuration should change.
+2. Fix warnings that can be addressed with the proposed ESPHome version.
+3. From the `esphome/` directory, regenerate the catalog:
+
+   ```bash
+   ./scripts/esphome-warnings update
+   ```
+
+   The command performs a fresh sequential compile of every active device. It
+   leaves `warning-catalog.yaml` unchanged if any configuration fails.
+
+4. Review the configuration change and generated catalog diff together. A fixed
+   warning should disappear from the catalog; a new warning that remains should
+   appear in it.

--- a/.github/workflows/esphome.yaml
+++ b/.github/workflows/esphome.yaml
@@ -66,6 +66,12 @@ jobs:
       run: nix develop ..#default --command ./scripts/esphome-all compile -j 1 --shard
         ${{ matrix.shard_index }}/${{ matrix.shard_total }}
 
+    - name: Check ESPHome warning catalog
+      if: hashFiles('esphome/logs/*.status') != ''
+      working-directory: esphome
+      run: nix develop ..#default --command ./scripts/esphome-warnings check --logs-dir
+        logs
+
     - name: Collect failed logs
       if: always()
       run: |

--- a/esphome/scripts/esphome-all
+++ b/esphome/scripts/esphome-all
@@ -6,9 +6,10 @@ cd "$(dirname "$0")/.." || exit 1
 
 usage() {
   cat >&2 <<'USAGE'
-Usage: ./esphome-all COMMAND [-j [JOBS]] [--shard N/TOTAL] [-- [ESPHOME_ARGS]]
+Usage: ./esphome-all COMMAND [-j [JOBS]] [--shard N/TOTAL] [--logs-dir DIR] [-- [ESPHOME_ARGS]]
 
-Runs an ESPHome command on all top-level YAML configs in this directory (excluding secrets).
+Runs an ESPHome command on all top-level device YAML configs in this directory
+(excluding secrets and warning-catalog.yaml).
 Runs sequentially by default. With -j, runs in parallel and saves logs to logs/<name>.log.
 
   COMMAND         ESPHome command to run (e.g., compile, upload, clean, logs)
@@ -16,6 +17,7 @@ Runs sequentially by default. With -j, runs in parallel and saves logs to logs/<
                   passed without a value, uses the number of CPUs on this host.
   --shard N/TOTAL Only process a subset of configs for CI sharding.
                   N is 1-based shard index; TOTAL is shard count.
+  --logs-dir DIR  Write per-config logs to DIR. Parallel mode defaults to logs/.
   -- [ARGS]       Additional arguments to pass to esphome
 
 Examples:
@@ -49,6 +51,7 @@ shift
 
 SHARD_INDEX=""; SHARD_TOTAL=""
 JOBS=""
+LOGS_DIR=""
 ESPHOME_ARGS=()
 
 while (( "$#" )); do
@@ -70,6 +73,11 @@ while (( "$#" )); do
       val="${1:-}"
       [ -n "$val" ] || { echo "--shard requires N/TOTAL" >&2; usage; exit 2; }
       SHARD_INDEX="${val%%/*}"; SHARD_TOTAL="${val##*/}"; shift ;;
+    --logs-dir)
+      shift
+      LOGS_DIR="${1:-}"
+      [ -n "$LOGS_DIR" ] || { echo "--logs-dir requires DIR" >&2; usage; exit 2; }
+      shift ;;
     -h|--help)
       usage; exit 0 ;;
     --)
@@ -102,6 +110,7 @@ mapfile -t files < <(
   find . -maxdepth 1 -type f -name '*.yaml' \
     ! -name 'secrets.yaml' \
     ! -name '*secrets*' \
+    ! -name 'warning-catalog.yaml' \
     -print | sort
 )
 
@@ -137,10 +146,30 @@ fi
 # If -j was not provided, run sequentially (streaming output)
 if [ -z "$JOBS" ]; then
   failures=()
+  if [ -n "$LOGS_DIR" ]; then
+    mkdir -p "$LOGS_DIR"
+  fi
   for f in "${files[@]}"; do
     cfg=${f#./}
     echo "==> Running 'esphome $COMMAND' on ${cfg}"
-    if "$ESPHOME_CMD" "$COMMAND" "$cfg" "${ESPHOME_ARGS[@]}"; then
+    if [ -n "$LOGS_DIR" ]; then
+      base="${cfg%.yaml}"
+      log_file="$LOGS_DIR/${base}.log"
+      status_file="$LOGS_DIR/${base}.status"
+      if "$ESPHOME_CMD" "$COMMAND" "$cfg" "${ESPHOME_ARGS[@]}" >"$log_file" 2>&1; then
+        result=0
+        echo OK >"$status_file"
+      else
+        result=$?
+        echo FAIL >"$status_file"
+      fi
+    elif "$ESPHOME_CMD" "$COMMAND" "$cfg" "${ESPHOME_ARGS[@]}"; then
+      result=0
+    else
+      result=$?
+    fi
+
+    if [ "$result" -eq 0 ]; then
       echo "✅ ${cfg} succeeded"
     else
       echo "❌ ${cfg} failed" >&2
@@ -162,7 +191,7 @@ if [ -z "$JOBS" ]; then
 fi
 
 # Parallel mode
-logs_dir="logs"
+logs_dir="${LOGS_DIR:-logs}"
 mkdir -p "${logs_dir}"
 if [ "$JOBS" = "auto" ] || [ -z "$JOBS" ]; then
   JOBS="$(default_jobs)"

--- a/esphome/scripts/esphome-warnings
+++ b/esphome/scripts/esphome-warnings
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Generate and check the ESPHome warning catalog."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ESPHOME_DIR = Path(__file__).resolve().parent.parent
+CATALOG_PATH = ESPHOME_DIR / "warning-catalog.yaml"
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+LOG_RECORD = re.compile(r"^(?:DEBUG|INFO|WARNING|ERROR|CRITICAL) ")
+
+
+class CatalogError(Exception):
+    """Raised when warning catalog input is incomplete or invalid."""
+
+
+class CatalogDumper(yaml.SafeDumper):
+    """Render multiline warning messages as readable YAML blocks."""
+
+
+def represent_string(dumper: yaml.SafeDumper, value: str) -> yaml.Node:
+    style = "|" if "\n" in value else None
+    return dumper.represent_scalar("tag:yaml.org,2002:str", value, style=style)
+
+
+CatalogDumper.add_representer(str, represent_string)
+
+
+def active_configs() -> list[str]:
+    return sorted(
+        path.name
+        for path in ESPHOME_DIR.glob("*.yaml")
+        if path.name not in {"secrets.yaml", CATALOG_PATH.name}
+        and "secrets" not in path.name
+    )
+
+
+def normalize_warning(lines: list[str]) -> str:
+    normalized = [line.rstrip() for line in lines]
+    while normalized and not normalized[-1]:
+        normalized.pop()
+    return "\n".join(normalized)
+
+
+def extract_warnings(log_path: Path) -> list[str]:
+    text = ANSI_ESCAPE.sub("", log_path.read_text(errors="replace")).replace("\r", "")
+    warnings: list[str] = []
+    current: list[str] | None = None
+
+    for line in text.splitlines():
+        if line.startswith("WARNING "):
+            if current is not None:
+                warnings.append(normalize_warning(current))
+            current = [line.removeprefix("WARNING ")]
+        elif current is not None and LOG_RECORD.match(line):
+            warnings.append(normalize_warning(current))
+            current = None
+        elif current is not None:
+            current.append(line)
+
+    if current is not None:
+        warnings.append(normalize_warning(current))
+
+    return warnings
+
+
+def warnings_from_logs(logs_dir: Path) -> dict[str, list[str]]:
+    if not logs_dir.is_dir():
+        raise CatalogError(f"Log directory does not exist: {logs_dir}")
+
+    results: dict[str, list[str]] = {}
+    status_paths = sorted(logs_dir.glob("*.status"))
+    if not status_paths:
+        raise CatalogError(f"No ESPHome status files found in {logs_dir}")
+
+    for status_path in status_paths:
+        config = f"{status_path.stem}.yaml"
+        status = status_path.read_text().strip()
+        if status != "OK":
+            raise CatalogError(f"Cannot catalog warnings for failed config: {config}")
+
+        log_path = logs_dir / f"{status_path.stem}.log"
+        if not log_path.is_file():
+            raise CatalogError(f"Missing compile log for {config}: {log_path}")
+        results[config] = extract_warnings(log_path)
+
+    return results
+
+
+def validate_warning_mapping(value: Any) -> dict[str, list[str]]:
+    if not isinstance(value, dict):
+        raise CatalogError("Catalog 'warnings' must be a mapping")
+
+    result: dict[str, list[str]] = {}
+    for config, messages in value.items():
+        if not isinstance(config, str) or not isinstance(messages, list):
+            raise CatalogError("Catalog entries must map config names to warning lists")
+        if not all(isinstance(message, str) for message in messages):
+            raise CatalogError(f"Catalog warnings for {config} must all be strings")
+        result[config] = messages
+    return result
+
+
+def load_catalog() -> dict[str, list[str]]:
+    if not CATALOG_PATH.is_file():
+        raise CatalogError(f"Warning catalog does not exist: {CATALOG_PATH}")
+
+    document = yaml.safe_load(CATALOG_PATH.read_text())
+    if not isinstance(document, dict) or document.get("schema") != 1:
+        raise CatalogError("Warning catalog must use schema 1")
+    return validate_warning_mapping(document.get("warnings"))
+
+
+def dump_yaml(document: dict[str, Any], *, explicit_start: bool = False) -> str:
+    return yaml.dump(
+        document,
+        Dumper=CatalogDumper,
+        allow_unicode=True,
+        default_flow_style=False,
+        explicit_start=explicit_start,
+        sort_keys=False,
+        width=80,
+    )
+
+
+def render_catalog(warnings: dict[str, list[str]]) -> str:
+    rendered = dump_yaml({"schema": 1, "warnings": warnings}, explicit_start=True)
+    return rendered.replace("schema: 1\nwarnings:", "schema: 1\n\nwarnings:", 1)
+
+
+def validate_catalog_configs(catalog: dict[str, list[str]]) -> None:
+    active = active_configs()
+    catalog_configs = sorted(catalog)
+    if catalog_configs == active:
+        return
+
+    missing = sorted(set(active) - set(catalog_configs))
+    stale = sorted(set(catalog_configs) - set(active))
+    details = []
+    if missing:
+        details.append(f"missing active configs: {', '.join(missing)}")
+    if stale:
+        details.append(f"stale configs: {', '.join(stale)}")
+    raise CatalogError(
+        "Warning catalog config list is out of date (" + "; ".join(details) + ")"
+    )
+
+
+def yaml_fragment(config: str, messages: list[str]) -> list[str]:
+    return dump_yaml({"warnings": {config: messages}}).splitlines(keepends=True)
+
+
+def check_catalog(logs_dir: Path) -> int:
+    catalog = load_catalog()
+    validate_catalog_configs(catalog)
+    current = warnings_from_logs(logs_dir)
+
+    unknown = sorted(set(current) - set(catalog))
+    if unknown:
+        raise CatalogError(f"Logs contain unknown configs: {', '.join(unknown)}")
+
+    changed = False
+    for config, messages in current.items():
+        expected = catalog[config]
+        if expected == messages:
+            continue
+        changed = True
+        sys.stderr.writelines(
+            difflib.unified_diff(
+                yaml_fragment(config, expected),
+                yaml_fragment(config, messages),
+                fromfile=f"catalog/{config}",
+                tofile=f"current/{config}",
+            )
+        )
+
+    if changed:
+        print(
+            "ESPHome warning catalog is out of date. Inspect or fix the warnings, "
+            "then run ./scripts/esphome-warnings update.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"ESPHome warning catalog matches {len(current)} compiled config(s).")
+    return 0
+
+
+def print_failed_logs(logs_dir: Path) -> None:
+    for status_path in sorted(logs_dir.glob("*.status")):
+        if status_path.read_text().strip() == "OK":
+            continue
+        log_path = logs_dir / f"{status_path.stem}.log"
+        if not log_path.is_file():
+            continue
+        print(f"\n==> Last 200 lines from {log_path.name}", file=sys.stderr)
+        lines = log_path.read_text(errors="replace").splitlines()
+        print("\n".join(lines[-200:]), file=sys.stderr)
+
+
+def update_catalog() -> int:
+    with tempfile.TemporaryDirectory(prefix="esphome-warnings-") as temp_dir:
+        logs_dir = Path(temp_dir)
+        command = [
+            str(ESPHOME_DIR / "scripts" / "esphome-all"),
+            "compile",
+            "--logs-dir",
+            str(logs_dir),
+        ]
+
+        result = subprocess.run(command, cwd=ESPHOME_DIR, check=False)
+        if result.returncode != 0:
+            print_failed_logs(logs_dir)
+            print(
+                "Compilation failed; warning-catalog.yaml was not changed.",
+                file=sys.stderr,
+            )
+            return result.returncode
+
+        current = warnings_from_logs(logs_dir)
+        active = active_configs()
+        if sorted(current) != active:
+            missing = sorted(set(active) - set(current))
+            raise CatalogError(
+                "Full catalog update did not compile every active config"
+                + (f"; missing: {', '.join(missing)}" if missing else "")
+            )
+
+        new_text = render_catalog({config: current[config] for config in active})
+        old_text = CATALOG_PATH.read_text() if CATALOG_PATH.exists() else ""
+        if new_text == old_text:
+            print("ESPHome warning catalog is already current.")
+            return 0
+
+        sys.stdout.writelines(
+            difflib.unified_diff(
+                old_text.splitlines(keepends=True),
+                new_text.splitlines(keepends=True),
+                fromfile=str(CATALOG_PATH),
+                tofile=str(CATALOG_PATH),
+            )
+        )
+
+        file_descriptor, temporary_name = tempfile.mkstemp(
+            dir=CATALOG_PATH.parent, prefix=f".{CATALOG_PATH.name}.", text=True
+        )
+        try:
+            with os.fdopen(file_descriptor, "w") as temporary_file:
+                temporary_file.write(new_text)
+            os.replace(temporary_name, CATALOG_PATH)
+        finally:
+            if os.path.exists(temporary_name):
+                os.unlink(temporary_name)
+
+        print(f"Updated {CATALOG_PATH.name} from {len(active)} compiled config(s).")
+        return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check_parser = subparsers.add_parser(
+        "check", help="compare compile logs with the catalog"
+    )
+    check_parser.add_argument("--logs-dir", type=Path, default=ESPHOME_DIR / "logs")
+
+    subparsers.add_parser(
+        "update", help="compile all configs sequentially and regenerate the catalog"
+    )
+
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "check":
+            return check_catalog(args.logs_dir.resolve())
+        return update_catalog()
+    except CatalogError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/esphome/warning-catalog.yaml
+++ b/esphome/warning-catalog.yaml
@@ -1,0 +1,33 @@
+---
+schema: 1
+
+warnings:
+  basement-clock.yaml: []
+  eightsleep-power.yaml: []
+  freezer-door.yaml: []
+  freezer.yaml: []
+  garage-bme280.yaml: []
+  infra1-power.yaml: []
+  k3-power.yaml: []
+  k4-power.yaml: []
+  k5-power.yaml: []
+  living-room-bme280.yaml: []
+  office-bme280.yaml: []
+  office-closet-lamp.yaml: []
+  office-foot-warmer.yaml: []
+  office-heater.yaml: []
+  officedesk.yaml: []
+  opengarage-left-door.yaml: []
+  opengarage-right-door.yaml: []
+  p1-power.yaml: []
+  szamar-power.yaml: []
+  temp-probe1.yaml:
+  - GPIO35 is used by the PSRAM interface on ESP32-S3R8 / ESP32-S3R8V and should be
+    avoided on these models
+  temp-probe2.yaml:
+  - GPIO35 is used by the PSRAM interface on ESP32-S3R8 / ESP32-S3R8V and should be
+    avoided on these models
+  temp-probe3.yaml: []
+  ups-power.yaml: []
+  x1c-ams1-monitor.yaml: []
+  x1c-ams2-monitor.yaml: []


### PR DESCRIPTION
ESPHome upgrades can introduce configuration warnings without failing firmware compilation, making deprecations easy to miss across the device fleet. Generate a structured catalog from the existing per-device compile logs and verify each CI shard against it.

The local update command compiles all active configurations sequentially before replacing the catalog, so incomplete or failed runs cannot produce baseline data. The upgrade guide documents how to inspect, fix, and regenerate warning changes.
