### PR TITLE
Monitor database replication across CNPG clusters

### DIFF
--- a/.kyverno/policies/require-cnpg-monitoring-annotations.yaml
+++ b/.kyverno/policies/require-cnpg-monitoring-annotations.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+
+metadata:
+  name: require-cnpg-monitoring-annotations
+
+spec:
+  validationFailureAction: Enforce
+  rules:
+  - name: require-prometheus-scrape-annotations
+    match:
+      any:
+      - resources:
+          kinds:
+          - postgresql.cnpg.io/v1/Cluster
+    validate:
+      message: >-
+        Database clusters must set prometheus.io/scrape to 'true' and
+        prometheus.io/port to '9187' under spec.inheritedMetadata.annotations
+        so Prometheus monitors their pods.
+      pattern:
+        spec:
+          inheritedMetadata:
+            annotations:
+              prometheus.io/scrape: 'true'
+              prometheus.io/port: '9187'

--- a/kubernetes/ara/ara-postgres-cluster.yaml
+++ b/kubernetes/ara/ara-postgres-cluster.yaml
@@ -6,6 +6,11 @@ metadata:
   name: ara-postgres
 
 spec:
+  inheritedMetadata:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9187'
+
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:18.6-standard-trixie@sha256:e5e820a9083134141caac23cad1d6affd39101a9fefe7bf6cc07738a3fa89452
 

--- a/kubernetes/authentik/authentik-postgres-cluster.yaml
+++ b/kubernetes/authentik/authentik-postgres-cluster.yaml
@@ -6,6 +6,11 @@ metadata:
   name: authentik-postgres
 
 spec:
+  inheritedMetadata:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9187'
+
   instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:18.6-standard-trixie@sha256:e5e820a9083134141caac23cad1d6affd39101a9fefe7bf6cc07738a3fa89452
   enablePDB: true

--- a/kubernetes/bambuddy/postgres-cluster.yaml
+++ b/kubernetes/bambuddy/postgres-cluster.yaml
@@ -7,6 +7,11 @@ metadata:
   namespace: bambuddy
 
 spec:
+  inheritedMetadata:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9187'
+
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:18.6-standard-trixie@sha256:e5e820a9083134141caac23cad1d6affd39101a9fefe7bf6cc07738a3fa89452
   enablePDB: false

--- a/kubernetes/dawarich/dawarich-postgres-cluster.yaml
+++ b/kubernetes/dawarich/dawarich-postgres-cluster.yaml
@@ -6,6 +6,11 @@ metadata:
   name: dawarich-postgres
 
 spec:
+  inheritedMetadata:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9187'
+
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgis:17.7-3.6.1-standard-trixie@sha256:168efc33d74d2aacc3e6a4793e6a3e812d6d4c193ec292274d655eed242d8755
   enablePDB: false

--- a/kubernetes/felix/postgres.yaml
+++ b/kubernetes/felix/postgres.yaml
@@ -7,6 +7,11 @@ metadata:
   namespace: felix
 
 spec:
+  inheritedMetadata:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9187'
+
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:18.6-standard-trixie@sha256:e5e820a9083134141caac23cad1d6affd39101a9fefe7bf6cc07738a3fa89452
   enablePDB: false

--- a/kubernetes/hass/hass-postgres-cluster.yaml
+++ b/kubernetes/hass/hass-postgres-cluster.yaml
@@ -6,6 +6,11 @@ metadata:
   name: hass-postgres
 
 spec:
+  inheritedMetadata:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9187'
+
   instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:18.6-standard-trixie@sha256:e5e820a9083134141caac23cad1d6affd39101a9fefe7bf6cc07738a3fa89452
   enablePDB: true

--- a/kubernetes/healthchecks/postgres-cluster.yaml
+++ b/kubernetes/healthchecks/postgres-cluster.yaml
@@ -6,6 +6,11 @@ metadata:
   name: healthchecks-postgres
 
 spec:
+  inheritedMetadata:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9187'
+
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:18.6-standard-trixie@sha256:e5e820a9083134141caac23cad1d6affd39101a9fefe7bf6cc07738a3fa89452
   enablePDB: false

--- a/kubernetes/homebox/homebox-postgres-cluster.yaml
+++ b/kubernetes/homebox/homebox-postgres-cluster.yaml
@@ -6,6 +6,11 @@ metadata:
   name: homebox-postgres
 
 spec:
