### PR TITLE
Update Renovate version constraints

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -485,7 +485,7 @@
     },
     {
       "description": "Home Assistant: One month behind latest (auto-managed)",
-      "allowedVersions": "/^2026\\.7\\./",
+      "allowedVersions": "/^2026\\.8\\./",
       "matchDatasources": [
         "docker"
       ],


### PR DESCRIPTION
This PR updates auto-managed version constraints in `.renovaterc` based on current data from endoflife.date and PyPI.

**Rules applied:**
- **MariaDB**: LTS versions at least 6 months old
- **PostgreSQL**: Major versions at least 6 months old
- **Home Assistant**: One month behind latest stable
- **ESPHome**: One month behind latest stable

Auto-generated by `scripts/update-renovate-versions.py`