### PR TITLE
Trust monitored backups during routine update reviews

### DIFF
--- a/.renovate-eval.md
+++ b/.renovate-eval.md
@@ -2,9 +2,10 @@
 
 ## Role of This File
 
-This file provides repository context, discovery hints, available tools, and
-action-menu behavior. It does not redefine the shared `renovate:safe`,
-`renovate:caution`, `renovate:breaking`, or `renovate:risk` label semantics.
+This file provides repository context, operational requirements, accepted update
+behavior, discovery hints, available tools, and action-menu behavior. It does
+not redefine the shared `renovate:safe`, `renovate:caution`,
+`renovate:breaking`, or `renovate:risk` label semantics.
 
 ## Repo Layout
 
@@ -29,19 +30,37 @@ workflows. Needing one of these normal workflows is not, by itself, evidence for
 
 ## Migration Risk Calibration
 
-For this repository, expected pod replacement, use of an unchanged
-application-managed migration mechanism, forward-only schema changes, lack of
-downgrade support, and migration duration that varies with data size do not
-constitute migration concerns by themselves. Do not infer exceptional downtime
-merely because an update contains migrations or because the live data size is
-unknown. Treat unknown duration as a validation boundary, not a verdict
-escalator.
+Routine application-managed migrations from established third-party software are
+normal updates for this repository. Expected pod replacement, additive schema
+changes such as new columns or indexes, use of an unchanged migration mechanism,
+forward-only schema changes, lack of downgrade support, and migration duration
+that varies with data size do not constitute migration concerns by themselves.
+Do not infer exceptional downtime merely because an update contains migrations
+or because the live data size is unknown. Unknown duration alone is not a reason
+to raise the risk rating.
 
 Raise a migration concern only for concrete version-specific evidence such as
 required manual prerequisites outside the normal GitOps path, explicit data loss
 or destructive conversion, failure or bypass of the configured migration
 mechanism, incompatibility with the deployed configuration, or
 upstream-documented outage or recovery steps materially beyond a normal rollout.
+
+Backups are monitored and trusted. Routine update evaluations do not require a
+fresh backup check, a restore test for each application, or a new backup before
+the update. This is repository policy, not a claim that backups were freshly
+verified. See [Backup Architecture](.agents/rules/backups.md) for the documented
+coverage and recovery methods; do not assume every storage path is covered.
+
+Investigate backup or recovery concerns when the update introduces concrete
+evidence of a problem, such as damaging existing backups or making the
+documented recovery method unusable. Continue reporting known upgrade failures,
+regressions, incompatibilities, and data-loss defects; trusting backups is not a
+reason to dismiss them. More specific application requirements take precedence
+over these general defaults.
+
+When revisiting a report, reassess its follow-up requirements using the evidence
+and this policy. An earlier report's proposed checks or risk ratings are not
+binding requirements.
 
 ## Pre-commit Hook Security Review
 


### PR DESCRIPTION
Routine application migrations should not require fresh backup checks or a restore test for every application. Document that monitored backups are trusted and routine migrations are normal updates here.

Keep scrutiny of known failures and data-loss defects, and reassess earlier follow-up demands against this policy.
