### PR TITLE
Upgrade VPA and remove obsolete startup options

### DIFF
--- a/kubernetes/vpa/Chart.yaml
+++ b/kubernetes/vpa/Chart.yaml
@@ -4,5 +4,5 @@ name: vpa-meta
 version: 0.1.0
 dependencies:
 - name: vpa
-  version: 4.12.5
+  version: 5.0.0
   repository: https://charts.fairwinds.com/stable

--- a/kubernetes/vpa/helm/crds/vpa-v1-crd.yaml
+++ b/kubernetes/vpa/helm/crds/vpa-v1-crd.yaml
@@ -256,6 +256,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .spec.updatePolicy.minReplicas
+      name: MinReplicas
+      priority: 1
+      type: integer
+    - jsonPath: .spec.updatePolicy.evictAfterOOMSeconds
+      name: OOMSeconds
+      priority: 1
+      type: integer
     name: v1
     schema:
       openAPIV3Schema:
@@ -356,6 +364,25 @@ spec:
                             Specifies the maximum amount of resources that will be recommended
                             for the container. The default is no maximum.
                           type: object
+                        memoryAggregationIntervalCount:
+                          description: |-
+                            memoryAggregationIntervalCount is the number of consecutive
+                            memoryAggregationIntervals which make up the memory aggregation window.
+                            The total window length is:
+                            MemoryAggregationIntervalSeconds * MemoryAggregationIntervalCount.
+                          format: int64
+                          minimum: 1
+                          type: integer
+                        memoryAggregationIntervalSeconds:
+                          description: |-
+                            memoryAggregationIntervalSeconds is the length of a single interval
+                            (in seconds) for which the peak memory usage is computed.
+                            Memory usage peaks are aggregated in multiples of this interval.
+                            In other words, there is one memory usage sample per interval
+                            (the maximum usage over that interval).
+                          format: int32
+                          minimum: 1
+                          type: integer
                         minAllowed:
                           additionalProperties:
                             anyOf:
@@ -390,8 +417,113 @@ spec:
                             when OOM is detected.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        startupBoost:
+                          description: |-
+                            startupBoost specifies the startup boost policy for the container.
+                            This overrides any pod-level startup boost policy.
+                            The startup boost policy takes precedence over the rest of the fields in
+                            this struct, except for ContainerName and ControlledValues.
+                          properties:
+                            cpu:
+                              description: |-
+                                cpu specifies the CPU startup boost policy.
+                                If this field is not set, no startup boost is applied.
+                              properties:
+                                durationSeconds:
+                                  description: |-
+                                    durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.
+                                    Defaults to 0.
+                                  format: int32
+                                  type: integer
+                                factor:
+                                  description: |-
+                                    factor specifies the factor to apply to the resource request.
+                                    This field is required when Type is "Factor".
+                                  format: int32
+                                  type: integer
+                                quantity:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    quantity specifies the absolute resource quantity to be used as the
+                                    resource request and limit during the boost phase.
+                                    This field is required when Type is "Quantity".
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: |-
+                                    type specifies the kind of boost to apply.
+                                    Supported values are: "Factor", "Quantity".
+                                    No startupboost will be applied for unrecognized values.
+                                  enum:
+                                  - Factor
+                                  - Quantity
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: factor is required when type is Factor and
+                                  forbidden otherwise
+                                rule: (self.type == 'Factor') == has(self.factor)
+                              - message: quantity is required when type is Quantity
+                                  and forbidden otherwise
+                                rule: (self.type == 'Quantity') == has(self.quantity)
+                          type: object
                       type: object
                     type: array
+                type: object
+              startupBoost:
+                description: startupBoost specifies the startup boost policy for the
+                  pod.
+                properties:
+                  cpu:
+                    description: |-
+                      cpu specifies the CPU startup boost policy.
+                      If this field is not set, no startup boost is applied.
+                    properties:
+                      durationSeconds:
+                        description: |-
+                          durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.
+                          Defaults to 0.
+                        format: int32
+                        type: integer
+                      factor:
+                        description: |-
+                          factor specifies the factor to apply to the resource request.
+                          This field is required when Type is "Factor".
+                        format: int32
+                        type: integer
+                      quantity:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          quantity specifies the absolute resource quantity to be used as the
+                          resource request and limit during the boost phase.
+                          This field is required when Type is "Quantity".
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type:
+                        description: |-
+                          type specifies the kind of boost to apply.
+                          Supported values are: "Factor", "Quantity".
+                          No startupboost will be applied for unrecognized values.
+                        enum:
+                        - Factor
+                        - Quantity
+                        type: string
+                    required:
+                    - type
+                    type: object
+                    x-kubernetes-validations:
+                    - message: factor is required when type is Factor and forbidden
+                        otherwise
+                      rule: (self.type == 'Factor') == has(self.factor)
+                    - message: quantity is required when type is Quantity and forbidden
+                        otherwise
+                      rule: (self.type == 'Quantity') == has(self.quantity)
                 type: object
               targetRef:
                 description: |-
@@ -427,6 +559,14 @@ spec:
                   If not specified, all fields in the `PodUpdatePolicy` are set to their
                   default values.
                 properties:
