### PR TITLE
Update ESPHome to 2026.7.4

### DIFF
--- a/esphome/common/device-classes/crowpanel-p4-10.yaml
+++ b/esphome/common/device-classes/crowpanel-p4-10.yaml
@@ -3,22 +3,20 @@
 # EK79007 display driver, GT911 touch, ESP32-C6 WiFi coprocessor
 esphome:
   name: ${devicename}
-  min_version: 2026.1.0
+  min_version: 2026.6.0
+  build_flags: -DBOARD_HAS_PSRAM
   on_boot:
     priority: 600
     then:
     - output.turn_on: backlight_power
-  platformio_options:
-    board_build.flash_mode: qio
-    board_build.psram_type: opi
-    build_flags: -DBOARD_HAS_PSRAM
 
 psram:
   mode: hex
   speed: 200MHz
 
 esp32:
-  board: esp32-p4_r3
+  # This CrowPanel has pre-v3 P4 silicon (the device reports revision 1.3).
+  board: esp32-p4
   variant: esp32p4
   flash_size: 16MB
   cpu_frequency: 360MHz
@@ -35,31 +33,16 @@ esp32:
       # ESP-IDF 5.5.5's P4 bootloader exceeds the default 0x6000 space at INFO.
       # Retest without this after future ESP-IDF upgrades and remove it once the default fits.
       CONFIG_BOOTLOADER_LOG_LEVEL_WARN: y
-      # ESP32-C6 WiFi coprocessor via SDIO
-      CONFIG_ESP_HOSTED_ENABLED: y
-      CONFIG_ESP_HOSTED_PRIV_SDIO_OPTION: y
-      CONFIG_ESP_HOSTED_IDF_SLAVE_TARGET: esp32c6
-      CONFIG_ESP_HOSTED_SDIO_RESET_ACTIVE_HIGH: y
-      CONFIG_ESP_HOSTED_SDIO_SLOT_1: y
-      CONFIG_ESP_HOSTED_SDIO_1_BIT_BUS: y
-      CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ: '40000'
-      CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_CLK_SLOT_1: '18'
-      CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_CMD_SLOT_1: '19'
-      CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D0_SLOT_1: '14'
-      CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D1_4BIT_BUS_SLOT_1: '15'
-      CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D2_4BIT_BUS_SLOT_1: '16'
-      CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D3_4BIT_BUS_SLOT_1: '17'
-      CONFIG_ESP_HOSTED_SDIO_GPIO_RESET_SLAVE: '32'
 
 esp32_hosted:
   variant: ESP32C6
+  use_psram: true
+  bus_width: 1
+  sdio_frequency: 40MHz
   reset_pin: 32
   cmd_pin: 19
   clk_pin: 18
   d0_pin: 14
-  d1_pin: 15
-  d2_pin: 16
-  d3_pin: 17
   active_high: true
 
 external_components:

--- a/esphome/common/weather-bg.yaml
+++ b/esphome/common/weather-bg.yaml
@@ -4,8 +4,9 @@
 #   weather_entity_id, sun_entity_id
 # Cross-references LVGL widget: bg_image (must be defined in main config)
 
-online_image:
-- url: ${weather_bg_base}/sunny-day.png
+image:
+- platform: online_image
+  url: ${weather_bg_base}/sunny-day.png
   id: weather_bg_a
   format: png
   resize: ${weather_bg_width}x${weather_bg_height}
@@ -19,7 +20,8 @@ online_image:
   on_error:
   - lambda: id(current_bg_url) = "";
   - logger.log: Failed to download weather background
-- url: ${weather_bg_base}/sunny-day.png
+- platform: online_image
+  url: ${weather_bg_base}/sunny-day.png
   id: weather_bg_b
   format: png
   resize: ${weather_bg_width}x${weather_bg_height}

--- a/esphome/scripts/versions
+++ b/esphome/scripts/versions
@@ -1,2 +1,2 @@
 # Managed by Renovate. Sourced by the ESPHome command wrappers.
