### PR TITLE
Increase exporter alert tolerance

### DIFF
--- a/kubernetes/prometheus/config/rules.yml
+++ b/kubernetes/prometheus/config/rules.yml
@@ -33,7 +33,7 @@ groups:
   - alert: ExporterDown
     expr: up{job!="node resources", job!="hwinfo gaming pc", resticprofile!~".+"}
       == 0
-    for: 15m
+    for: 1h
   - alert: AutobrrIRCUnhealthy
     expr: >
       autobrr_irc_enabled_total{app_kubernetes_io_name="autobrr"}


### PR DESCRIPTION
Exporter outages do not require immediate intervention, and transient probe failures during backup maintenance have been generating unnecessary notifications. Extend the continuous failure period from 15 minutes to one hour so sustained outages still alert without paging on brief interruptions.
