### PR TITLE
Manage DNS packages for flux on Debian 12

### DIFF
--- a/ansible/host_vars/flux.yaml
+++ b/ansible/host_vars/flux.yaml
@@ -1,7 +1,11 @@
 ---
-# Vultr VPS running Debian 11 (bullseye)
+# Vultr VPS running Debian 12 (bookworm)
 # vc2-1c-1gb instance
-tailscale_args: --advertise-exit-node
+common_additional_packages:
+  # Flux uses Vultr networking rather than the role that installs this elsewhere.
+  - resolvconf
+# This remote VPS needs MagicDNS for its backup and monitoring endpoints.
+tailscale_args: --advertise-exit-node --accept-dns=true
 tailscale_tags: ["flux"]
 ip_forwarding_enabled: true
 qemu_guest_agent_enabled: false


### PR DESCRIPTION
Flux uses Vultr networking, so it does not run the interfaces role that installs resolvconf on other hosts. Explicitly install resolvconf and enable Tailscale DNS for its remote backup and monitoring endpoints. Update the host comment to reflect the completed Debian 12 upgrade.

Deployed the hostname, common, and Tailscale roles to flux successfully. After reboot, verified resolvconf integration, public and tailnet DNS, APT updates, fresh Netdata metrics, and a successful Restic backup.