-ESPHOME_VERSION="2026.6.5"
+ESPHOME_VERSION="2026.7.4"

--- a/esphome/warning-catalog.yaml
+++ b/esphome/warning-catalog.yaml
@@ -2,32 +2,88 @@
 schema: 1
 
 warnings:
-  basement-clock.yaml: []
+  basement-clock.yaml:
+  - 'The ''web_server'' ''auth'' scheme currently defaults to ''basic'', which sends
+    the password over the network in an easily reversible form. The default will change
+    to ''digest'' in ESPHome 2027.1.0. To keep using basic authentication, set ''type:
+    basic'' under ''auth:'' explicitly; otherwise set ''type: digest'' now to adopt
+    the more secure scheme.'
   eightsleep-power.yaml: []
-  freezer-door.yaml: []
-  freezer.yaml: []
+  freezer-door.yaml:
+  - 'The ''web_server'' ''auth'' scheme currently defaults to ''basic'', which sends
+    the password over the network in an easily reversible form. The default will change
+    to ''digest'' in ESPHome 2027.1.0. To keep using basic authentication, set ''type:
+    basic'' under ''auth:'' explicitly; otherwise set ''type: digest'' now to adopt
+    the more secure scheme.'
+  freezer.yaml:
+  - 'The ''web_server'' ''auth'' scheme currently defaults to ''basic'', which sends
+    the password over the network in an easily reversible form. The default will change
+    to ''digest'' in ESPHome 2027.1.0. To keep using basic authentication, set ''type:
+    basic'' under ''auth:'' explicitly; otherwise set ''type: digest'' now to adopt
+    the more secure scheme.'
   garage-bme280.yaml: []
-  infra1-power.yaml: []
-  k3-power.yaml: []
-  k4-power.yaml: []
-  k5-power.yaml: []
+  infra1-power.yaml:
+  - 'The ''web_server'' ''auth'' scheme currently defaults to ''basic'', which sends
+    the password over the network in an easily reversible form. The default will change
+    to ''digest'' in ESPHome 2027.1.0. To keep using basic authentication, set ''type:
+    basic'' under ''auth:'' explicitly; otherwise set ''type: digest'' now to adopt
+    the more secure scheme.'
+  k3-power.yaml:
+  - 'The ''web_server'' ''auth'' scheme currently defaults to ''basic'', which sends
+    the password over the network in an easily reversible form. The default will change
+    to ''digest'' in ESPHome 2027.1.0. To keep using basic authentication, set ''type:
+    basic'' under ''auth:'' explicitly; otherwise set ''type: digest'' now to adopt
+    the more secure scheme.'
+  k4-power.yaml:
+  - 'The ''web_server'' ''auth'' scheme currently defaults to ''basic'', which sends
+    the password over the network in an easily reversible form. The default will change
+    to ''digest'' in ESPHome 2027.1.0. To keep using basic authentication, set ''type:
+    basic'' under ''auth:'' explicitly; otherwise set ''type: digest'' now to adopt
+    the more secure scheme.'
+  k5-power.yaml:
+  - 'The ''web_server'' ''auth'' scheme currently defaults to ''basic'', which sends
+    the password over the network in an easily reversible form. The default will change
+    to ''digest'' in ESPHome 2027.1.0. To keep using basic authentication, set ''type:
+    basic'' under ''auth:'' explicitly; otherwise set ''type: digest'' now to adopt
+    the more secure scheme.'
   living-room-bme280.yaml: []
   office-bme280.yaml: []
-  office-closet-lamp.yaml: []
+  office-closet-lamp.yaml:
+  - 'The ''web_server'' ''auth'' scheme currently defaults to ''basic'', which sends
+    the password over the network in an easily reversible form. The default will change
+    to ''digest'' in ESPHome 2027.1.0. To keep using basic authentication, set ''type:
+    basic'' under ''auth:'' explicitly; otherwise set ''type: digest'' now to adopt
+    the more secure scheme.'
   office-foot-warmer.yaml: []
   office-heater.yaml: []
   officedesk.yaml: []
