### PR TITLE
Add persistent Synology console logging

### DIFF
--- a/ansible/host_vars/infra1.yaml
+++ b/ansible/host_vars/infra1.yaml
@@ -9,6 +9,15 @@ traefik_config_files:
 tailscale_args: --advertise-routes=172.19.74.0/23,172.20.4.0/22 --advertise-exit-node --accept-dns=false
 ip_forwarding_enabled: true
 
+# Serial consoles captured by Conserver. The client certificate is readable
+# only by root, so connect with: ssh -t infra1 sudo console fs2
+conserver_consoles:
+  - name: fs2
+    device: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A9CXTVTH-if00-port0
+    baud: 115200
+    rw_users:
+      - root
+
 # Static network configuration
 manage_network: true
 interfaces_ether_interfaces:

--- a/ansible/inventory/default
+++ b/ansible/inventory/default
@@ -64,6 +64,9 @@ p1
 [nut_server]
 infra1
 
+[conserver]
+infra1
+
 [docker]
 infra1
 luser

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -24,6 +24,8 @@ roles:
     version: "3.0.0"
 
 collections:
+  - name: community.crypto
+    version: "3.3.0"
   - name: https://github.com/artis3n/ansible-collection-tailscale.git
     type: git
     version: v1.2.1

--- a/ansible/roles/conserver/defaults/main.yaml
+++ b/ansible/roles/conserver/defaults/main.yaml
@@ -1,0 +1,8 @@
+---
+# Debian runs Conserver as the unprivileged conservr user, so its listener must
+# stay above the privileged-port boundary (1024).
+conserver_port: 3109
+conserver_log_retention_days: 365
+conserver_tls_directory: /etc/conserver/tls
+conserver_tls_validity_days: 36500
+conserver_consoles: []

--- a/ansible/roles/conserver/handlers/main.yaml
+++ b/ansible/roles/conserver/handlers/main.yaml
@@ -1,0 +1,5 @@
+---
+- name: Restart Conserver
+  ansible.builtin.systemd_service:
+    name: conserver-server
+    state: restarted

--- a/ansible/roles/conserver/tasks/main.yaml
+++ b/ansible/roles/conserver/tasks/main.yaml
@@ -1,0 +1,97 @@
+---
+- name: Validate Conserver settings
+  ansible.builtin.assert:
+    that:
+      - conserver_consoles | length > 0
+      - conserver_port | int >= 1024
+      - conserver_port | int <= 65535
+      - conserver_tls_directory is match('^/')
+      - conserver_tls_validity_days | int >= 36500
+    fail_msg: >-
+      Conserver requires at least one console and an unprivileged TCP port
+      between 1024 and 65535.
+
+- name: Validate serial console definitions
+  ansible.builtin.assert:
+    that:
+      - item.name is match('^[A-Za-z0-9][A-Za-z0-9_.-]*$')
+      - item.device is match('^/dev/')
+      - item.baud | int > 0
+      - item.rw_users is sequence
+      - item.rw_users is not string
+      - item.rw_users | length > 0
+    fail_msg: "Invalid serial console definition: {{ item }}"
+  loop: "{{ conserver_consoles }}"
+  loop_control:
+    label: "{{ item.name | default('unnamed') }}"
+
+- name: Install Conserver without starting its package defaults
+  ansible.builtin.apt:
+    name:
+      - conserver-client
+      - conserver-server
+      - python3-cryptography
+    state: present
+    # Debian policy-rc.d exit code 101 denies service starts. The apt module
+    # installs this policy only for this task and restores any prior policy
+    # afterward, so Conserver starts below with our configuration in place.
+    policy_rc_d: 101
+
+- name: Allow Conserver to access serial devices
+  ansible.builtin.user:
+    name: conservr
+    groups: dialout
+    append: true
+  notify: Restart Conserver
+
+- name: Create Conserver log directory
+  ansible.builtin.file:
+    path: /var/log/conserver
+    state: directory
+    owner: conservr
+    group: adm
+    mode: "0750"
+
+- name: Configure Conserver TLS
+  ansible.builtin.import_tasks: tls.yaml
+
+- name: Configure Conserver
+  ansible.builtin.template:
+    src: conserver.cf.j2
+    dest: /etc/conserver/conserver.cf
+    owner: root
+    group: root
+    mode: "0644"
+    validate: /usr/sbin/conserver -S -C %s
+  notify: Restart Conserver
+
+- name: Restrict Conserver to loopback
+  ansible.builtin.template:
+    src: server.local.j2
+    dest: /etc/conserver/server.local
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart Conserver
+
+- name: Configure the local Conserver client
+  ansible.builtin.template:
+    src: console.cf.j2
+    dest: /etc/conserver/console.cf
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Configure Conserver log retention
+  ansible.builtin.template:
+    src: logrotate.j2
+    dest: /etc/logrotate.d/conserver-server
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Enable and start Conserver
+  ansible.builtin.systemd_service:
+    name: conserver-server
+    enabled: true
+    state: started