+  inheritedMetadata:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9187'
+
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:18.6-standard-trixie@sha256:e5e820a9083134141caac23cad1d6affd39101a9fefe7bf6cc07738a3fa89452
   enablePDB: false

--- a/kubernetes/immich/helm/immich/machine-learning.yaml
+++ b/kubernetes/immich/helm/immich/machine-learning.yaml
@@ -10,6 +10,11 @@ metadata:
     app.kubernetes.io/name: machine-learning
     app.kubernetes.io/version: v2.6.3
   namespace: immich
+
+
+
+
+
 ---
 # Source: immich/templates/machine-learning.yaml
 kind: PersistentVolumeClaim
@@ -28,6 +33,8 @@ spec:
   resources:
     requests:
       storage: "10Gi"
+
+
 ---
 # Source: immich/templates/machine-learning.yaml
 apiVersion: v1
@@ -183,3 +190,7 @@ spec:
         - name: cache
           persistentVolumeClaim:
             claimName: immich-machine-learning
+
+
+  
+

--- a/kubernetes/immich/helm/immich/server.yaml
+++ b/kubernetes/immich/helm/immich/server.yaml
@@ -10,6 +10,11 @@ metadata:
     app.kubernetes.io/name: server
     app.kubernetes.io/version: v2.6.3
   namespace: immich
+
+
+
+
+
 ---
 # Source: immich/templates/server.yaml
 apiVersion: v1
@@ -36,6 +41,8 @@ spec:
     app.kubernetes.io/controller: main
     app.kubernetes.io/instance: immich
     app.kubernetes.io/name: server
+
+
 ---
 # Source: immich/templates/server.yaml
 apiVersion: apps/v1
@@ -144,6 +151,10 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: immich-library
+
+
+  
+
 ---
 # Source: immich/templates/server.yaml
 apiVersion: networking.k8s.io/v1

--- a/kubernetes/immich/immich-postgres-cluster.yaml
+++ b/kubernetes/immich/immich-postgres-cluster.yaml
@@ -6,6 +6,11 @@ metadata:
   name: immich-postgres
 
 spec:
+  inheritedMetadata:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9187'
+
   instances: 1
   imageName: ghcr.io/tensorchord/cloudnative-vectorchord:17-0.4.3
   enablePDB: false

--- a/kubernetes/karakeep/postgres-cluster.yaml
+++ b/kubernetes/karakeep/postgres-cluster.yaml
@@ -6,6 +6,11 @@ metadata:
   name: karakeep-postgres
 
 spec:
+  inheritedMetadata:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9187'
+
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:18.6-standard-trixie@sha256:e5e820a9083134141caac23cad1d6affd39101a9fefe7bf6cc07738a3fa89452
   enablePDB: false

--- a/kubernetes/kube-state-metrics/helm/templates/crs-configmap.yaml
+++ b/kubernetes/kube-state-metrics/helm/templates/crs-configmap.yaml
@@ -1,0 +1,40 @@
+---
+# Source: kube-state-metrics/templates/crs-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-state-metrics-customresourcestate-config
+  namespace: default
+  labels:    
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: kube-state-metrics
+    app.kubernetes.io/version: "2.19.1"
+data:
+  config.yaml: |
+    kind: CustomResourceStateMetrics
+    spec:
+      resources:
+      - groupVersionKind:
+          group: postgresql.cnpg.io
+          kind: Cluster
+          version: v1
+        labelsFromPath:
+          cnpg_io_cluster:
+          - metadata
+          - name
+          namespace:
+          - metadata
+          - namespace
+        metrics:
+        - each:
+            gauge:
+              path:
+              - spec
+              - instances
+            type: Gauge
+          help: Configured number of database instances.
+          name: cnpg_instances
+

--- a/kubernetes/kube-state-metrics/helm/templates/deployment.yaml
+++ b/kubernetes/kube-state-metrics/helm/templates/deployment.yaml
@@ -47,6 +47,11 @@ spec:
         args:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpointslices,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
+        - --custom-resource-state-config-file=/etc/customresourcestate/config.yaml
+        volumeMounts:
+        - name: customresourcestate-config
+          mountPath: /etc/customresourcestate
+          readOnly: true
         imagePullPolicy: IfNotPresent
         image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.1
         ports:
