### PR TITLE
Upgrade Tailscale operator with required PeerRelay CRD

### DIFF
--- a/kubernetes/tailscale-operator/Chart.yaml
+++ b/kubernetes/tailscale-operator/Chart.yaml
@@ -5,5 +5,5 @@ version: 1.0.0
 description: Tailscale Kubernetes operator for secure networking
 dependencies:
 - name: tailscale-operator
-  version: 1.98.9
+  version: 1.102.3
   repository: https://pkgs.tailscale.com/helmcharts

--- a/kubernetes/tailscale-operator/helm/templates/deployment.yaml
+++ b/kubernetes/tailscale-operator/helm/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
             secretName: operator-oauth
       containers:
         - name: operator
-          image: tailscale/k8s-operator:v1.98.9
+          image: tailscale/k8s-operator:v1.102.3
           imagePullPolicy: Always
           env:
             - name: OPERATOR_INITIAL_TAGS
@@ -42,6 +42,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: OPERATOR_SERVICE_ACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
             - name: OPERATOR_LOGIN_SERVER
               value: 
             - name: OPERATOR_INGRESS_CLASS_NAME
@@ -51,7 +55,7 @@ spec:
             - name: CLIENT_SECRET_FILE
               value: /oauth/client_secret
             - name: PROXY_IMAGE
-              value: tailscale/tailscale:v1.98.9
+              value: tailscale/tailscale:v1.102.3
             - name: PROXY_TAGS
               value: tag:k8s
             - name: APISERVER_PROXY

--- a/kubernetes/tailscale-operator/helm/templates/operator-rbac.yaml
+++ b/kubernetes/tailscale-operator/helm/templates/operator-rbac.yaml
@@ -8,6 +8,7 @@ kind: ServiceAccount
 metadata:
   name: operator
   namespace: default
+
 ---
 # Source: tailscale-operator/templates/operator-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -40,6 +41,9 @@ rules:
   resources: ["tailnets", "tailnets/status"]
   verbs: ["get", "list", "watch", "update"]
 - apiGroups: ["tailscale.com"]
