### PR TITLE
Upgrade Home Assistant and retire HTTP YAML settings

### DIFF
--- a/kubernetes/hass/config/configuration.yaml
+++ b/kubernetes/hass/config/configuration.yaml
@@ -7,12 +7,6 @@ homeassistant:
 # Enables the frontend
 frontend:
 
-http:
-  use_x_forwarded_for: true
-  trusted_proxies:
-  - 10.244.0.0/16
-  - 172.19.74.0/24
-
 # Enables configuration UI
 config:
 

--- a/kubernetes/hass/kustomization.yaml
+++ b/kubernetes/hass/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
 images:
 - name: ghcr.io/home-assistant/home-assistant
   newName: homeassistant/home-assistant
-  newTag: 2026.7.4@sha256:5a531753cea96444200158fc2b0ac7ccd739291ec50414877b396de6e0bb29b3
+  newTag: 2026.8.3@sha256:14931c6b13756317849f46da1d01b45937a1150db66c081cfe529d48215943fe
 
 labels:
 


### PR DESCRIPTION
Home Assistant 2026.8 imports HTTP configuration into persistent
storage and ignores the YAML afterward. Upgrade to 2026.8.3 and
remove the obsolete proxy configuration after verifying migration
preserves the existing trusted networks and port.

The upgrade and cleanup were deployed together for validation.
Ingress remained accessible after a second startup, MQTT soil and
rain readings updated, and the basement clock received a tested
41% to 40% to 41% volume change from the HT-A9. The original volume
and power-off activity were restored afterward.
