### PR TITLE
Document OpenTofu validation roots

### DIFF
--- a/.renovate-eval.md
+++ b/.renovate-eval.md
@@ -153,5 +153,8 @@ skill (Merge, Review later, Close).
   updates. Follow the repository instructions loaded by the current agent and
   read any detailed deployment guidance they reference. For Kubernetes:
   `kubectl apply -k kubernetes/<app>/`. For Ansible: run `ansible-playbook` from
-  the `ansible/` directory. For OpenTofu: run `tofu plan` then `tofu apply` from
-  the `opentofu/` directory.
+  the `ansible/` directory. For OpenTofu, read `opentofu/README.md` and the
+  documentation for every affected OpenTofu directory, then follow that root's
+  validation and deployment procedure. For a provider or lockfile-only bootstrap
+  update, initialize without upgrading providers and validate the configuration;
+  do not plan or apply the state-free bootstrap root.

--- a/opentofu/README.md
+++ b/opentofu/README.md
@@ -1,0 +1,28 @@
+# OpenTofu
+
+This repository has three separate OpenTofu roots. Read the instructions for the
+affected root before running OpenTofu commands.
+
+## Main infrastructure
+
+The configuration in this directory manages the homelab's regular
+infrastructure. Run OpenTofu from `opentofu/`. Its state is stored in the S3
+bucket configured in `main.tf`.
+
+Do not use `tofu init -upgrade`; dependency versions are controlled by the lock
+file. See
+[the repository OpenTofu instructions](../.agents/rules/opentofu/usage.md) for
+the standard workflow.
+
+## Slack applications
+
+The configuration in [`slack/`](slack/) is a separate OpenTofu root. Use
+`scripts/tofu-slack` from the repository root instead of running OpenTofu in
+that directory directly. See [`slack/README.md`](slack/README.md) for details.
+
+## State-bucket bootstrap
+
+The configuration in [`bootstrap/`](bootstrap/) is a one-time setup root that
+created the S3 bucket used by the main infrastructure root. It does not share
+the main root's state or normal planning workflow. See
+[`bootstrap/README.md`](bootstrap/README.md) before validating or changing it.

--- a/opentofu/bootstrap/README.md
+++ b/opentofu/bootstrap/README.md
@@ -1,0 +1,21 @@
+# OpenTofu state-bucket bootstrap
+
+This directory contains the one-time setup used to create the S3 bucket that
+stores state for the main `opentofu/` root. It also configured versioning,
+encryption, public-access blocking, and lifecycle cleanup for that bucket.
+
+The bootstrap state was not retained. OpenTofu state files are ignored by Git,
+and this root does not use a remote backend. As a result, a plan from a normal
+checkout will show all bootstrap resources as new. That output does not mean a
+dependency-only change will create those resources, and it is not useful for
+deciding whether such a change is safe.
+
+For a provider or lockfile-only update, initialize without upgrading providers,
+validate the configuration, and rely on the repository's normal CI and safety
+checks. Do not reject the update because a state-free plan shows the existing
+bootstrap resources as new.
+
+Changes to the managed resource definitions require manual handling. Without
+reconstructing or importing the existing resources into state, a plan cannot
+show how those changes would affect the live bucket. Do not run `tofu apply`
+against the existing bucket from a state-free checkout.


### PR DESCRIPTION
The bootstrap root has no retained state, so a normal plan misleadingly reports its existing resources as new. Document each OpenTofu root's workflow and explain the appropriate validation for dependency-only bootstrap updates.