-  opengarage-left-door.yaml: []
-  opengarage-right-door.yaml: []
-  p1-power.yaml: []
+  opengarage-left-door.yaml:
+  - 'The ''web_server'' ''auth'' scheme currently defaults to ''basic'', which sends
+    the password over the network in an easily reversible form. The default will change
+    to ''digest'' in ESPHome 2027.1.0. To keep using basic authentication, set ''type:
+    basic'' under ''auth:'' explicitly; otherwise set ''type: digest'' now to adopt
+    the more secure scheme.'
+  opengarage-right-door.yaml:
+  - 'The ''web_server'' ''auth'' scheme currently defaults to ''basic'', which sends
+    the password over the network in an easily reversible form. The default will change
+    to ''digest'' in ESPHome 2027.1.0. To keep using basic authentication, set ''type:
+    basic'' under ''auth:'' explicitly; otherwise set ''type: digest'' now to adopt
+    the more secure scheme.'
+  p1-power.yaml:
+  - 'The ''web_server'' ''auth'' scheme currently defaults to ''basic'', which sends
+    the password over the network in an easily reversible form. The default will change
+    to ''digest'' in ESPHome 2027.1.0. To keep using basic authentication, set ''type:
+    basic'' under ''auth:'' explicitly; otherwise set ''type: digest'' now to adopt
+    the more secure scheme.'
   szamar-power.yaml: []
-  temp-probe1.yaml:
-  - GPIO35 is used by the PSRAM interface on ESP32-S3R8 / ESP32-S3R8V and should be
-    avoided on these models
-  temp-probe2.yaml:
-  - GPIO35 is used by the PSRAM interface on ESP32-S3R8 / ESP32-S3R8V and should be
-    avoided on these models
+  temp-probe1.yaml: []
+  temp-probe2.yaml: []
   temp-probe3.yaml: []
-  ups-power.yaml: []
+  ups-power.yaml:
+  - 'The ''web_server'' ''auth'' scheme currently defaults to ''basic'', which sends
+    the password over the network in an easily reversible form. The default will change
+    to ''digest'' in ESPHome 2027.1.0. To keep using basic authentication, set ''type:
+    basic'' under ''auth:'' explicitly; otherwise set ''type: digest'' now to adopt
+    the more secure scheme.'
   x1c-ams1-monitor.yaml: []
   x1c-ams2-monitor.yaml: []

--- a/flake-versions.yaml
+++ b/flake-versions.yaml
@@ -7,6 +7,7 @@ age: 1.3.1
 ansible-lint: 25.8.2
 awscli2: 2.35.11
 bats: 1.14.0
+ccache: 4.13.6
 curl: 8.21.0
 efficient-compression-tool: 0.9.5
 go-unifi-mcp: d96b3c4bbe6b639f298bd230ec5adc9d5854b3bc

--- a/flake.nix
+++ b/flake.nix
@@ -208,6 +208,7 @@
               ansible-lint
               pythonEnv
               awscli2
+              ccache
               curl
               efficient-compression-tool
               jq

--- a/kubernetes/semaphore/nix-flake.nix
+++ b/kubernetes/semaphore/nix-flake.nix
@@ -209,6 +209,7 @@
               ansible-lint
               pythonEnv
               awscli2
+              ccache
               curl
               efficient-compression-tool
               jq


### PR DESCRIPTION
ESPHome 2026.7.4 changes the online-image schema and exposes supported configuration for the ESP32-hosted transport. Update the shared version and warning catalog while adapting those interfaces.

Target the Basement Clock's pre-v3 P4 silicon explicitly, keep its hosted transport on the tested one-bit SDIO bus, and place the transport mempool in PSRAM so the large LVGL application boots reliably. Add ccache to make repeated local firmware builds less expensive.