@@ -82,4 +87,8 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+      volumes:
+        - name: customresourcestate-config
+          configMap:
+            name: kube-state-metrics-customresourcestate-config
 

--- a/kubernetes/kube-state-metrics/helm/templates/role.yaml
+++ b/kubernetes/kube-state-metrics/helm/templates/role.yaml
@@ -153,4 +153,16 @@ rules:
     - volumeattachments
   verbs: ["list", "watch"]
 
+- apiGroups: ["apiextensions.k8s.io"]
+  resources:
+    - customresourcedefinitions
+  verbs: ["list", "watch"]
+
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - clusters
+  verbs:
+  - list
+  - watch
 

--- a/kubernetes/kube-state-metrics/kustomization.yaml
+++ b/kubernetes/kube-state-metrics/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - helm/templates/serviceaccount.yaml
 - helm/templates/deployment.yaml
 - helm/templates/service.yaml
+- helm/templates/crs-configmap.yaml
 
 commonAnnotations:
   argoManaged: 'true'

--- a/kubernetes/kube-state-metrics/values.yaml
+++ b/kubernetes/kube-state-metrics/values.yaml
@@ -1,2 +1,27 @@
 ---
-...
+rbac:
+  extraRules:
+  - apiGroups: [postgresql.cnpg.io]
+    resources: [clusters]
+    verbs: [list, watch]
+
+customResourceState:
+  enabled: true
+  config:
+    kind: CustomResourceStateMetrics
+    spec:
+      resources:
+      - groupVersionKind:
+          group: postgresql.cnpg.io
+          version: v1
+          kind: Cluster
+        labelsFromPath:
+          namespace: [metadata, namespace]
+          cnpg_io_cluster: [metadata, name]
+        metrics:
+        - name: cnpg_instances
+          help: Configured number of database instances.
+          each:
+            type: Gauge
+            gauge:
+              path: [spec, instances]

--- a/kubernetes/openarchiver/postgres-cluster.yaml
+++ b/kubernetes/openarchiver/postgres-cluster.yaml
@@ -7,6 +7,11 @@ metadata:
   namespace: openarchiver
 
 spec:
+  inheritedMetadata:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9187'
+
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:18.6-standard-trixie@sha256:e5e820a9083134141caac23cad1d6affd39101a9fefe7bf6cc07738a3fa89452
   enablePDB: false

--- a/kubernetes/prometheus/config/cnpg-rules.yml
+++ b/kubernetes/prometheus/config/cnpg-rules.yml
@@ -1,0 +1,64 @@
+---
+groups:
+- name: cnpg.rules
+  rules:
+  - alert: CNPGReplicationDisconnected
+    expr: >
+      (cnpg_pg_replication_is_wal_receiver_up{job="kubernetes-pods", cnpg_io_podRole="instance"}
+      == 0)
+      and on(kubernetes_namespace,kubernetes_pod_name)
+      (cnpg_pg_replication_in_recovery{job="kubernetes-pods", cnpg_io_podRole="instance"}
+      == 1)
+    for: 30m
+    annotations:
+      message: Database replica {{ $labels.kubernetes_namespace }}/{{ $labels.kubernetes_pod_name
+        }} has not been receiving updates for 30 minutes
+  - alert: CNPGReplicationLag
+    expr: >
+      (cnpg_pg_replication_lag{job="kubernetes-pods", cnpg_io_podRole="instance"}
+      > 300)
+      and on(kubernetes_namespace,kubernetes_pod_name)
+      (cnpg_pg_replication_is_wal_receiver_up{job="kubernetes-pods", cnpg_io_podRole="instance"}
+      == 1)
+    for: 30m
+    annotations:
+      message: Database replica {{ $labels.kubernetes_namespace }}/{{ $labels.kubernetes_pod_name
+        }} has remained more than five minutes behind for 30 minutes while connected
+  - alert: CNPGMonitoringUnavailable
+    expr: >
+      (up{job="kubernetes-pods", cnpg_io_podRole="instance"} == 0)
+      or (cnpg_collector_up{job="kubernetes-pods", cnpg_io_podRole="instance"} ==
+      0)
+      or (cnpg_collector_last_collection_error{job="kubernetes-pods", cnpg_io_podRole="instance"}
+      == 1)
+    for: 1h
+    annotations:
+      message: Database monitoring is failing for {{ $labels.kubernetes_namespace }}/{{
+        $labels.kubernetes_pod_name }}
+  - alert: CNPGReplicationMetricsMissing
+    expr: >
+      ((up{job="kubernetes-pods", cnpg_io_podRole="instance"} == 1) unless on(kubernetes_namespace,kubernetes_pod_name)
+        cnpg_pg_replication_in_recovery{job="kubernetes-pods", cnpg_io_podRole="instance"})
+      or ((up{job="kubernetes-pods", cnpg_io_podRole="instance"} == 1) unless on(kubernetes_namespace,kubernetes_pod_name)
+        cnpg_pg_replication_is_wal_receiver_up{job="kubernetes-pods", cnpg_io_podRole="instance"})
+    for: 1h
+    annotations:
+      message: Database {{ $labels.kubernetes_namespace }}/{{ $labels.kubernetes_pod_name
+        }} responds to monitoring but its replication metrics are missing
+  - alert: CNPGDatabaseInstancesMissing
+    # Use Kubernetes' desired count, including when every scrape target disappears.
+    expr: >
+      (
+        count by(namespace,cnpg_io_cluster) (
+          label_replace(up{job="kubernetes-pods", cnpg_io_podRole="instance"} == 1,
+            "namespace", "$1", "kubernetes_namespace", "(.+)")
+        )
+        or on(namespace,cnpg_io_cluster)
+        (0 * max by(namespace,cnpg_io_cluster) (kube_customresource_cnpg_instances))
+      )
+      < on(namespace,cnpg_io_cluster)
+      max by(namespace,cnpg_io_cluster) (kube_customresource_cnpg_instances)
+    for: 1h
+    annotations:
+      message: Database cluster {{ $labels.namespace }}/{{ $labels.cnpg_io_cluster
+        }} has had fewer monitored instances than configured for one hour

