### PR TITLE
Use full target versions in Renovate branch names

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -11,6 +11,7 @@
     "ansible/galaxy/**"
   ],
   "rebaseWhen": "behind-base-branch",
+  "branchTopic": "{{{depNameSanitized}}}-{{{newVersion}}}{{#if isLockfileUpdate}}-lockfile{{/if}}",
   "automergeStrategy": "rebase",
   "minimumReleaseAge": "14 days",
   "prHourlyLimit": 0,


### PR DESCRIPTION
Renovate can retain a superseded PR while a newer release waits for the minimum age check because both versions share a branch. Make full target versions the repository-wide branch naming default so superseded updates can be cleaned up and replacement PRs receive fresh evaluations. Preserve the lockfile suffix and existing specialized naming overrides.

Existing PRs with changed branch names may be replaced after this takes effect. Defer merging until only a few PRs remain to limit that churn.

