### PR TITLE
Delay VRRoom reboot until Harmony is ready

### DIFF
--- a/kubernetes/hass/config/packages/basement_entertainment.yaml
+++ b/kubernetes/hass/config/packages/basement_entertainment.yaml
@@ -259,4 +259,23 @@ automation:
     entity_id: sensor.szamar_power_min_2m
     below: 50  # PC draws ~1.5W sleeping, 200W+ awake
   action:
+  # Harmony reports Watch PC before its device startup sequence completes.
+  # Wait until the TV and input switching are ready before rebooting VRRoom.
+  - wait_template: >-
+      {{ is_state_attr('remote.harmony_hub', 'current_activity', 'Watch PC') and
+          state_attr('remote.harmony_hub', 'activity_starting') is none }}
+    timeout: 00:01:00
+    continue_on_timeout: false
+  - delay:
+      seconds: 5
+  # Do not reboot if the user changed activities during the settling delay.
+  - condition: template
+    value_template: >-
+      {{ is_state_attr('remote.harmony_hub', 'current_activity', 'Watch PC') and
+          state_attr('remote.harmony_hub', 'activity_starting') is none }}
   - service: rest_command.reboot_vrroom
+  - delay:
+      seconds: 20
+  - service: homeassistant.update_entity
+    target:
+      entity_id: sensor.hdfury_vrroom_status


### PR DESCRIPTION
The VRRoom reboot previously ran as soon as Harmony reported Watch PC, while the TV and input startup sequence was still in progress. Wait for Harmony to finish, allow a short settling interval, and confirm the activity is still active before rebooting; refresh VRRoom status after it returns.