+  resources: ["peerrelays", "peerrelays/status"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: ["tailscale.com"]
   resources: ["proxygrouppolicies", "proxygrouppolicies/status"]
   verbs: ["get", "list", "watch", "update"]
 - apiGroups: ["tailscale.com"]
@@ -52,6 +56,7 @@ rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["validatingadmissionpolicies", "validatingadmissionpolicybindings"]
   verbs: ["list", "create", "delete", "update", "get", "watch"]
+
 ---
 # Source: tailscale-operator/templates/operator-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -66,6 +71,7 @@ roleRef:
   kind: ClusterRole
   name: tailscale-operator
   apiGroup: rbac.authorization.k8s.io
+
 ---
 # Source: tailscale-operator/templates/operator-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -77,6 +83,10 @@ rules:
 - apiGroups: [""]
   resources: ["secrets", "serviceaccounts", "configmaps"]
   verbs: ["create","delete","deletecollection","get","list","patch","update","watch"]
+- apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  resourceNames: ["operator"]
+  verbs: ["create"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","watch", "update"]
@@ -95,6 +105,7 @@ rules:
 - apiGroups: ["monitoring.coreos.com"]
   resources: ["servicemonitors"]
   verbs: ["get", "list", "update", "create", "delete"]
+
 ---
 # Source: tailscale-operator/templates/operator-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/kubernetes/tailscale-operator/helm/templates/peerrelay.yaml
+++ b/kubernetes/tailscale-operator/helm/templates/peerrelay.yaml
@@ -1,0 +1,292 @@
+---
+# Source: tailscale-operator/templates/peerrelay.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: peerrelays.tailscale.com
+spec:
+  group: tailscale.com
+  names:
+    kind: PeerRelay
+    listKind: PeerRelayList
+    plural: peerrelays
+    shortNames:
+      - pr
+    singular: peerrelay
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: Status of the deployed PeerRelay resources.
+          jsonPath: .status.conditions[?(@.type == "PeerRelayReady")].reason
+          name: Status
+          type: string
+        - description: Public addresses the peer relay replicas are reachable on.
+          jsonPath: .status.endpoints[*].address
+          name: Endpoints
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - metadata
+            - spec
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Spec describes the desired state of the PeerRelay.
+                More info:
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              properties:
+                aws:
+                  description: |-
+                    AWS contains configuration for pinning each replica to a specific AWS Elastic IP and subnet. Only meaningful
+                    when running on EKS with the AWS Load Balancer Controller. When set, the per-replica values override any
+                    aws-load-balancer-eip-allocations or aws-load-balancer-subnets values supplied via spec.service.annotations.
+
+                    Leave this unset unless the peer relays must be reachable on addresses you control. Pinning a subnet
+                    confines a replica's load balancer to that subnet's availability zone, and an AWS Network Load Balancer
+                    only forwards to targets in a zone that is enabled on it, so a replica whose pod is scheduled into any
+                    other zone stops receiving traffic. Setting this field therefore also requires pinning the pods to the
+                    matching zone with a ProxyClass, as described on ElasticIPs. Without this field the AWS Load Balancer
+                    Controller instead provisions each load balancer across every zone it discovers, and the operator turns on
+                    cross-zone load balancing so the replica is reachable wherever it happens to be scheduled, with no
+                    scheduling constraints needed.
+                  type: object
+                  required:
+                    - elasticIPs
+                  properties:
+                    elasticIPs:
+                      description: |-
+                        ElasticIPs pins each replica to a specific AWS EIP allocation and subnet. Only meaningful when Network Load
+                        Balancers are provisioned by the AWS Load Balancer Controller. ElasticIPs supplies one allocation-subnet pair
+                        per replica: replica N uses ElasticIPs[N]. The list must be at least as long as spec.replicas so every replica
+                        has a distinct EIP; extra entries are permitted so that scale-up doesn't immediately trip validation.
+
+                        Pinning a subnet enables only that subnet's availability zone on the replica's load balancer, and a Network
+                        Load Balancer only forwards to targets in an enabled zone. Nothing constrains the scheduler to place the
+                        replica's pod in that zone, so a pod scheduled elsewhere, including after a reschedule, becomes unreachable
+                        on its Elastic IP while still appearing healthy.
+
+                        Every replica of a PeerRelay shares one pod template, so a ProxyClass referenced by spec.proxyClass can
+                        confine the pods to a zone but cannot place different replicas in different zones. To use this field
+                        safely, name subnets in a single availability zone and pin the pods to that same zone with a ProxyClass
+                        setting spec.statefulSet.pod.nodeSelector to topology.kubernetes.io/zone. Note that this trades the zone
+                        redundancy that running several replicas would otherwise buy. Spreading replicas across zones with their
+                        own Elastic IPs needs a per-replica scheduling constraint that neither PeerRelay nor ProxyClass can
+                        currently express.
+
+                        When set, the reconciler stamps
+                        service.beta.kubernetes.io/aws-load-balancer-eip-allocations and
+                        service.beta.kubernetes.io/aws-load-balancer-subnets on each per-replica Service, overriding any values in
+                        spec.service.annotations.
+                      type: array
+                      minItems: 1
+                      items:
+                        description: PeerRelayAWSElasticIP pairs an EIP allocation with the subnet it is attached to.
+                        type: object
+                        required:
+                          - allocationID
+                          - subnetID
+                        properties:
+                          allocationID:
+                            description: |-
+                              AllocationID is the AWS EIP allocation ID (e.g. eipalloc-0123abcd) whose public IP this replica is reachable
+                              on. Stamped as service.beta.kubernetes.io/aws-load-balancer-eip-allocations on the replica's Service.
+                            type: string
+                            pattern: ^eipalloc-[0-9a-f]+$
+                          subnetID:
+                            description: |-
+                              SubnetID is the AWS subnet the replica's load balancer is provisioned in (e.g. subnet-0123abcd). It must be
+                              a public subnet, and no two replicas may name subnets in the same availability zone, since a load balancer
+                              accepts only one Elastic IP per zone. A standard VPC Elastic IP is regional rather than zonal, so it takes
+                              the zone of whichever subnet it is paired with here. Stamped as
+                              service.beta.kubernetes.io/aws-load-balancer-subnets on the replica's Service.
+                            type: string
+                            pattern: ^subnet-[0-9a-f]+$
+                      x-kubernetes-list-type: atomic
+                hostnamePrefix:
+                  description: |-
+                    HostnamePrefix specifies the hostname prefix for each
+                    replica. Each device will have the integer number
+                    from its StatefulSet pod appended to this prefix to form the full hostname.
+                    HostnamePrefix can contain lower case letters, numbers and dashes, it
+                    must not start with a dash and must be between 1 and 62 characters long.
+                  type: string
+                  pattern: ^[a-z0-9][a-z0-9-]{0,61}$
+                proxyClass:
+                  description: |-
+                    ProxyClass is the name of the ProxyClass custom resource that
+                    contains configuration options that should be applied to the
+                    resources created for this PeerRelay. If unset, the operator will
+                    create resources with the default configuration.
+                  type: string
+                replicas:
+                  description: |-
+                    Replicas specifies how many devices to create. Set this to enable
+                    high availability for peer relays.
+                    https://tailscale.com/kb/1115/high-availability. Defaults to 1.
+                  type: integer
+                  format: int32
+                  default: 1
+                  minimum: 0
+                service:
+                  description: Service contains configuration values to modify the LoadBalancer service used to expose the peer relay.
+                  type: object
+                  properties:
+                    annotations:
+                      description: |-
+                        Annotations to apply to the LoadBalancer service. Any annotations that conflict with those used by known
+                        cloud providers to ensure IP addresses rather than DNS names are ignored.
+                      type: object
+                      additionalProperties:
+                        type: string
+                tags:
+                  description: |-
+                    Tags that the Tailscale node will be tagged with.
+                    Defaults to [tag:k8s].
+                    To autoapprove the device defined by a PeerRelay,
+                    you can configure Tailscale ACLs to give these tags the necessary
+                    permissions.
+                    See https://tailscale.com/kb/1337/acl-syntax#autoapprovers.
+                    If you specify custom tags here, you must also make the operator an owner of these tags.
+                    See  https://tailscale.com/kb/1236/kubernetes-operator/#setting-up-the-kubernetes-operator.
+                    Tags cannot be changed once a PeerRelay node has been created.
+                    Tag values must be in form ^tag:[a-zA-Z][a-zA-Z0-9-]*$.
+                  type: array
+                  items:
+                    type: string
+                    pattern: ^tag:[a-zA-Z][a-zA-Z0-9-]*$
+                tailnet:
+                  description: |-
+                    Tailnet specifies the tailnet this PeerRelay should join. If blank, the default tailnet is used. When set, this
+                    name must match that of a valid Tailnet resource. This field is immutable and cannot be changed once set.
+                  type: string
+                  x-kubernetes-validations:
+                    - rule: self == oldSelf
+                      message: PeerRelay tailnet is immutable
+              x-kubernetes-validations:
+                - rule: '!has(self.aws) || !has(self.aws.elasticIPs) || self.aws.elasticIPs.size() >= self.replicas'
+                  message: spec.aws.elasticIPs must contain at least one entry per replica
+            status:
+              description: |-
+                Status describes the status of the PeerRelay. This is set
+                and managed by the Tailscale operator.
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                endpoints:
+                  description: |-
+                    Endpoints lists the public address:port pairs each peer relay replica is reachable on. Entries appear as the
+                    underlying cloud provisions each Service. A replica has one entry per address its LoadBalancer Service was
+                    given, which is usually one, but a load balancer spanning several availability zones has an address in each
+                    and every one of them is listed.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - address
+                      - port
+                      - replica
+                    properties:
+                      address:
+                        description: |-
+                          Address is the public IP or hostname the cloud has allocated for this replica's LoadBalancer Service.
+                          Peers reach this relay by connecting to Address:Port over UDP.
+                        type: string
+                      port:
+                        description: Port is the UDP port the peer relay listens on.
+                        type: integer
+                        format: int32
+                      replica:
+                        description: Replica is the zero-based index of the peer relay replica this endpoint targets.
+                        type: integer
+                        format: int32
+                  x-kubernetes-list-map-keys:
+                    - replica
+                    - address
+                  x-kubernetes-list-type: map
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/kubernetes/tailscale-operator/helm/templates/proxy-rbac.yaml
+++ b/kubernetes/tailscale-operator/helm/templates/proxy-rbac.yaml
@@ -8,6 +8,7 @@ kind: ServiceAccount
 metadata:
   name: proxies
   namespace: default
+
 ---
 # Source: tailscale-operator/templates/proxy-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -22,6 +23,7 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create", "patch", "get"]
+
 ---
 # Source: tailscale-operator/templates/proxy-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/kubernetes/tailscale-operator/helm/templates/tailnet.yaml
+++ b/kubernetes/tailscale-operator/helm/templates/tailnet.yaml
@@ -60,15 +60,18 @@ spec:
                 - credentials
               properties:
                 credentials:
-                  description: Denotes the location of the OAuth credentials to use for authenticating with this Tailnet.
+                  description: Denotes the location of the credentials to use for authenticating with this Tailnet.
                   type: object
                   required:
                     - secretName
                   properties:
                     secretName:
                       description: |-
-                        The name of the secret containing the OAuth credentials. This secret must contain two fields "client_id" and
-                        "client_secret".
+                        The name of the secret containing the credentials used to authenticate with this Tailnet. The secret must always
+                        contain a "client_id" field. To authenticate with a static OAuth client, also set "client_secret". To authenticate
+                        via workload identity federation, set "audience" to the audience value expected by the Tailscale OAuth
+                        client; the operator will mint a ServiceAccount token for itself with that audience and exchange it for an API
+                        token. "client_secret" and "audience" are mutually exclusive.
                       type: string
                 loginUrl:
                   description: URL of the control plane to be used by all resources managed by the operator using this Tailnet.

--- a/kubernetes/tailscale-operator/kustomization.yaml
+++ b/kubernetes/tailscale-operator/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - helm/templates/ingressclass.yaml
 - helm/templates/oauth-secret.yaml
 - helm/templates/operator-rbac.yaml
+- helm/templates/peerrelay.yaml
 - helm/templates/proxy-rbac.yaml
 - helm/templates/proxyclass.yaml
 - helm/templates/proxygroup.yaml


### PR DESCRIPTION
Tailscale 1.102.3 always starts a PeerRelay controller, so upgrading without installing its CRD prevents operator startup. Upgrade the chart and rendered operator/proxy manifests from 1.98.9 to 1.102.3 and include the new CRD in Kustomize.

Combines the upgrade from #2923 with the required installation fix. The combined manifests passed server-side dry-run validation and were deployed locally: the operator and all ten proxies ran 1.102.3 with zero restarts, and repeated ArgoCD ingress, Netdata, and xtal scrape checks passed. One xtal scrape was missed during rollout and recovered on the next scrape.
