### PR TITLE
Document Synology console access

### DIFF
--- a/.agents/rules/integrations/synology.md
+++ b/.agents/rules/integrations/synology.md
@@ -1,0 +1,14 @@
+# Synology
+
+`fs2` is a Synology DS2419+ with its rear serial console connected to infra1.
+
+When troubleshooting fs2, use the serial console as an independent source of
+information:
+
+- Current transcript: `/var/log/conserver/fs2.log` on infra1
+- Rotated transcripts: `/var/log/conserver/` on infra1
+- Interactive console: `ssh -t infra1 sudo console fs2`
+- Retention: daily rotation for 365 days
+
+The serial console and its logs remain available independently of DSM and fs2's
+network connectivity.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ including:
   Authentik integration
 - **[integrations/](.agents/rules/integrations/)** - Home Assistant and other
   integrations
+- **[integrations/synology.md](.agents/rules/integrations/synology.md)** -
+  Synology troubleshooting resources
 
 ## Architecture Principles
 


### PR DESCRIPTION
Synology troubleshooting needs an independent source when DSM or the NAS network path is unavailable. Document fs2's serial transcript location, retention, and interactive access command in a dedicated Synology rule, and link it from the repository guidance.