--- a/kubernetes/prometheus/config/prometheus.yml
+++ b/kubernetes/prometheus/config/prometheus.yml
@@ -5,6 +5,7 @@ global:
 
 rule_files:
 - /etc/prometheus/rules.yml
+- /etc/prometheus/cnpg-rules.yml
 
 alerting:
   alertmanagers:
@@ -254,6 +255,10 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
     action: keep
     regex: true
+  # CNPG inherits pod scrape annotations onto Services too; collect each pod once.
+  - source_labels: [__meta_kubernetes_service_label_cnpg_io_cluster]
+    action: drop
+    regex: .+
   - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
     action: replace
     target_label: __scheme__

--- a/kubernetes/prometheus/kustomization.yaml
+++ b/kubernetes/prometheus/kustomization.yaml
@@ -30,3 +30,4 @@ configMapGenerator:
   files:
   - config/prometheus.yml
   - config/rules.yml
+  - config/cnpg-rules.yml

--- a/kubernetes/semaphore/semaphore-postgres-cluster.yaml
+++ b/kubernetes/semaphore/semaphore-postgres-cluster.yaml
@@ -6,6 +6,11 @@ metadata:
   name: semaphore-postgres
 
 spec:
+  inheritedMetadata:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9187'
+
   instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:18.6-standard-trixie@sha256:e5e820a9083134141caac23cad1d6affd39101a9fefe7bf6cc07738a3fa89452
   enablePDB: true

--- a/kubernetes/speakr/speakr-postgres-cluster.yaml
+++ b/kubernetes/speakr/speakr-postgres-cluster.yaml
@@ -6,6 +6,11 @@ metadata:
   name: speakr-postgres
 
 spec:
+  inheritedMetadata:
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9187'
+
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:18.6-standard-trixie@sha256:e5e820a9083134141caac23cad1d6affd39101a9fefe7bf6cc07738a3fa89452
   enablePDB: false


### PR DESCRIPTION
Database replicas can stop receiving updates while their pods remain healthy. Scrape CNPG pods through annotations and alert on replication trouble lasting 30 minutes or monitoring gaps lasting one hour.

Keep database rules in a separate file, read expected instance counts through kube-state-metrics, and require scrape annotations through the existing Kyverno checks. Exclude inherited Service annotations to avoid duplicate scraping.

Verified 16 healthy scrape targets across 13 clusters, missing-instance detection, and rejection of missing or incorrect annotations. Deployed and confirmed alerts cleared after repairing the Authentik and Home Assistant replicas.