+                  evictAfterOOMSeconds:
+                    description: |-
+                      evictAfterOOMSeconds specifies the time in seconds to wait after an OOM event before
+                      considering the pod for eviction. Pods that have OOMed in less than this time
+                      since start will be evicted.
+                    format: int32
+                    minimum: 1
+                    type: integer
                   evictionRequirements:
                     description: |-
                       EvictionRequirements is a list of EvictionRequirements that need to
@@ -477,6 +617,7 @@ spec:
                     - Initial
                     - Recreate
                     - InPlaceOrRecreate
+                    - InPlace
                     - Auto
                     type: string
                 type: object
@@ -506,6 +647,14 @@ spec:
                         message is a human-readable explanation containing details about
                         the transition
                       type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
                     reason:
                       description: reason is the reason for the condition's last transition.
                       type: string
@@ -521,6 +670,12 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  by this autoscaler.
+                format: int64
+                minimum: 0
+                type: integer
               recommendation:
                 description: |-
                   The most recently computed amount of resources recommended by the

--- a/kubernetes/vpa/helm/templates/admission-controller-deployment.yaml
+++ b/kubernetes/vpa/helm/templates/admission-controller-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/name: vpa
     app.kubernetes.io/instance: vpa
-    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/version: "1.7.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 2
@@ -40,12 +40,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.6.0
+          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.7.1
           imagePullPolicy: Always
           args:
             - --register-webhook=false
             - --webhook-service=vpa-webhook
-            - --feature-gates=InPlaceOrRecreate=true
             - --reload-cert=true
           volumeMounts:
             - name: tls-certs

--- a/kubernetes/vpa/helm/templates/admission-controller-service-account.yaml
+++ b/kubernetes/vpa/helm/templates/admission-controller-service-account.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: vpa
     app.kubernetes.io/instance: vpa
-    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/version: "1.7.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-controller
 

--- a/kubernetes/vpa/helm/templates/recommender-deployment.yaml
+++ b/kubernetes/vpa/helm/templates/recommender-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: recommender
     app.kubernetes.io/name: vpa
     app.kubernetes.io/instance: vpa
-    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/version: "1.7.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -40,7 +40,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: registry.k8s.io/autoscaling/vpa-recommender:1.6.0
+          image: registry.k8s.io/autoscaling/vpa-recommender:1.7.1
           imagePullPolicy: Always
           args:
             - --pod-recommendation-min-cpu-millicores=15

--- a/kubernetes/vpa/helm/templates/recommender-service-account.yaml
+++ b/kubernetes/vpa/helm/templates/recommender-service-account.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: vpa
     app.kubernetes.io/instance: vpa
-    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/version: "1.7.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: recommender
 

--- a/kubernetes/vpa/helm/templates/updater-deployment.yaml
+++ b/kubernetes/vpa/helm/templates/updater-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: updater
     app.kubernetes.io/name: vpa
     app.kubernetes.io/instance: vpa
-    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/version: "1.7.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 0
@@ -40,13 +40,12 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: registry.k8s.io/autoscaling/vpa-updater:1.6.0
+          image: registry.k8s.io/autoscaling/vpa-updater:1.7.1
           imagePullPolicy: Always
           args:
             - --eviction-rate-burst=1
             - --eviction-rate-limit=0.0667
             - --eviction-tolerance=0.15
-            - --feature-gates=InPlaceOrRecreate=true
             - --min-replicas=1
             - --updater-interval=2m
             - --use-admission-controller-status=true

--- a/kubernetes/vpa/helm/templates/updater-service-account.yaml
+++ b/kubernetes/vpa/helm/templates/updater-service-account.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: vpa
     app.kubernetes.io/instance: vpa
-    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/version: "1.7.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: updater
 

--- a/kubernetes/vpa/helm/templates/webhooks/mutating.yaml
+++ b/kubernetes/vpa/helm/templates/webhooks/mutating.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/name: vpa
     app.kubernetes.io/instance: vpa
-    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/version: "1.7.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/inject-ca-from: vpa/vpa-webhook-cert

--- a/kubernetes/vpa/values.yaml
+++ b/kubernetes/vpa/values.yaml
@@ -17,7 +17,6 @@ updater:
     eviction-tolerance: "0.15"
     updater-interval: "2m"
     use-admission-controller-status: "true"
-    feature-gates: "InPlaceOrRecreate=true"
 
 admissionController:
   enabled: true  # Apply recommendations to NEW pods
@@ -36,7 +35,6 @@ admissionController:
   generateCertificate: false  # Use cert-manager instead of Helm hooks
   secretName: vpa-webhook-tls
   extraArgs:
-    feature-gates: "InPlaceOrRecreate=true"
     reload-cert: "true"
   tlsSecretKeys:
   - key: ca.crt


### PR DESCRIPTION
VPA 1.7 removes the InPlaceOrRecreate feature gate, so the existing options prevent the admission controller and updater from starting. Upgrade the Fairwinds chart to 5.0.0, remove both obsolete options, and regenerate the VPA 1.7.1 deployment files and CRD. Existing update modes and the overnight schedule remain unchanged.

Deployed for testing: both admission-controller replicas and the recommender are healthy, and all 192 existing recommendations were retained. A temporary updater restricted to a test namespace resized a running pod in place; a replacement pod received the recommended resources at startup. Temporary test resources were removed, and the production updater remains on its normal overnight schedule.

Includes the upgrade proposed in #2935 with the required configuration correction.