--- a/ansible/roles/conserver/tasks/tls.yaml
+++ b/ansible/roles/conserver/tasks/tls.yaml
@@ -1,0 +1,142 @@
+---
+- name: Create Conserver TLS directory
+  ansible.builtin.file:
+    path: "{{ conserver_tls_directory }}"
+    state: directory
+    owner: root
+    group: root
+    # The directory is searchable so conservr can open its explicitly named
+    # credential, but not listable; individual files enforce read access.
+    mode: "0711"
+
+- name: Generate Conserver TLS private keys
+  community.crypto.openssl_privatekey:
+    path: "{{ item.path }}"
+    type: RSA
+    size: 3072
+    owner: root
+    group: root
+    mode: "0600"
+  loop:
+    - name: CA
+      path: "{{ conserver_tls_directory }}/ca.key"
+    - name: server
+      path: "{{ conserver_tls_directory }}/server-20-key.pem"
+    - name: client
+      path: "{{ conserver_tls_directory }}/client-20-key.pem"
+  loop_control:
+    label: "{{ item.name }}"
+  notify: Restart Conserver
+
+- name: Generate Conserver TLS certificate requests
+  community.crypto.openssl_csr:
+    path: "{{ item.csr }}"
+    privatekey_path: "{{ item.key }}"
+    common_name: "{{ item.name }}"
+    basic_constraints: "{{ item.basic_constraints | default(omit) }}"
+    basic_constraints_critical: "{{ item.basic_constraints is defined }}"
+    key_usage: "{{ item.key_usage }}"
+    key_usage_critical: true
+    extended_key_usage: "{{ item.extended_key_usage | default(omit) }}"
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - name: Conserver local CA
+      key: "{{ conserver_tls_directory }}/ca.key"
+      csr: "{{ conserver_tls_directory }}/ca.csr"
+      basic_constraints:
+        - CA:TRUE
+      key_usage:
+        - keyCertSign
+        - cRLSign
+    - name: infra1 Conserver server
+      key: "{{ conserver_tls_directory }}/server-20-key.pem"
+      csr: "{{ conserver_tls_directory }}/server.csr"
+      key_usage:
+        - digitalSignature
+        - keyEncipherment
+      extended_key_usage:
+        - serverAuth
+    - name: infra1 root console client
+      key: "{{ conserver_tls_directory }}/client-20-key.pem"
+      csr: "{{ conserver_tls_directory }}/client.csr"
+      key_usage:
+        - digitalSignature
+      extended_key_usage:
+        - clientAuth
+  loop_control:
+    label: "{{ item.name }}"
+  notify: Restart Conserver
+
+- name: Generate Conserver CA certificate
+  community.crypto.x509_certificate:
+    path: "{{ conserver_tls_directory }}/ca.crt"
+    csr_path: "{{ conserver_tls_directory }}/ca.csr"
+    privatekey_path: "{{ conserver_tls_directory }}/ca.key"
+    provider: selfsigned
+    selfsigned_not_after: "+{{ conserver_tls_validity_days }}d"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart Conserver
+
+- name: Generate Conserver TLS certificates
+  community.crypto.x509_certificate:
+    path: "{{ item.certificate }}"
+    csr_path: "{{ item.csr }}"
+    provider: ownca
+    ownca_path: "{{ conserver_tls_directory }}/ca.crt"
+    ownca_privatekey_path: "{{ conserver_tls_directory }}/ca.key"
+    ownca_not_after: "+{{ conserver_tls_validity_days }}d"
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - csr: "{{ conserver_tls_directory }}/server.csr"
+      certificate: "{{ conserver_tls_directory }}/server-10-certificate.pem"
+    - csr: "{{ conserver_tls_directory }}/client.csr"
+      certificate: "{{ conserver_tls_directory }}/client-10-certificate.pem"
+  loop_control:
+    label: "{{ item.certificate | basename }}"
+  notify: Restart Conserver
+
+- name: Assemble Conserver TLS credentials
+  ansible.builtin.assemble:
+    src: "{{ conserver_tls_directory }}"
+    dest: "{{ item.dest }}"
+    regexp: "^{{ item.name }}-[0-9]+-.*[.]pem$"
+    owner: "{{ item.owner }}"
+    group: root
+    mode: "{{ item.mode }}"
+  loop:
+    - name: server
+      dest: "{{ conserver_tls_directory }}/server.pem"
+      owner: conservr
+      mode: "0400"
+    - name: client
+      dest: "{{ conserver_tls_directory }}/client.pem"
+      owner: root
+      mode: "0600"
+  loop_control:
+    label: "{{ item.dest | basename }}"
+  notify: Restart Conserver
+
+- name: Remove superseded Conserver TLS fragments
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ conserver_tls_directory }}/server-credentials.d"
+    - "{{ conserver_tls_directory }}/client-credentials.d"
+
+- name: Validate Conserver TLS certificate chains
+  ansible.builtin.command:
+    argv:
+      - openssl
+      - verify
+      - -CAfile
+      - "{{ conserver_tls_directory }}/ca.crt"
+      - "{{ conserver_tls_directory }}/server-10-certificate.pem"
+      - "{{ conserver_tls_directory }}/client-10-certificate.pem"
+  changed_when: false

