### PR TITLE
Expose OpenArchiver API key to direnv

### DIFF
--- a/.secrets.tmpl
+++ b/.secrets.tmpl
@@ -63,3 +63,6 @@ export SLACK_TOKEN_EXPIRES_AT="{{ op://infra/slack-config-tokens/expires-at }}"
 # Homebox (used by: skills/homebox)
 export HOMEBOX_USERNAME="{{ op://infra/homebox/admin_email }}"
 export HOMEBOX_PASSWORD="{{ op://infra/homebox/admin_password }}"
+
+# OpenArchiver (used by: openarchiver skill, kubernetes/openarchiver/scripts/status)
+export OPENARCHIVER_API_KEY="{{ op://infra/openarchiver/api_key }}"


### PR DESCRIPTION
The OpenArchiver CLI currently falls back to an interactive 1Password lookup when its API key is absent. Add the existing 1Password field to the encrypted direnv template so local archive searches can use the standard repository secrets workflow.