--- a/ansible/roles/conserver/templates/conserver.cf.j2
+++ b/ansible/roles/conserver/templates/conserver.cf.j2
@@ -1,0 +1,28 @@
+config * {
+    defaultaccess rejected;
+    sslcredentials {{ conserver_tls_directory }}/server.pem;
+    sslcacertificatefile {{ conserver_tls_directory }}/ca.crt;
+    sslrequired yes;
+    sslreqclientcert yes;
+}
+
+default * {
+    logfile /var/log/conserver/&.log;
+    timestamp 1ha;
+    options !ixon,!ixoff,!crtscts,!cstopb,!hupcl,autoreinit,reinitoncc;
+}
+
+{% for console in conserver_consoles %}
+console {{ console.name }} {
+    master localhost;
+    type device;
+    device {{ console.device }};
+    baud {{ console.baud }};
+    parity none;
+    rw {{ console.rw_users | join(',') }};
+}
+
+{% endfor %}
+access * {
+    trusted 127.0.0.1;
+}

--- a/ansible/roles/conserver/templates/console.cf.j2
+++ b/ansible/roles/conserver/templates/console.cf.j2
@@ -1,0 +1,7 @@
+config * {
+    master 127.0.0.1;
+    port {{ conserver_port }};
+    sslcredentials {{ conserver_tls_directory }}/client.pem;
+    sslcacertificatefile {{ conserver_tls_directory }}/ca.crt;
+    sslrequired yes;
+}

--- a/ansible/roles/conserver/templates/logrotate.j2
+++ b/ansible/roles/conserver/templates/logrotate.j2
@@ -1,0 +1,13 @@
+/var/log/conserver/*.log {
+    daily
+    rotate {{ conserver_log_retention_days }}
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0640 conservr adm
+    sharedscripts
+    postrotate
+        service conserver-server rotate >/dev/null 2>&1 || true
+    endscript
+}

--- a/ansible/roles/conserver/templates/server.local.j2
+++ b/ansible/roles/conserver/templates/server.local.j2
@@ -1,0 +1,1 @@
+OPTS="-M 127.0.0.1 -p {{ conserver_port }} -R"

--- a/ansible/site.yaml
+++ b/ansible/site.yaml
@@ -259,6 +259,12 @@
     - role: nut
       tags: nut
 
+- name: Conserver
+  hosts: conserver
+  roles:
+    - role: conserver
+      tags: conserver
+
 - name: OS install server
   hosts: infra1
   roles:


### PR DESCRIPTION
The fs2 Synology needs an independent console record when DSM becomes unreachable. This adds a loopback-only Conserver service on infra1 that owns the FTDI adapter, preserves interactive SSH access, and retains compressed logs for 365 days.

Conserver uses port 3109 because Debian runs it without privileged-port capability. Package startup is delayed until the managed configuration and serial permissions are in place.
